### PR TITLE
Add bounded intermediary pipeline orchestration

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -31,6 +31,27 @@ Use:
 - `CleanlinessPolicy` for application-owned pool release decisions; and
 - `GssEncUpgrade` or `TokenAuthEngine` for platform credential adapters.
 
+## Replace proxy message queues with a bounded pipeline ledger
+
+Opt in with `Intermediary::with_pipeline(BoundedPipeline::new(limit)?)`. Feed
+each decoded frontend message to `pipeline_mut().accept_frontend(...)`. A
+`Forward` action returns the original owned message for upstream encoding; a
+`Discard` action identifies a locally handled operation; and capacity returns
+the original message so the proxy can pause downstream reads and retry it.
+
+The ledger stores only operation metadata. It does not clone or retain SQL,
+Bind values, COPY chunks, rows, or forwarded responses. For a local response,
+retain its `OperationId`, wait until that operation is at the response head,
+then call `try_emit_local`. A premature call returns the same response as
+`BackendAction::Deferred`, so it cannot overtake earlier upstream work.
+
+After either an upstream or local extended-query `ErrorResponse`, the ledger
+discards accepted operations through the next `Sync`. Only the corresponding
+`ReadyForQuery` completes recovery. Authorisation, rewriting, routing, local
+response contents, and the decision to forward or intercept remain application
+policy; pg-proto owns ordering, bounded capacity, protocol legality, COPY phase
+tracking, and error-drain bookkeeping.
+
 ## Authentication and TLS
 
 Create and authenticate each side independently. Client-facing server-role TLS
@@ -52,5 +73,7 @@ idle readiness evidence and an application cleanliness policy that permits it.
   policy and registries plug in.
 - [`examples/rewriting_intermediary.rs`](examples/rewriting_intermediary.rs)
   modifies reconstructable extended-query and result messages.
+- [`examples/intermediary_pipeline.rs`](examples/intermediary_pipeline.rs)
+  combines forwarding, local rejection, backpressure, and ordered emission.
 - [`tests/intermediary_harness.rs`](tests/intermediary_harness.rs) is the neutral
   capability acceptance harness.

--- a/PLAN.md
+++ b/PLAN.md
@@ -244,6 +244,9 @@ neutral composition harnesses and examples.
 
 ## Optional future work
 
+- [x] Add optional operation-bounded intermediary pipeline orchestration with
+  payload-free ordering records, local responses, COPY, and Sync error recovery.
+
 These are deliberately not completion criteria for `pg-proto`'s current plan.
 They depend on downstream requirements or pursue additional assurance beyond the
 library boundary established above.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ Only `Conn<_, Ready, Pristine>` exposes unconditional release.
 
 ## What can be built with it?
 
+The [bounded intermediary pipeline example](examples/intermediary_pipeline.rs)
+shows ordered forwarding, local interception, and backpressure without proxy-owned
+message queues.
+
 - A TLS-terminating PostgreSQL proxy which authenticates each side independently
   and inspects plaintext SQL and result rows.
 - A transaction or session pooler whose release policy consumes explicit

--- a/examples/intermediary_pipeline.rs
+++ b/examples/intermediary_pipeline.rs
@@ -1,0 +1,59 @@
+//! Minimal bounded-pipeline policy for a `PostgreSQL` intermediary.
+
+use bytes::Bytes;
+use pg_proto::{
+    codec::{BackendMessage, DiagnosticResponse, FrontendMessage, Parse, TransactionStatus},
+    intermediary::Intermediary,
+    pipeline::{BackendAction, BoundedPipeline, FrontendAction, FrontendHandling},
+};
+
+fn main() {
+    let mut proxy = Intermediary::new((), ())
+        .with_pipeline(BoundedPipeline::new(16).expect("non-zero pipeline limit"));
+
+    let parse = FrontendMessage::Parse(Parse {
+        statement: Bytes::from_static(b"blocked"),
+        query: Bytes::from_static(b"select secret"),
+        parameter_types: vec![],
+    });
+    let local_id = match proxy
+        .pipeline_mut()
+        .frontend_action(parse, FrontendHandling::Local)
+        .expect("legal Parse")
+    {
+        FrontendAction::Discard { id } => id,
+        FrontendAction::Forward { message, .. } => {
+            // Encode `message` to the upstream transport here.
+            drop(message);
+            return;
+        }
+        FrontendAction::Backpressure(message) => {
+            // Pause downstream reads and retry this same owned value later.
+            drop(message);
+            return;
+        }
+    };
+
+    let local_error = BackendMessage::ErrorResponse(DiagnosticResponse { fields: vec![] });
+    match proxy
+        .pipeline_mut()
+        .try_emit_local(local_id, local_error)
+        .expect("response matches Parse")
+    {
+        BackendAction::Emit(message) => {
+            // Encode `message` to the downstream transport here.
+            drop(message);
+        }
+        BackendAction::Deferred(message) => {
+            // An earlier response must be processed first; retry this owned value.
+            drop(message);
+        }
+    }
+
+    let _ = proxy
+        .pipeline_mut()
+        .frontend_action(FrontendMessage::Sync, FrontendHandling::Forward);
+    let _ = proxy
+        .pipeline_mut()
+        .accept_backend(BackendMessage::ReadyForQuery(TransactionStatus::Idle));
+}

--- a/src/demux.rs
+++ b/src/demux.rs
@@ -121,6 +121,21 @@ pub struct Demux {
 }
 
 impl Demux {
+    /// Reports whether a backend message is causally independent of session progress.
+    ///
+    /// Pipeline orchestration uses this shared classifier rather than defining a
+    /// second asynchronous-message taxonomy.
+    #[must_use]
+    pub fn is_asynchronous(message: &BackendMessage) -> bool {
+        matches!(
+            message,
+            BackendMessage::NoticeResponse(_)
+                | BackendMessage::ParameterStatus { .. }
+                | BackendMessage::NotificationResponse { .. }
+                | BackendMessage::BackendKeyData { .. }
+        )
+    }
+
     /// Routes one decoded backend message.
     ///
     /// Async messages are consumed and recorded; only session-advancing messages

--- a/src/intermediary.rs
+++ b/src/intermediary.rs
@@ -2,25 +2,72 @@
 
 use std::future::Future;
 
-/// Owns the two independently typed sides of an intermediary connection.
+use crate::pipeline::{NoPipeline, Pipeline, PipelinePolicy};
+
+/// Result of changing one side while preserving the complete intermediary on rejection.
+pub type IntermediaryTransition<Current, Next, Output, Error> =
+    Result<(Next, Output), (Current, Error)>;
+
+/// Owns two independently typed sides and optional pipeline orchestration.
 ///
 /// `Downstream` is normally a server-role session facing a client and `Upstream`
 /// is normally a client-role session facing `PostgreSQL`. No phase, transport,
 /// authentication mechanism, or cleanliness index is coupled between them.
+/// `Policy` defaults to [`NoPipeline`]; call [`Self::with_pipeline`] to opt into
+/// bounded pipelining without changing either session type.
 #[must_use = "dropping an intermediary abandons both PostgreSQL sessions"]
 #[derive(Debug)]
-pub struct Intermediary<Downstream, Upstream> {
+pub struct Intermediary<Downstream, Upstream, Policy = NoPipeline> {
     downstream: Downstream,
     upstream: Upstream,
+    pipeline: Pipeline<Policy>,
 }
 
-impl<Downstream, Upstream> Intermediary<Downstream, Upstream> {
+impl<Downstream, Upstream> Intermediary<Downstream, Upstream, NoPipeline> {
     /// Pairs two independently established protocol sessions.
-    pub const fn new(downstream: Downstream, upstream: Upstream) -> Self {
+    pub fn new(downstream: Downstream, upstream: Upstream) -> Self {
         Self {
             downstream,
             upstream,
+            pipeline: Pipeline::new(NoPipeline),
         }
+    }
+}
+
+impl<Downstream, Upstream, Policy: PipelinePolicy> Intermediary<Downstream, Upstream, Policy> {
+    /// Replaces the pipeline policy while no pipeline operations are outstanding.
+    ///
+    /// # Panics
+    ///
+    /// Panics if operations were accepted before replacing the policy.
+    pub fn with_pipeline<Next: PipelinePolicy>(
+        self,
+        policy: Next,
+    ) -> Intermediary<Downstream, Upstream, Next> {
+        let Self {
+            downstream,
+            upstream,
+            pipeline,
+        } = self;
+        assert!(
+            pipeline.is_empty(),
+            "pipeline policy cannot change with outstanding operations"
+        );
+        Intermediary {
+            downstream,
+            upstream,
+            pipeline: Pipeline::new(policy),
+        }
+    }
+
+    /// Returns the reusable request/response pipeline component.
+    pub const fn pipeline(&self) -> &Pipeline<Policy> {
+        &self.pipeline
+    }
+
+    /// Returns mutable access to bounded pipeline orchestration.
+    pub const fn pipeline_mut(&mut self) -> &mut Pipeline<Policy> {
+        &mut self.pipeline
     }
 
     /// Borrows the client-facing side without weakening its typestate.
@@ -56,16 +103,18 @@ impl<Downstream, Upstream> Intermediary<Downstream, Upstream> {
     pub fn transition_downstream<Next, Output, Error>(
         self,
         transition: impl FnOnce(Downstream) -> Result<(Next, Output), (Downstream, Error)>,
-    ) -> Result<(Intermediary<Next, Upstream>, Output), (Self, Error)> {
+    ) -> IntermediaryTransition<Self, Intermediary<Next, Upstream, Policy>, Output, Error> {
         let Self {
             downstream,
             upstream,
+            pipeline,
         } = self;
         match transition(downstream) {
             Ok((downstream, output)) => Ok((
                 Intermediary {
                     downstream,
                     upstream,
+                    pipeline,
                 },
                 output,
             )),
@@ -73,6 +122,7 @@ impl<Downstream, Upstream> Intermediary<Downstream, Upstream> {
                 Intermediary {
                     downstream,
                     upstream,
+                    pipeline,
                 },
                 error,
             )),
@@ -89,16 +139,18 @@ impl<Downstream, Upstream> Intermediary<Downstream, Upstream> {
     pub fn transition_upstream<Next, Output, Error>(
         self,
         transition: impl FnOnce(Upstream) -> Result<(Next, Output), (Upstream, Error)>,
-    ) -> Result<(Intermediary<Downstream, Next>, Output), (Self, Error)> {
+    ) -> IntermediaryTransition<Self, Intermediary<Downstream, Next, Policy>, Output, Error> {
         let Self {
             downstream,
             upstream,
+            pipeline,
         } = self;
         match transition(upstream) {
             Ok((upstream, output)) => Ok((
                 Intermediary {
                     downstream,
                     upstream,
+                    pipeline,
                 },
                 output,
             )),
@@ -106,6 +158,7 @@ impl<Downstream, Upstream> Intermediary<Downstream, Upstream> {
                 Intermediary {
                     downstream,
                     upstream,
+                    pipeline,
                 },
                 error,
             )),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod erased;
 pub mod grammar;
 pub mod integrations;
 pub mod intermediary;
+pub mod pipeline;
 pub mod pre_startup;
 pub mod replication;
 pub mod resources;

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1,0 +1,721 @@
+//! Bounded, payload-free orchestration for proxy request pipelines.
+//!
+//! The ledger in this module records protocol obligations, not wire messages.
+//! Applications retain ownership of decoded messages until [`FrontendAction`] or
+//! [`BackendAction`] tells them to forward, emit, retry, or discard the value.
+//! Upstream transports may continue using [`Demux`]: drain its ordered async
+//! events before passing each returned [`SessionItem`] to
+//! [`Pipeline::accept_session_item`]. This retains the existing notice tagging,
+//! parameter map, notification queue, cancellation key, and transaction evidence.
+
+use std::{collections::VecDeque, sync::Arc};
+
+use tokio::sync::Notify;
+
+use crate::{
+    codec::{BackendMessage, FrontendMessage},
+    demux::{Demux, SessionItem},
+    grammar::backend,
+};
+
+/// Stable identity of an accepted frontend operation.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct OperationId(u64);
+
+/// Pipeline policy which preserves the historical lock-step behaviour.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct NoPipeline;
+
+/// Configuration for a bounded frontend operation pipeline.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct BoundedPipeline {
+    max_operations: usize,
+}
+
+impl BoundedPipeline {
+    /// Creates a pipeline with a non-zero operation-count limit.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when `max_operations` is zero.
+    pub fn new(max_operations: usize) -> Result<Self, PipelineConfigError> {
+        if max_operations == 0 {
+            return Err(PipelineConfigError);
+        }
+        Ok(Self { max_operations })
+    }
+
+    /// Returns the maximum number of incomplete operations.
+    #[must_use]
+    pub const fn max_operations(self) -> usize {
+        self.max_operations
+    }
+}
+
+/// A zero operation-count limit is not a usable pipeline configuration.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct PipelineConfigError;
+
+impl std::fmt::Display for PipelineConfigError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("pipeline operation limit must be non-zero")
+    }
+}
+
+impl std::error::Error for PipelineConfigError {}
+
+mod private {
+    pub trait Sealed {}
+}
+
+/// Configuration accepted by [`Pipeline`].
+pub trait PipelinePolicy: private::Sealed + Copy {
+    /// Maximum number of incomplete operation records.
+    fn operation_limit(self) -> usize;
+}
+
+impl private::Sealed for NoPipeline {}
+impl PipelinePolicy for NoPipeline {
+    fn operation_limit(self) -> usize {
+        1
+    }
+}
+
+impl private::Sealed for BoundedPipeline {}
+impl PipelinePolicy for BoundedPipeline {
+    fn operation_limit(self) -> usize {
+        self.max_operations
+    }
+}
+
+/// Whether an accepted frontend operation is locally handled or forwarded.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum FrontendHandling {
+    /// Send the returned message to the upstream connection.
+    Forward,
+    /// Do not send the request upstream; application code will synthesize its response.
+    Local,
+}
+
+/// Application action for one successfully projected frontend message.
+#[derive(Debug, Eq, PartialEq)]
+pub enum FrontendAction {
+    /// Forward the owned message upstream.
+    Forward {
+        /// Accepted operation identity.
+        id: OperationId,
+        /// Original, unretained frontend message.
+        message: FrontendMessage,
+    },
+    /// The operation is locally handled and the message can be discarded.
+    Discard {
+        /// Accepted operation identity.
+        id: OperationId,
+    },
+    /// Capacity is exhausted; pause reads and retry this unchanged message.
+    Backpressure(FrontendMessage),
+}
+
+/// Position of a successfully accepted operation.
+#[derive(Debug, Eq, PartialEq)]
+pub enum FrontendAdmission {
+    /// Nothing earlier prevents this operation's response from being emitted.
+    Immediate(FrontendAction),
+    /// The operation was accepted but an earlier response must be emitted first.
+    Waiting(FrontendAction),
+}
+
+impl FrontendAdmission {
+    /// Returns the application action, discarding only the positional annotation.
+    #[must_use]
+    pub fn into_action(self) -> FrontendAction {
+        match self {
+            Self::Immediate(action) | Self::Waiting(action) => action,
+        }
+    }
+}
+
+/// Why a frontend message could not be accepted.
+#[derive(Debug, Eq, PartialEq)]
+pub enum FrontendProjectionError {
+    /// The bounded ledger is full; the unchanged message may be retried.
+    Capacity(Box<FrontendMessage>),
+    /// The message is not legal in the projected frontend protocol state.
+    Illegal {
+        /// Projected state at rejection.
+        state: PipelineState,
+        /// Unchanged illegal message.
+        message: Box<FrontendMessage>,
+    },
+}
+
+/// Application action for a backend message.
+#[derive(Debug, Eq, PartialEq)]
+pub enum BackendAction {
+    /// Emit this owned message to the downstream client now.
+    Emit(BackendMessage),
+    /// An earlier operation must complete; retry this unchanged message later.
+    Deferred(BackendMessage),
+}
+
+/// A backend message was not legal for any outstanding operation.
+#[derive(Debug, Eq, PartialEq)]
+pub struct BackendProjectionError {
+    /// Current response-side state.
+    pub state: PipelineState,
+    /// Unchanged illegal message.
+    pub message: BackendMessage,
+}
+
+/// Public summary of the pipeline's projected frontend state.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PipelineState {
+    /// A simple or extended cycle may begin.
+    Ready,
+    /// Extended-query messages are being accepted.
+    Extended,
+    /// An extended error discards messages through `Sync`.
+    ExtendedError,
+    /// COPY IN accepts frontend data.
+    CopyIn,
+    /// COPY OUT accepts only backend data.
+    CopyOut,
+    /// COPY BOTH accepts data in both directions.
+    CopyBoth,
+    /// The connection has terminated.
+    Terminated,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RequestState {
+    Ready,
+    Extended { bound: bool },
+    ExtendedError,
+    CopyIn,
+    CopyOut,
+    CopyBoth,
+    Terminated,
+}
+
+impl RequestState {
+    const fn public(self) -> PipelineState {
+        match self {
+            Self::Ready => PipelineState::Ready,
+            Self::Extended { .. } => PipelineState::Extended,
+            Self::ExtendedError => PipelineState::ExtendedError,
+            Self::CopyIn => PipelineState::CopyIn,
+            Self::CopyOut => PipelineState::CopyOut,
+            Self::CopyBoth => PipelineState::CopyBoth,
+            Self::Terminated => PipelineState::Terminated,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Origin {
+    Forwarded,
+    Local,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum OperationKind {
+    Query,
+    FunctionCall,
+    Parse,
+    Bind,
+    Describe,
+    Execute,
+    Close,
+    Flush,
+    Sync,
+    CopyData,
+    CopyDone,
+    CopyFail,
+    Terminate,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct Operation {
+    id: OperationId,
+    kind: OperationKind,
+    origin: Origin,
+    discarded: bool,
+}
+
+/// A bounded ledger coordinating independently owned frontend and backend values.
+#[derive(Debug)]
+pub struct Pipeline<P = NoPipeline> {
+    policy: P,
+    operations: VecDeque<Operation>,
+    request_state: RequestState,
+    response_state: Option<PipelineState>,
+    next_id: u64,
+    changed: Arc<Notify>,
+}
+
+impl Default for Pipeline<NoPipeline> {
+    fn default() -> Self {
+        Self::new(NoPipeline)
+    }
+}
+
+impl<P: PipelinePolicy> Pipeline<P> {
+    /// Creates an empty pipeline using `policy`.
+    #[must_use]
+    pub fn new(policy: P) -> Self {
+        Self {
+            policy,
+            operations: VecDeque::new(),
+            request_state: RequestState::Ready,
+            response_state: None,
+            next_id: 0,
+            changed: Arc::new(Notify::new()),
+        }
+    }
+
+    /// Returns the projected frontend protocol state.
+    #[must_use]
+    pub fn state(&self) -> PipelineState {
+        self.response_state
+            .unwrap_or_else(|| self.request_state.public())
+    }
+
+    /// Returns the number of incomplete lightweight operation records.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.operations.len()
+    }
+
+    /// Reports whether no operations remain outstanding.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.operations.is_empty()
+    }
+
+    /// Projects and accepts one frontend message without retaining its payload.
+    ///
+    /// Capacity and legality failures return the original owned message. A
+    /// capacity failure does not mutate either projected state or the ledger.
+    ///
+    /// # Errors
+    ///
+    /// Returns the unchanged boxed message when capacity is exhausted or the
+    /// message is illegal in the projected state.
+    pub fn accept_frontend(
+        &mut self,
+        message: FrontendMessage,
+        handling: FrontendHandling,
+    ) -> Result<FrontendAdmission, FrontendProjectionError> {
+        self.remove_inert_heads();
+        if self.operations.len() == self.policy.operation_limit() {
+            return Err(FrontendProjectionError::Capacity(Box::new(message)));
+        }
+
+        let Some((kind, next_state)) = project_frontend(self.request_state, &message) else {
+            return Err(FrontendProjectionError::Illegal {
+                state: self.state(),
+                message: Box::new(message),
+            });
+        };
+        let waiting = !self.operations.is_empty();
+        let id = OperationId(self.next_id);
+        self.next_id = self.next_id.saturating_add(1);
+        self.request_state = next_state;
+        let origin = match handling {
+            FrontendHandling::Forward => Origin::Forwarded,
+            FrontendHandling::Local => Origin::Local,
+        };
+        self.operations.push_back(Operation {
+            id,
+            kind,
+            origin,
+            discarded: matches!(self.request_state, RequestState::ExtendedError)
+                && kind != OperationKind::Sync,
+        });
+        let action = match handling {
+            FrontendHandling::Forward => FrontendAction::Forward { id, message },
+            FrontendHandling::Local => FrontendAction::Discard { id },
+        };
+        Ok(if waiting {
+            FrontendAdmission::Waiting(action)
+        } else {
+            FrontendAdmission::Immediate(action)
+        })
+    }
+
+    /// Convenience projection which reports capacity as [`FrontendAction::Backpressure`].
+    ///
+    /// # Errors
+    ///
+    /// Returns the unchanged message for capacity or protocol illegality.
+    pub fn project_frontend(
+        &mut self,
+        message: FrontendMessage,
+        handling: FrontendHandling,
+    ) -> Result<FrontendAdmission, FrontendProjectionError> {
+        self.accept_frontend(message, handling)
+    }
+
+    /// Projects a frontend value into the compact application-action vocabulary.
+    ///
+    /// Use [`Self::accept_frontend`] when the caller also needs to distinguish an
+    /// immediately emittable operation from an accepted waiting operation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an illegal message; capacity is represented as a successful
+    /// [`FrontendAction::Backpressure`] action.
+    pub fn frontend_action(
+        &mut self,
+        message: FrontendMessage,
+        handling: FrontendHandling,
+    ) -> Result<FrontendAction, FrontendProjectionError> {
+        match self.accept_frontend(message, handling) {
+            Ok(admission) => Ok(admission.into_action()),
+            Err(FrontendProjectionError::Capacity(message)) => {
+                Ok(FrontendAction::Backpressure(*message))
+            }
+            Err(error @ FrontendProjectionError::Illegal { .. }) => Err(error),
+        }
+    }
+
+    /// Projects one upstream backend message and preserves response order.
+    ///
+    /// # Errors
+    ///
+    /// Returns an unchanged response which cannot belong to any outstanding operation.
+    pub fn accept_backend(
+        &mut self,
+        message: BackendMessage,
+    ) -> Result<BackendAction, BackendProjectionError> {
+        self.accept_response(None, message)
+    }
+
+    /// Projects one protocol-advancing item returned by the existing [`Demux`].
+    ///
+    /// Before calling this method, forward any values from
+    /// [`Demux::pop_async_event`] in queue order. Command notices remain available
+    /// through the demux's notice queue; the ledger itself stores no notice payload.
+    ///
+    /// # Errors
+    ///
+    /// Returns an unchanged reconstructed response which cannot belong to any
+    /// outstanding operation.
+    pub fn accept_session_item(
+        &mut self,
+        item: SessionItem,
+    ) -> Result<BackendAction, BackendProjectionError> {
+        let message = match item {
+            SessionItem::Message(message) => message,
+            SessionItem::ReadyForQuery { status, .. } => BackendMessage::ReadyForQuery(status),
+            SessionItem::CommandComplete { tag, .. } => BackendMessage::CommandComplete(tag),
+        };
+        self.accept_backend(message)
+    }
+
+    /// Attempts to register and emit a locally synthesized response.
+    ///
+    /// The message is returned as [`BackendAction::Deferred`] when `id` has not
+    /// reached the head. No backend payload is retained by the ledger.
+    ///
+    /// # Errors
+    ///
+    /// Returns the unchanged message when it is illegal for the named operation.
+    pub fn try_emit_local(
+        &mut self,
+        id: OperationId,
+        message: BackendMessage,
+    ) -> Result<BackendAction, BackendProjectionError> {
+        self.accept_response(Some(id), message)
+    }
+
+    /// Waits until a local operation reaches the response head.
+    ///
+    /// Cancellation is safe: polling this future never reserves or removes a
+    /// ledger entry. The caller should then invoke [`Self::try_emit_local`].
+    pub async fn wait_until_emittable(&self, id: OperationId) {
+        loop {
+            let notified = self.changed.notified();
+            if self
+                .operations
+                .front()
+                .is_some_and(|operation| operation.id == id)
+            {
+                return;
+            }
+            notified.await;
+        }
+    }
+
+    fn accept_response(
+        &mut self,
+        local_id: Option<OperationId>,
+        message: BackendMessage,
+    ) -> Result<BackendAction, BackendProjectionError> {
+        if is_asynchronous(&message) {
+            return Ok(BackendAction::Emit(message));
+        }
+        self.remove_inert_heads();
+        let Some(head) = self.operations.front().copied() else {
+            return Err(BackendProjectionError {
+                state: self.state(),
+                message,
+            });
+        };
+        if let Some(id) = local_id {
+            if head.id != id {
+                return Ok(BackendAction::Deferred(message));
+            }
+            if head.origin != Origin::Local {
+                return Err(BackendProjectionError {
+                    state: self.state(),
+                    message,
+                });
+            }
+        } else if head.origin == Origin::Local {
+            if self.operations.iter().skip(1).any(|operation| {
+                operation.origin == Origin::Forwarded && response_fits(operation.kind, &message)
+            }) {
+                return Ok(BackendAction::Deferred(message));
+            }
+            return Err(BackendProjectionError {
+                state: self.state(),
+                message,
+            });
+        }
+        if head.discarded || !response_fits(head.kind, &message) {
+            if self
+                .operations
+                .iter()
+                .skip(1)
+                .any(|operation| response_fits(operation.kind, &message))
+            {
+                return Ok(BackendAction::Deferred(message));
+            }
+            return Err(BackendProjectionError {
+                state: self.state(),
+                message,
+            });
+        }
+
+        let terminal = response_is_terminal(head.kind, &message);
+        let error = matches!(message, BackendMessage::ErrorResponse(_));
+        let copy_state = copy_state(&message);
+        if terminal {
+            self.operations.pop_front();
+            if error && is_extended_kind(head.kind) {
+                self.enter_extended_error();
+            }
+        }
+        if let Some(state) = copy_state {
+            self.response_state = Some(state.public());
+            if matches!(state, RequestState::CopyIn | RequestState::CopyBoth) {
+                self.request_state = state;
+            }
+        }
+        if terminal {
+            self.response_state = None;
+            match head.kind {
+                OperationKind::Sync | OperationKind::Query => {
+                    self.request_state = RequestState::Ready;
+                }
+                OperationKind::Execute if !error => {
+                    self.request_state = RequestState::Extended { bound: true };
+                }
+                _ => {}
+            }
+        }
+        self.remove_inert_heads();
+        self.changed.notify_waiters();
+        Ok(BackendAction::Emit(message))
+    }
+
+    fn enter_extended_error(&mut self) {
+        self.request_state = RequestState::ExtendedError;
+        self.response_state = None;
+        for operation in &mut self.operations {
+            if operation.kind == OperationKind::Sync {
+                break;
+            }
+            operation.discarded = true;
+        }
+    }
+
+    fn remove_inert_heads(&mut self) {
+        let previous_len = self.operations.len();
+        while self.operations.front().is_some_and(|operation| {
+            operation.kind == OperationKind::Flush
+                || operation.kind == OperationKind::CopyData
+                || operation.kind == OperationKind::CopyDone
+                || operation.kind == OperationKind::CopyFail
+                || operation.kind == OperationKind::Terminate
+                || operation.discarded
+        }) {
+            self.operations.pop_front();
+        }
+        if self.operations.len() != previous_len {
+            self.changed.notify_waiters();
+        }
+    }
+}
+
+fn project_frontend(
+    state: RequestState,
+    message: &FrontendMessage,
+) -> Option<(OperationKind, RequestState)> {
+    use FrontendMessage as F;
+    use OperationKind as O;
+    use RequestState as S;
+    let generated_state = match state {
+        S::Ready => backend::RuntimeState::Ready,
+        S::Extended { .. } => backend::RuntimeState::Building,
+        S::ExtendedError => backend::RuntimeState::ExtendedError,
+        S::CopyIn => backend::RuntimeState::ExtendedCopyIn,
+        S::CopyOut => backend::RuntimeState::ExtendedCopyOut,
+        S::CopyBoth => backend::RuntimeState::ExtendedCopyBoth,
+        S::Terminated => backend::RuntimeState::Terminated,
+    };
+    backend::project_external(generated_state, message)?;
+
+    match (state, message) {
+        (S::Ready, F::Query(_)) => Some((O::Query, S::Ready)),
+        (S::Ready, F::FunctionCall(_)) => Some((O::FunctionCall, S::Ready)),
+        (S::Ready, F::Parse(_)) => Some((O::Parse, S::Extended { bound: false })),
+        (S::Ready | S::Extended { .. }, F::Bind(_)) => Some((O::Bind, S::Extended { bound: true })),
+        (S::Ready, F::Describe(_)) => Some((O::Describe, S::Extended { bound: false })),
+        (S::Ready | S::Extended { .. }, F::Execute(_)) => {
+            Some((O::Execute, S::Extended { bound: true }))
+        }
+        (S::Ready, F::Close(_)) => Some((O::Close, S::Extended { bound: false })),
+        (S::Ready, F::Terminate) => Some((O::Terminate, S::Terminated)),
+        (S::Extended { bound }, F::Parse(_)) => Some((O::Parse, S::Extended { bound })),
+        (S::Extended { bound }, F::Describe(_)) => Some((O::Describe, S::Extended { bound })),
+        (S::Extended { bound }, F::Close(_)) => Some((O::Close, S::Extended { bound })),
+        (S::Extended { bound }, F::Flush) => Some((O::Flush, S::Extended { bound })),
+        (S::Extended { .. } | S::ExtendedError, F::Sync) => Some((O::Sync, S::Ready)),
+        (S::ExtendedError, _) => Some((classify_discard(message)?, S::ExtendedError)),
+        (S::CopyIn, F::CopyData(_)) => Some((O::CopyData, S::CopyIn)),
+        (S::CopyIn, F::CopyDone) => Some((O::CopyDone, S::Extended { bound: true })),
+        (S::CopyIn, F::CopyFail(_)) => Some((O::CopyFail, S::ExtendedError)),
+        (S::CopyBoth, F::CopyData(_)) => Some((O::CopyData, S::CopyBoth)),
+        (S::CopyBoth, F::CopyDone) => Some((O::CopyDone, S::CopyBoth)),
+        _ => None,
+    }
+}
+
+fn classify_discard(message: &FrontendMessage) -> Option<OperationKind> {
+    Some(match message {
+        FrontendMessage::Parse(_) => OperationKind::Parse,
+        FrontendMessage::Bind(_) => OperationKind::Bind,
+        FrontendMessage::Describe(_) => OperationKind::Describe,
+        FrontendMessage::Execute(_) => OperationKind::Execute,
+        FrontendMessage::Close(_) => OperationKind::Close,
+        FrontendMessage::Flush => OperationKind::Flush,
+        FrontendMessage::Query(_) => OperationKind::Query,
+        FrontendMessage::FunctionCall(_) => OperationKind::FunctionCall,
+        FrontendMessage::CopyData(_) => OperationKind::CopyData,
+        FrontendMessage::CopyDone => OperationKind::CopyDone,
+        FrontendMessage::CopyFail(_) => OperationKind::CopyFail,
+        FrontendMessage::Terminate => OperationKind::Terminate,
+        FrontendMessage::PasswordResponse(_) => return None,
+        FrontendMessage::Sync => unreachable!("Sync is classified before discard"),
+    })
+}
+
+fn response_fits(kind: OperationKind, message: &BackendMessage) -> bool {
+    use BackendMessage as B;
+    use OperationKind as O;
+    match kind {
+        O::Query => matches!(
+            message,
+            B::RowDescription(_)
+                | B::DataRow(_)
+                | B::CommandComplete(_)
+                | B::EmptyQueryResponse
+                | B::CopyInResponse(_)
+                | B::CopyOutResponse(_)
+                | B::CopyBothResponse(_)
+                | B::CopyData(_)
+                | B::CopyDone
+                | B::ErrorResponse(_)
+                | B::ReadyForQuery(_)
+        ),
+        O::FunctionCall => matches!(
+            message,
+            B::FunctionCallResponse(_) | B::ErrorResponse(_) | B::ReadyForQuery(_)
+        ),
+        O::Parse => matches!(message, B::ParseComplete | B::ErrorResponse(_)),
+        O::Bind => matches!(message, B::BindComplete | B::ErrorResponse(_)),
+        O::Describe => matches!(
+            message,
+            B::ParameterDescription(_) | B::RowDescription(_) | B::NoData | B::ErrorResponse(_)
+        ),
+        O::Execute => matches!(
+            message,
+            B::RowDescription(_)
+                | B::DataRow(_)
+                | B::EmptyQueryResponse
+                | B::CommandComplete(_)
+                | B::PortalSuspended
+                | B::CopyInResponse(_)
+                | B::CopyOutResponse(_)
+                | B::CopyBothResponse(_)
+                | B::CopyData(_)
+                | B::CopyDone
+                | B::ErrorResponse(_)
+        ),
+        O::Close => matches!(message, B::CloseComplete | B::ErrorResponse(_)),
+        O::Sync => matches!(message, B::ReadyForQuery(_)),
+        O::CopyDone => matches!(
+            message,
+            B::CopyDone | B::CommandComplete(_) | B::ErrorResponse(_)
+        ),
+        O::CopyFail => matches!(message, B::ErrorResponse(_)),
+        O::Flush | O::CopyData | O::Terminate => false,
+    }
+}
+
+fn response_is_terminal(kind: OperationKind, message: &BackendMessage) -> bool {
+    use BackendMessage as B;
+    use OperationKind as O;
+    match kind {
+        O::Query | O::FunctionCall | O::Sync => matches!(message, B::ReadyForQuery(_)),
+        O::Parse => matches!(message, B::ParseComplete | B::ErrorResponse(_)),
+        O::Bind => matches!(message, B::BindComplete | B::ErrorResponse(_)),
+        O::Describe => matches!(
+            message,
+            B::RowDescription(_) | B::NoData | B::ErrorResponse(_)
+        ),
+        O::Execute => matches!(
+            message,
+            B::CommandComplete(_) | B::PortalSuspended | B::ErrorResponse(_)
+        ),
+        O::Close => matches!(message, B::CloseComplete | B::ErrorResponse(_)),
+        O::CopyDone => matches!(
+            message,
+            B::CopyDone | B::CommandComplete(_) | B::ErrorResponse(_)
+        ),
+        O::CopyFail => matches!(message, B::ErrorResponse(_)),
+        O::Flush | O::CopyData | O::Terminate => true,
+    }
+}
+
+fn is_extended_kind(kind: OperationKind) -> bool {
+    !matches!(
+        kind,
+        OperationKind::Query | OperationKind::FunctionCall | OperationKind::Terminate
+    )
+}
+
+fn copy_state(message: &BackendMessage) -> Option<RequestState> {
+    match message {
+        BackendMessage::CopyInResponse(_) => Some(RequestState::CopyIn),
+        BackendMessage::CopyOutResponse(_) => Some(RequestState::CopyOut),
+        BackendMessage::CopyBothResponse(_) => Some(RequestState::CopyBoth),
+        _ => None,
+    }
+}
+
+fn is_asynchronous(message: &BackendMessage) -> bool {
+    Demux::is_asynchronous(message)
+}

--- a/tests/intermediary_pipeline.rs
+++ b/tests/intermediary_pipeline.rs
@@ -1,0 +1,490 @@
+//! Deterministic coverage for bounded intermediary pipeline orchestration.
+
+use bytes::Bytes;
+use pg_proto::{
+    codec::{
+        BackendMessage, Bind, Close, CopyResponse, DataRow, Describe, DescribeTarget,
+        DiagnosticResponse, Execute, FrontendMessage, Parse, TransactionStatus,
+    },
+    demux::Demux,
+    intermediary::Intermediary,
+    pipeline::{
+        BackendAction, BoundedPipeline, FrontendAction, FrontendAdmission, FrontendHandling,
+        FrontendProjectionError, NoPipeline, Pipeline, PipelineState,
+    },
+};
+
+fn parse(name: &'static [u8]) -> FrontendMessage {
+    FrontendMessage::Parse(Parse {
+        statement: Bytes::from_static(name),
+        query: Bytes::from_static(b"select 1"),
+        parameter_types: vec![],
+    })
+}
+
+fn bind() -> FrontendMessage {
+    FrontendMessage::Bind(Bind {
+        portal: Bytes::new(),
+        statement: Bytes::new(),
+        parameter_formats: vec![],
+        parameters: vec![],
+        result_formats: vec![],
+    })
+}
+
+fn describe() -> FrontendMessage {
+    FrontendMessage::Describe(Describe {
+        target: DescribeTarget::Portal,
+        name: Bytes::new(),
+    })
+}
+
+fn execute() -> FrontendMessage {
+    FrontendMessage::Execute(Execute {
+        portal: Bytes::new(),
+        max_rows: 0,
+    })
+}
+
+fn close() -> FrontendMessage {
+    FrontendMessage::Close(Close {
+        target: DescribeTarget::Portal,
+        name: Bytes::new(),
+    })
+}
+
+fn error() -> BackendMessage {
+    BackendMessage::ErrorResponse(DiagnosticResponse { fields: vec![] })
+}
+
+fn forwarded_id(admission: FrontendAdmission) -> pg_proto::pipeline::OperationId {
+    match admission.into_action() {
+        FrontendAction::Forward { id, .. } => id,
+        other => panic!("expected forwarding action, got {other:?}"),
+    }
+}
+
+fn local_id(admission: FrontendAdmission) -> pg_proto::pipeline::OperationId {
+    match admission.into_action() {
+        FrontendAction::Discard { id } => id,
+        other => panic!("expected discard action, got {other:?}"),
+    }
+}
+
+fn bounded(limit: usize) -> Pipeline<BoundedPipeline> {
+    Pipeline::new(BoundedPipeline::new(limit).unwrap())
+}
+
+#[test]
+fn bounded_capacity_returns_owned_message_and_recovers() {
+    let mut pipeline = bounded(1);
+    pipeline
+        .accept_frontend(
+            FrontendMessage::Query(Bytes::from_static(b"select 1")),
+            FrontendHandling::Forward,
+        )
+        .unwrap();
+    let retry = FrontendMessage::Query(Bytes::from_static(b"select 2"));
+    let FrontendProjectionError::Capacity(retry) = pipeline
+        .accept_frontend(retry, FrontendHandling::Forward)
+        .unwrap_err()
+    else {
+        panic!("capacity must be distinguished from illegality")
+    };
+    pipeline
+        .accept_backend(BackendMessage::ReadyForQuery(TransactionStatus::Idle))
+        .unwrap();
+    assert!(
+        pipeline
+            .accept_frontend(*retry, FrontendHandling::Forward)
+            .is_ok()
+    );
+}
+
+#[test]
+fn large_payload_is_returned_not_retained() {
+    let body = Bytes::from(vec![7_u8; 2 * 1024 * 1024]);
+    let pointer = body.as_ptr();
+    let mut pipeline = bounded(2);
+    let admission = pipeline
+        .accept_frontend(FrontendMessage::Query(body), FrontendHandling::Forward)
+        .unwrap();
+    let FrontendAction::Forward {
+        message: FrontendMessage::Query(body),
+        ..
+    } = admission.into_action()
+    else {
+        panic!("query must be returned to the application")
+    };
+    assert_eq!(body.as_ptr(), pointer);
+    assert_eq!(pipeline.len(), 1);
+}
+
+#[test]
+fn simple_query_stream_stays_at_head_until_ready() {
+    let mut pipeline = bounded(2);
+    pipeline
+        .accept_frontend(
+            FrontendMessage::Query(Bytes::from_static(b"select 1")),
+            FrontendHandling::Forward,
+        )
+        .unwrap();
+    for response in [
+        BackendMessage::DataRow(DataRow {
+            columns: vec![Some(Bytes::from_static(b"1"))],
+        }),
+        BackendMessage::CommandComplete(Bytes::from_static(b"SELECT 1")),
+    ] {
+        assert!(matches!(
+            pipeline.accept_backend(response).unwrap(),
+            BackendAction::Emit(_)
+        ));
+        assert_eq!(pipeline.len(), 1);
+    }
+    pipeline
+        .accept_backend(BackendMessage::ReadyForQuery(TransactionStatus::Idle))
+        .unwrap();
+    assert!(pipeline.is_empty());
+}
+
+#[test]
+fn complete_extended_pipeline_is_ordered() {
+    let mut pipeline = bounded(8);
+    for message in [
+        parse(b"s"),
+        bind(),
+        describe(),
+        execute(),
+        close(),
+        FrontendMessage::Flush,
+        FrontendMessage::Sync,
+    ] {
+        pipeline
+            .accept_frontend(message, FrontendHandling::Forward)
+            .unwrap();
+    }
+    assert_eq!(pipeline.len(), 7);
+    for response in [
+        BackendMessage::ParseComplete,
+        BackendMessage::BindComplete,
+        BackendMessage::NoData,
+        BackendMessage::CommandComplete(Bytes::from_static(b"SELECT 1")),
+        BackendMessage::CloseComplete,
+        BackendMessage::ReadyForQuery(TransactionStatus::Idle),
+    ] {
+        pipeline.accept_backend(response).unwrap();
+    }
+    assert!(pipeline.is_empty());
+}
+
+#[test]
+fn multiple_operations_are_accepted_before_responses_and_flush_is_inert() {
+    let mut pipeline = bounded(5);
+    assert!(matches!(
+        pipeline
+            .accept_frontend(parse(b"a"), FrontendHandling::Forward)
+            .unwrap(),
+        FrontendAdmission::Immediate(_)
+    ));
+    for message in [bind(), FrontendMessage::Flush, FrontendMessage::Sync] {
+        assert!(matches!(
+            pipeline
+                .accept_frontend(message, FrontendHandling::Forward)
+                .unwrap(),
+            FrontendAdmission::Waiting(_)
+        ));
+    }
+    pipeline
+        .accept_backend(BackendMessage::ParseComplete)
+        .unwrap();
+    pipeline
+        .accept_backend(BackendMessage::BindComplete)
+        .unwrap();
+    pipeline
+        .accept_backend(BackendMessage::ReadyForQuery(TransactionStatus::Idle))
+        .unwrap();
+    assert!(pipeline.is_empty());
+}
+
+#[test]
+fn local_rejection_waits_behind_forwarded_parse() {
+    let mut pipeline = bounded(4);
+    pipeline
+        .accept_frontend(parse(b"a"), FrontendHandling::Forward)
+        .unwrap();
+    let rejected = local_id(
+        pipeline
+            .accept_frontend(parse(b"b"), FrontendHandling::Local)
+            .unwrap(),
+    );
+    pipeline
+        .accept_frontend(FrontendMessage::Sync, FrontendHandling::Forward)
+        .unwrap();
+    assert!(matches!(
+        pipeline.try_emit_local(rejected, error()).unwrap(),
+        BackendAction::Deferred(_)
+    ));
+    pipeline
+        .accept_backend(BackendMessage::ParseComplete)
+        .unwrap();
+    assert!(matches!(
+        pipeline.try_emit_local(rejected, error()).unwrap(),
+        BackendAction::Emit(BackendMessage::ErrorResponse(_))
+    ));
+    pipeline
+        .accept_backend(BackendMessage::ReadyForQuery(TransactionStatus::Idle))
+        .unwrap();
+    assert!(pipeline.is_empty());
+}
+
+#[test]
+fn first_local_rejection_discards_through_sync() {
+    let mut pipeline = bounded(4);
+    let rejected = local_id(
+        pipeline
+            .accept_frontend(parse(b"bad"), FrontendHandling::Local)
+            .unwrap(),
+    );
+    pipeline
+        .accept_frontend(bind(), FrontendHandling::Forward)
+        .unwrap();
+    pipeline
+        .accept_frontend(FrontendMessage::Sync, FrontendHandling::Forward)
+        .unwrap();
+    pipeline.try_emit_local(rejected, error()).unwrap();
+    assert_eq!(pipeline.state(), PipelineState::ExtendedError);
+    assert_eq!(
+        pipeline.len(),
+        1,
+        "discarded Bind must not await a response"
+    );
+    pipeline
+        .accept_backend(BackendMessage::ReadyForQuery(TransactionStatus::Idle))
+        .unwrap();
+    assert!(pipeline.is_empty());
+}
+
+#[test]
+fn upstream_error_discards_following_operations_until_sync() {
+    let mut pipeline = bounded(4);
+    for message in [parse(b"bad"), bind(), FrontendMessage::Sync] {
+        pipeline
+            .accept_frontend(message, FrontendHandling::Forward)
+            .unwrap();
+    }
+    pipeline.accept_backend(error()).unwrap();
+    assert_eq!(pipeline.len(), 1);
+    pipeline
+        .accept_backend(BackendMessage::ReadyForQuery(TransactionStatus::Idle))
+        .unwrap();
+    assert!(pipeline.is_empty());
+}
+
+#[test]
+fn illegal_frontend_and_backend_messages_are_not_deferred() {
+    let mut pipeline = bounded(3);
+    let illegal = FrontendMessage::CopyData(Bytes::from_static(b"outside COPY"));
+    assert!(matches!(
+        pipeline
+            .accept_frontend(illegal, FrontendHandling::Forward)
+            .unwrap_err(),
+        FrontendProjectionError::Illegal { .. }
+    ));
+    pipeline
+        .accept_frontend(parse(b"s"), FrontendHandling::Forward)
+        .unwrap();
+    assert!(
+        pipeline
+            .accept_backend(BackendMessage::BindComplete)
+            .is_err()
+    );
+}
+
+#[test]
+fn copy_in_out_and_both_preserve_nested_legality() {
+    let copy = CopyResponse {
+        overall_format: 0,
+        column_formats: vec![],
+    };
+
+    let mut input = bounded(6);
+    for message in [parse(b"s"), bind(), execute()] {
+        input
+            .accept_frontend(message, FrontendHandling::Forward)
+            .unwrap();
+    }
+    input.accept_backend(BackendMessage::ParseComplete).unwrap();
+    input.accept_backend(BackendMessage::BindComplete).unwrap();
+    input
+        .accept_backend(BackendMessage::CopyInResponse(copy.clone()))
+        .unwrap();
+    assert_eq!(input.state(), PipelineState::CopyIn);
+    input
+        .accept_frontend(
+            FrontendMessage::CopyData(Bytes::from_static(b"row\n")),
+            FrontendHandling::Forward,
+        )
+        .unwrap();
+    input
+        .accept_frontend(FrontendMessage::CopyDone, FrontendHandling::Forward)
+        .unwrap();
+
+    for (response, expected) in [
+        (
+            BackendMessage::CopyOutResponse(copy.clone()),
+            PipelineState::CopyOut,
+        ),
+        (
+            BackendMessage::CopyBothResponse(copy),
+            PipelineState::CopyBoth,
+        ),
+    ] {
+        let mut pipeline = bounded(4);
+        for message in [parse(b"s"), bind(), execute()] {
+            pipeline
+                .accept_frontend(message, FrontendHandling::Forward)
+                .unwrap();
+        }
+        pipeline
+            .accept_backend(BackendMessage::ParseComplete)
+            .unwrap();
+        pipeline
+            .accept_backend(BackendMessage::BindComplete)
+            .unwrap();
+        pipeline.accept_backend(response).unwrap();
+        assert_eq!(pipeline.state(), expected);
+        pipeline
+            .accept_backend(BackendMessage::CopyData(Bytes::from_static(b"row\n")))
+            .unwrap();
+    }
+}
+
+#[test]
+fn asynchronous_messages_do_not_advance_the_ledger() {
+    let mut pipeline = bounded(2);
+    pipeline
+        .accept_frontend(parse(b"s"), FrontendHandling::Forward)
+        .unwrap();
+    for message in [
+        BackendMessage::NoticeResponse(DiagnosticResponse { fields: vec![] }),
+        BackendMessage::NotificationResponse {
+            process_id: 7,
+            channel: Bytes::from_static(b"events"),
+            payload: Bytes::from_static(b"changed"),
+        },
+        BackendMessage::ParameterStatus {
+            name: Bytes::from_static(b"TimeZone"),
+            value: Bytes::from_static(b"UTC"),
+        },
+        BackendMessage::BackendKeyData {
+            process_id: 9,
+            secret_key: Bytes::from_static(b"secret-key"),
+        },
+    ] {
+        assert!(matches!(
+            pipeline.accept_backend(message).unwrap(),
+            BackendAction::Emit(_)
+        ));
+        assert_eq!(pipeline.len(), 1);
+    }
+}
+
+#[test]
+fn demuxed_session_items_share_the_pipeline_ordering_path() {
+    let mut demux = Demux::default();
+    let mut pipeline = bounded(2);
+    pipeline
+        .accept_frontend(parse(b"s"), FrontendHandling::Forward)
+        .unwrap();
+    assert!(
+        demux
+            .route(BackendMessage::NoticeResponse(DiagnosticResponse {
+                fields: vec![],
+            }))
+            .is_none()
+    );
+    assert!(demux.pop_async_event().is_some());
+    let item = demux
+        .route(BackendMessage::ParseComplete)
+        .expect("ParseComplete advances the session");
+    assert!(matches!(
+        pipeline.accept_session_item(item).unwrap(),
+        BackendAction::Emit(BackendMessage::ParseComplete)
+    ));
+}
+
+#[tokio::test]
+async fn cancellation_of_waiting_local_caller_does_not_change_ledger() {
+    let mut pipeline = bounded(2);
+    pipeline
+        .accept_frontend(parse(b"a"), FrontendHandling::Forward)
+        .unwrap();
+    let local = local_id(
+        pipeline
+            .accept_frontend(parse(b"b"), FrontendHandling::Local)
+            .unwrap(),
+    );
+    let result = tokio::time::timeout(
+        std::time::Duration::from_millis(1),
+        pipeline.wait_until_emittable(local),
+    )
+    .await;
+    assert!(result.is_err());
+    assert_eq!(pipeline.len(), 2);
+    pipeline
+        .accept_backend(BackendMessage::ParseComplete)
+        .unwrap();
+    pipeline.wait_until_emittable(local).await;
+}
+
+#[test]
+fn no_pipeline_backpressures_until_current_cycle_completes() {
+    let mut pipeline = Pipeline::new(NoPipeline);
+    pipeline
+        .accept_frontend(
+            FrontendMessage::Query(Bytes::from_static(b"select 1")),
+            FrontendHandling::Forward,
+        )
+        .unwrap();
+    assert!(matches!(
+        pipeline
+            .accept_frontend(
+                FrontendMessage::Query(Bytes::from_static(b"select 2")),
+                FrontendHandling::Forward
+            )
+            .unwrap_err(),
+        FrontendProjectionError::Capacity(_)
+    ));
+}
+
+#[test]
+fn intermediary_preserves_old_constructor_and_can_opt_into_bounding() {
+    let old = Intermediary::new(1_u8, 2_u8);
+    assert_eq!(*old.downstream(), 1);
+    let mut bounded = old.with_pipeline(BoundedPipeline::new(4).unwrap());
+    bounded
+        .pipeline_mut()
+        .accept_frontend(parse(b"s"), FrontendHandling::Forward)
+        .unwrap();
+    assert_eq!(bounded.pipeline().len(), 1);
+}
+
+#[test]
+fn later_valid_backend_response_is_deferred_not_illegal() {
+    let mut pipeline = bounded(3);
+    let first = forwarded_id(
+        pipeline
+            .accept_frontend(parse(b"s"), FrontendHandling::Forward)
+            .unwrap(),
+    );
+    assert_eq!(first, first);
+    pipeline
+        .accept_frontend(bind(), FrontendHandling::Forward)
+        .unwrap();
+    assert!(matches!(
+        pipeline
+            .accept_backend(BackendMessage::BindComplete)
+            .unwrap(),
+        BackendAction::Deferred(BackendMessage::BindComplete)
+    ));
+}


### PR DESCRIPTION
## Summary

- add optional `NoPipeline` and operation-bounded `BoundedPipeline` policies to `Intermediary`
- preserve frontend/backend response order using lightweight operation records without retaining SQL, COPY, Bind, or DataRow payloads
- support forwarded and locally handled operations, ordered synthesised responses, explicit backpressure, COPY phases, and extended-query error draining through `Sync`
- share asynchronous-message classification and session-item handling with the existing demux
- add an intermediary pipeline example, migration guidance, and public API documentation

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`

The deterministic pipeline suite covers capacity recovery, payload ownership,
simple and extended ordering, Flush, local and upstream errors, COPY IN/OUT/BOTH,
asynchronous messages, cancellation safety, illegal projections, `NoPipeline`,
and existing `Intermediary` compatibility.
