### PR TITLE
Complete project documentation and repository housekeeping

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @freshtonic

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,40 @@
+name: Bug report
+description: Report incorrect protocol behaviour or a regression.
+title: "bug: "
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: Do not report security vulnerabilities here; use private vulnerability reporting.
+  - type: input
+    id: version
+    attributes:
+      label: pg-proto version
+      placeholder: 0.2.0
+    validations:
+      required: true
+  - type: dropdown
+    id: postgres
+    attributes:
+      label: PostgreSQL version
+      options: ["14", "15", "16", "17", "18", "Not applicable"]
+    validations:
+      required: true
+  - type: textarea
+    id: behaviour
+    attributes:
+      label: Observed behaviour
+      description: Include a minimal reproduction and sanitised protocol details.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Rust version, operating system, runtime and relevant configuration.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/freshtonic/pg-proto/security/advisories/new
+    about: Report vulnerabilities privately; do not create a public issue.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,24 @@
+name: Feature request
+description: Propose a protocol capability or public API change.
+title: "feature: "
+labels: [enhancement]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What proxy, pooler, driver or server use case is not currently possible?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed API or protocol model
+      description: Describe affected roles, phases, message families and compatibility constraints.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What other designs or workarounds have you considered?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Summary
+
+<!-- What changes, and why? -->
+
+## Protocol impact
+
+<!-- Which states/messages change? Write "None" when not applicable. -->
+
+## Verification
+
+- [ ] `cargo fmt --all -- --check`
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
+- [ ] `cargo test --workspace`
+- [ ] Public documentation updated where required
+- [ ] `PLAN.md` updated where required

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:00"
+      timezone: Australia/Sydney
+    open-pull-requests-limit: 10
+    groups:
+      cargo-patch-and-minor:
+        update-types: [minor, patch]
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:30"
+      timezone: Australia/Sydney
+    groups:
+      github-actions:
+        patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Install stable Rust
-        uses: dtolnay/rust-toolchain@stable
+      - name: Install development Rust
+        uses: dtolnay/rust-toolchain@1.97.1
         with:
           components: clippy, rustfmt
 
@@ -46,11 +46,37 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Install stable Rust
-        uses: dtolnay/rust-toolchain@stable
+      - name: Install development Rust
+        uses: dtolnay/rust-toolchain@1.97.1
 
       - name: Run all benchmarks
         run: cargo bench --workspace
+
+  msrv:
+    name: MSRV 1.88
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install minimum supported Rust
+        uses: dtolnay/rust-toolchain@1.88.0
+
+      - name: Check every workspace target
+        run: cargo check --workspace --all-targets
+
+  package:
+    name: Package crates
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install development Rust
+        uses: dtolnay/rust-toolchain@1.97.1
+
+      - name: Verify publishable packages
+        run: cargo package --workspace
 
   fuzz:
     name: Fuzz ${{ matrix.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,4 +101,4 @@ jobs:
         run: cargo install cargo-fuzz --locked
 
       - name: Run fuzz target
-        run: cargo fuzz run --fuzz-dir fuzz ${{ matrix.target }} -- -max_total_time=60
+        run: cargo +nightly fuzz run --fuzz-dir fuzz ${{ matrix.target }} -- -max_total_time=60

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,10 +7,11 @@ on:
 
 jobs:
   rustdoc:
+    name: Documentation
     runs-on: ubuntu-latest
     env:
       RUSTDOCFLAGS: -D warnings
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.97.1
       - run: cargo doc --workspace --no-deps

--- a/.github/workflows/postgres-compatibility.yml
+++ b/.github/workflows/postgres-compatibility.yml
@@ -19,6 +19,6 @@ jobs:
       PG_PROTO_POSTGRES_VERSION: ${{ matrix.version }}
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.97.1
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --test postgres_container -- --ignored

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -22,8 +22,8 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Install stable Rust
-        uses: dtolnay/rust-toolchain@stable
+      - name: Install development Rust
+        uses: dtolnay/rust-toolchain@1.97.1
 
       - name: Publish release
         uses: release-plz/action@v0.5
@@ -48,8 +48,8 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Install stable Rust
-        uses: dtolnay/rust-toolchain@stable
+      - name: Install development Rust
+        uses: dtolnay/rust-toolchain@1.97.1
 
       - name: Prepare release pull request
         uses: release-plz/action@v0.5

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -10,9 +10,17 @@ on:
 
 jobs:
   rustsec:
+    name: RustSec audit
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: rustsec/audit-check@v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  deny:
+    name: Dependency policy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: EmbarkStudios/cargo-deny-action@v1

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,7 +13,7 @@ jobs:
     name: RustSec audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: rustsec/audit-check@v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -22,5 +22,6 @@ jobs:
     name: Dependency policy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: EmbarkStudios/cargo-deny-action@v1
+      - uses: actions/checkout@v6
+      - uses: taiki-e/install-action@cargo-deny
+      - run: cargo deny check

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+support@cipherstash.com.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Contributing to pg-proto
+
+Thank you for helping improve `pg-proto`. By participating, you agree to follow
+the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Before opening a change
+
+Use an issue for substantial protocol or public-API design changes. Security
+reports must follow [SECURITY.md](SECURITY.md) and must not be filed publicly.
+
+Protocol changes should preserve the generated grammar as the single source of
+truth. Proxy-facing changes must retain the capabilities described in
+[PROXY_COMPATIBILITY.md](PROXY_COMPATIBILITY.md). Prose and comments use British
+English.
+
+## Development environment
+
+The repository's `rust-toolchain.toml` selects the development compiler. A
+Docker-compatible container runtime is needed for live PostgreSQL tests. The
+normal verification commands are:
+
+```console
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps
+cargo package --workspace
+```
+
+Run the PostgreSQL compatibility suite with:
+
+```console
+cargo test --test postgres_container -- --ignored --test-threads=1
+```
+
+Run a focused fuzz target with nightly Rust:
+
+```console
+cargo +nightly fuzz run --fuzz-dir fuzz backend_codec
+```
+
+## Pull requests
+
+- Keep changes focused and include tests for observable behaviour.
+- Update public Rustdoc and migration guidance when an API changes.
+- Update `PLAN.md` when completing or adding planned work.
+- Prefer Conventional Commit prefixes (`feat:`, `fix:`, `docs:`, `test:`,
+  `refactor:`, `perf:`, `chore:`) so release notes are grouped meaningfully.
+- Do not commit credentials, private certificates, production captures, or
+  unsanitised protocol payloads.
+
+All required checks must pass and review comments must be resolved before merge.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,15 @@ missing_docs = "deny"
 unsafe_code = "forbid"
 
 [lints.clippy]
-all = "warn"
-pedantic = "warn"
+all = { level = "warn", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
+nursery = { level = "warn", priority = -1 }
+cargo = { level = "warn", priority = -1 }
+# These produce unstable or dependency-graph noise rather than actionable defects.
+future_not_send = "allow"
+missing_const_for_fn = "allow"
+multiple_crate_versions = "allow"
+option_if_let_else = "allow"
 
 [dependencies]
 bytes = "1.12.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pg-proto"
 version = "0.2.0"
 edition = "2024"
-license = "Apache-2.0"
+license = "MIT"
 description = "Session-typed PostgreSQL wire protocol"
 documentation = "https://docs.rs/pg-proto"
 homepage = "https://github.com/freshtonic/pg-proto"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,11 @@
 name = "pg-proto"
 version = "0.2.0"
 edition = "2024"
+authors = ["James Sadler <freshtonic@gmail.com>"]
 license = "MIT"
 description = "Session-typed PostgreSQL wire protocol"
+keywords = ["postgresql", "protocol", "proxy", "typestate", "async"]
+categories = ["database", "network-programming", "asynchronous"]
 documentation = "https://docs.rs/pg-proto"
 homepage = "https://github.com/freshtonic/pg-proto"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "pg-proto"
 version = "0.2.0"
 edition = "2024"
+rust-version = "1.88"
 authors = ["James Sadler <freshtonic@gmail.com>"]
 license = "MIT"
 description = "Session-typed PostgreSQL wire protocol"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 James Sadler
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/PLAN.md
+++ b/PLAN.md
@@ -255,7 +255,8 @@ neutral composition harnesses and examples.
 - [x] Add contribution guidance, Proxy's Contributor Covenant, ownership and
   issue/PR templates, plus a private-reporting security policy and review archive.
 - [x] Add Dependabot, cargo-deny, MSRV and package CI, pinned stable tooling,
-  structured release notes, repository topics, private reporting, and main protection.
+  structured release notes, repository topics, private reporting, and main protection;
+  verify nightly fuzzing and current advisory parsing in GitHub Actions.
 
 These are deliberately not completion criteria for `pg-proto`'s current plan.
 They depend on downstream requirements or pursue additional assurance beyond the

--- a/PLAN.md
+++ b/PLAN.md
@@ -257,6 +257,8 @@ neutral composition harnesses and examples.
 - [x] Add Dependabot, cargo-deny, MSRV and package CI, pinned stable tooling,
   structured release notes, repository topics, private reporting, and main protection;
   verify nightly fuzzing and current advisory parsing in GitHub Actions.
+- [x] Enforce Clippy's all, pedantic, nursery, and Cargo lint groups, retaining
+  narrow exceptions only for unstable or dependency-graph noise.
 
 These are deliberately not completion criteria for `pg-proto`'s current plan.
 They depend on downstream requirements or pursue additional assurance beyond the

--- a/PLAN.md
+++ b/PLAN.md
@@ -254,6 +254,8 @@ neutral composition harnesses and examples.
   package badges, tidy the README, and document the FSM crate separately.
 - [x] Add contribution guidance, Proxy's Contributor Covenant, ownership and
   issue/PR templates, plus a private-reporting security policy and review archive.
+- [x] Add Dependabot, cargo-deny, MSRV and package CI, pinned stable tooling,
+  structured release notes, repository topics, private reporting, and main protection.
 
 These are deliberately not completion criteria for `pg-proto`'s current plan.
 They depend on downstream requirements or pursue additional assurance beyond the

--- a/PLAN.md
+++ b/PLAN.md
@@ -252,6 +252,8 @@ neutral composition harnesses and examples.
 - [x] Add package author metadata to both published crates.
 - [x] Declare and test the Rust 1.88 MSRV, pin the development toolchain, add
   package badges, tidy the README, and document the FSM crate separately.
+- [x] Add contribution guidance, Proxy's Contributor Covenant, ownership and
+  issue/PR templates, plus a private-reporting security policy and review archive.
 
 These are deliberately not completion criteria for `pg-proto`'s current plan.
 They depend on downstream requirements or pursue additional assurance beyond the

--- a/PLAN.md
+++ b/PLAN.md
@@ -247,6 +247,7 @@ neutral composition harnesses and examples.
 - [x] Add optional operation-bounded intermediary pipeline orchestration with
   payload-free ordering records, local responses, COPY, and Sync error recovery.
 - [x] Use the repository README as the crate-level Rustdoc landing page.
+- [x] License both published crates and the repository under the MIT License.
 
 These are deliberately not completion criteria for `pg-proto`'s current plan.
 They depend on downstream requirements or pursue additional assurance beyond the

--- a/PLAN.md
+++ b/PLAN.md
@@ -246,6 +246,7 @@ neutral composition harnesses and examples.
 
 - [x] Add optional operation-bounded intermediary pipeline orchestration with
   payload-free ordering records, local responses, COPY, and Sync error recovery.
+- [x] Use the repository README as the crate-level Rustdoc landing page.
 
 These are deliberately not completion criteria for `pg-proto`'s current plan.
 They depend on downstream requirements or pursue additional assurance beyond the

--- a/PLAN.md
+++ b/PLAN.md
@@ -248,6 +248,8 @@ neutral composition harnesses and examples.
   payload-free ordering records, local responses, COPY, and Sync error recovery.
 - [x] Use the repository README as the crate-level Rustdoc landing page.
 - [x] License both published crates and the repository under the MIT License.
+- [x] Add descriptive crates.io keywords and categories to both package manifests.
+- [x] Add package author metadata to both published crates.
 
 These are deliberately not completion criteria for `pg-proto`'s current plan.
 They depend on downstream requirements or pursue additional assurance beyond the

--- a/PLAN.md
+++ b/PLAN.md
@@ -250,6 +250,8 @@ neutral composition harnesses and examples.
 - [x] License both published crates and the repository under the MIT License.
 - [x] Add descriptive crates.io keywords and categories to both package manifests.
 - [x] Add package author metadata to both published crates.
+- [x] Declare and test the Rust 1.88 MSRV, pin the development toolchain, add
+  package badges, tidy the README, and document the FSM crate separately.
 
 These are deliberately not completion criteria for `pg-proto`'s current plan.
 They depend on downstream requirements or pursue additional assurance beyond the

--- a/README.md
+++ b/README.md
@@ -207,6 +207,10 @@ compile-fail, and documentation tests:
 cargo test --workspace
 ```
 
+## Licence
+
+Licensed under the [MIT License](https://github.com/freshtonic/pg-proto/blob/main/LICENSE).
+
 Live PostgreSQL tests require a Docker-compatible runtime:
 
 ```console

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![CI](https://github.com/freshtonic/pg-proto/actions/workflows/ci.yml/badge.svg)](https://github.com/freshtonic/pg-proto/actions/workflows/ci.yml)
 [![docs.rs](https://docs.rs/pg-proto/badge.svg)](https://docs.rs/pg-proto)
 [![crates.io](https://img.shields.io/crates/v/pg-proto.svg)](https://crates.io/crates/pg-proto)
+[![MSRV](https://img.shields.io/badge/MSRV-1.88-blue.svg)](https://blog.rust-lang.org/2025/06/26/Rust-1.88.0/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/freshtonic/pg-proto/blob/main/LICENSE)
 
 `pg-proto` is an asynchronous Rust implementation of the PostgreSQL
 frontend/backend wire protocol designed for proxies, poolers, gateways, drivers,
@@ -149,10 +151,11 @@ proxy composition boundary.
 - [Client-role query sessions](https://docs.rs/pg-proto/latest/pg_proto/session/)
 - [Server-role query sessions](https://docs.rs/pg-proto/latest/pg_proto/server_session/)
 - [Proxy-side composition hooks](https://docs.rs/pg-proto/latest/pg_proto/intermediary/)
+- [Bounded intermediary pipeline](https://docs.rs/pg-proto/latest/pg_proto/pipeline/)
 - [Prepared-statement and portal resources](https://docs.rs/pg-proto/latest/pg_proto/resources/)
 - [Generated protocol grammars and railroad diagrams](https://docs.rs/pg-proto/latest/pg_proto/grammar/)
 
-Until the first crates.io release, build the same documentation locally:
+Build the same documentation locally with:
 
 ```console
 cargo doc --workspace --no-deps --open
@@ -207,12 +210,12 @@ compile-fail, and documentation tests:
 cargo test --workspace
 ```
 
-## Licence
-
-Licensed under the [MIT License](https://github.com/freshtonic/pg-proto/blob/main/LICENSE).
-
 Live PostgreSQL tests require a Docker-compatible runtime:
 
 ```console
 cargo test --test postgres_container -- --ignored
 ```
+
+## Licence
+
+Licensed under the [MIT License](https://github.com/freshtonic/pg-proto/blob/main/LICENSE).

--- a/README.md
+++ b/README.md
@@ -200,6 +200,9 @@ Security assumptions and downstream responsibilities are documented in
 [`SECURITY.md`](SECURITY.md). The audited proxy capability boundary is in
 [`PROXY_COMPATIBILITY.md`](PROXY_COMPATIBILITY.md), and migration from a
 runtime-enum implementation is covered by [`MIGRATION.md`](MIGRATION.md).
+Contribution instructions and community expectations are in
+[`CONTRIBUTING.md`](CONTRIBUTING.md) and
+[`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).
 
 ## Verification
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,44 +1,37 @@
-# Security review
+# Security policy
 
-Review completed 4 August 2026 against the proxy-facing API and the audited
-CipherStash/pgcat protocol obligations.
+## Supported versions
 
-`cargo audit` scanned all 312 locked dependencies against 1,186 RustSec
-advisories on that date and reported no vulnerabilities.
+`pg-proto` is pre-1.0. Security fixes are provided for the latest published
+minor release only. Users should upgrade to the newest release before reporting
+or evaluating a possible vulnerability.
 
-## Reviewed controls
+| Version | Supported |
+| --- | --- |
+| 0.2.x | Yes |
+| 0.1.x | No |
 
-- **TLS policy:** `disable`, `allow`, `prefer`, `require`, `verify-ca`, and
-  `verify-full` have explicit negotiation branches. `verify-ca` validates the
-  chain; `verify-full` additionally validates the host. Modes below `verify-ca`
-  intentionally provide encryption without peer authentication, matching
-  libpq semantics, and must not be presented as identity verification.
-- **Channel binding:** `tls-server-end-point` hashes the complete DER leaf
-  certificate with the RFC 5929 digest selection rule, including SHA-1/MD5
-  promotion to SHA-256. SCRAM-PLUS is unavailable without transport evidence and
-  downgrade attempts are rejected.
-- **Credentials:** cleartext and MD5 verification use constant-time comparison;
-  SCRAM proof and channel-binding checks do likewise. MD5 and cleartext remain
-  compatibility mechanisms, not recommendations. Authentication payloads,
-  platform tokens, and cancellation secrets are redacted from `Debug` output.
-- **Framing and allocation:** declared lengths are validated before reservation.
-  Tagged frames default to 16 MiB and raw pre-startup packets to 10 kB; callers
-  may deliberately configure another valid bound. Count and integer conversions
-  are checked during reconstruction.
-- **Cancellation:** keys are length-validated, collisions are not overwritten,
-  and registry/minting policy is application-owned. Deployments must mint
-  unpredictable keys and remove mappings when either session detaches.
-- **Malformed messages:** both directional codecs reject unknown tags, truncated
-  known bodies, invalid counts/Booleans, bad protocol branches, and oversized
-  frames without advancing typed state. Compile-fail, fixture, differential, and
-  fuzz targets cover these boundaries.
+This table is updated when a new minor release supersedes the current line.
 
-## Residual application responsibilities
+## Reporting a vulnerability
 
-The library cannot erase every copied `Bytes` allocation on drop and does not
-control downstream logs of explicitly accessed SQL, parameters, rows, or
-credentials. Applications must minimise credential lifetime, avoid diagnostic
-logging of message bodies, configure trust roots and hostnames correctly, apply
-timeouts around handshakes and reads, and choose limits appropriate to their
-workload. GSSAPI/SSPI adapters must provide their platform's credential and
-context-lifetime guarantees.
+Do not open a public issue. Use GitHub's
+[private vulnerability reporting](https://github.com/freshtonic/pg-proto/security/advisories/new)
+to send the affected versions, impact, reproduction steps, and any suggested
+mitigation privately to the maintainer.
+
+You should receive an acknowledgement within 3 working days. The maintainer
+will investigate, coordinate a fix and disclosure where appropriate, and credit
+reporters who wish to be named. Please allow a reasonable remediation period
+before publishing details.
+
+## Scope and assumptions
+
+Security-sensitive surfaces include wire decoding, allocation bounds,
+authentication, TLS and channel binding, cancellation keys, protocol-state
+projection, and accidental disclosure through diagnostics. Proxy deployments
+remain responsible for credential storage, certificate provisioning, routing
+policy, connection timeouts, pool policy, and sanitising application logs.
+
+The latest completed review is recorded in
+[`docs/security-review-2026-08-04.md`](docs/security-review-2026-08-04.md).

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,29 @@
+[graph]
+all-features = true
+
+[advisories]
+ignore = []
+
+[licenses]
+confidence-threshold = 0.8
+allow = [
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-3-Clause",
+    "CC0-1.0",
+    "ISC",
+    "MIT",
+    "Unicode-3.0",
+    "Zlib",
+]
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+highlight = "all"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []

--- a/docs/security-review-2026-08-04.md
+++ b/docs/security-review-2026-08-04.md
@@ -1,0 +1,44 @@
+# Security review: 4 August 2026
+
+Review completed against the proxy-facing API and the audited CipherStash/pgcat
+protocol obligations.
+
+`cargo audit` scanned all 312 locked dependencies against 1,186 RustSec
+advisories on that date and reported no vulnerabilities.
+
+## Reviewed controls
+
+- **TLS policy:** `disable`, `allow`, `prefer`, `require`, `verify-ca`, and
+  `verify-full` have explicit negotiation branches. `verify-ca` validates the
+  chain; `verify-full` additionally validates the host. Modes below `verify-ca`
+  intentionally provide encryption without peer authentication, matching
+  libpq semantics, and must not be presented as identity verification.
+- **Channel binding:** `tls-server-end-point` hashes the complete DER leaf
+  certificate with the RFC 5929 digest selection rule, including SHA-1/MD5
+  promotion to SHA-256. SCRAM-PLUS is unavailable without transport evidence and
+  downgrade attempts are rejected.
+- **Credentials:** cleartext and MD5 verification use constant-time comparison;
+  SCRAM proof and channel-binding checks do likewise. MD5 and cleartext remain
+  compatibility mechanisms, not recommendations. Authentication payloads,
+  platform tokens, and cancellation secrets are redacted from `Debug` output.
+- **Framing and allocation:** declared lengths are validated before reservation.
+  Tagged frames default to 16 MiB and raw pre-startup packets to 10 kB; callers
+  may deliberately configure another valid bound. Count and integer conversions
+  are checked during reconstruction.
+- **Cancellation:** keys are length-validated, collisions are not overwritten,
+  and registry/minting policy is application-owned. Deployments must mint
+  unpredictable keys and remove mappings when either session detaches.
+- **Malformed messages:** both directional codecs reject unknown tags, truncated
+  known bodies, invalid counts/Booleans, bad protocol branches, and oversized
+  frames without advancing typed state. Compile-fail, fixture, differential, and
+  fuzz targets cover these boundaries.
+
+## Residual application responsibilities
+
+The library cannot erase every copied `Bytes` allocation on drop and does not
+control downstream logs of explicitly accessed SQL, parameters, rows, or
+credentials. Applications must minimise credential lifetime, avoid diagnostic
+logging of message bodies, configure trust roots and hostnames correctly, apply
+timeouts around handshakes and reads, and choose limits appropriate to their
+workload. GSSAPI/SSPI adapters must provide their platform's credential and
+context-lifetime guarantees.

--- a/pg-proto-fsm/Cargo.toml
+++ b/pg-proto-fsm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pg-proto-fsm"
 version = "0.2.0"
 edition = "2024"
-license = "Apache-2.0"
+license = "MIT"
 description = "Protocol grammar generator for pg-proto"
 documentation = "https://docs.rs/pg-proto-fsm"
 homepage = "https://github.com/freshtonic/pg-proto"

--- a/pg-proto-fsm/Cargo.toml
+++ b/pg-proto-fsm/Cargo.toml
@@ -2,8 +2,11 @@
 name = "pg-proto-fsm"
 version = "0.2.0"
 edition = "2024"
+authors = ["James Sadler <freshtonic@gmail.com>"]
 license = "MIT"
 description = "Protocol grammar generator for pg-proto"
+keywords = ["protocol", "typestate", "state-machine", "proc-macro", "railroad"]
+categories = ["development-tools::procedural-macro-helpers", "network-programming"]
 documentation = "https://docs.rs/pg-proto-fsm"
 homepage = "https://github.com/freshtonic/pg-proto"
 repository = "https://github.com/freshtonic/pg-proto"

--- a/pg-proto-fsm/Cargo.toml
+++ b/pg-proto-fsm/Cargo.toml
@@ -21,8 +21,15 @@ missing_docs = "deny"
 unsafe_code = "forbid"
 
 [lints.clippy]
-all = "warn"
-pedantic = "warn"
+all = { level = "warn", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
+nursery = { level = "warn", priority = -1 }
+cargo = { level = "warn", priority = -1 }
+# These produce unstable or dependency-graph noise rather than actionable defects.
+future_not_send = "allow"
+missing_const_for_fn = "allow"
+multiple_crate_versions = "allow"
+option_if_let_else = "allow"
 
 [dependencies]
 proc-macro2 = "1.0.107"

--- a/pg-proto-fsm/Cargo.toml
+++ b/pg-proto-fsm/Cargo.toml
@@ -2,6 +2,7 @@
 name = "pg-proto-fsm"
 version = "0.2.0"
 edition = "2024"
+rust-version = "1.88"
 authors = ["James Sadler <freshtonic@gmail.com>"]
 license = "MIT"
 description = "Protocol grammar generator for pg-proto"
@@ -10,6 +11,7 @@ categories = ["development-tools::procedural-macro-helpers", "network-programmin
 documentation = "https://docs.rs/pg-proto-fsm"
 homepage = "https://github.com/freshtonic/pg-proto"
 repository = "https://github.com/freshtonic/pg-proto"
+readme = "README.md"
 
 [lib]
 proc-macro = true

--- a/pg-proto-fsm/LICENSE
+++ b/pg-proto-fsm/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 James Sadler
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pg-proto-fsm/README.md
+++ b/pg-proto-fsm/README.md
@@ -1,0 +1,24 @@
+# pg-proto-fsm
+
+`pg-proto-fsm` is the procedural-macro implementation behind
+[`pg-proto`](https://crates.io/crates/pg-proto). It turns one PostgreSQL protocol
+grammar into:
+
+- transport-carrying typestate APIs for both protocol roles;
+- a runtime FSM used for differential and fuzz testing;
+- state-aware wire-message projectors; and
+- railroad diagrams embedded in Rustdoc.
+
+Most users should depend on `pg-proto`, which re-exports the generated protocol
+modules. Depend directly on this crate only when defining or testing another
+grammar with the same generator.
+
+## Documentation
+
+- [`pg-proto-fsm` Rustdoc](https://docs.rs/pg-proto-fsm)
+- [`pg-proto` Rustdoc](https://docs.rs/pg-proto)
+- [Repository](https://github.com/freshtonic/pg-proto)
+
+## Licence
+
+Licensed under the [MIT License](https://github.com/freshtonic/pg-proto/blob/main/pg-proto-fsm/LICENSE).

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -6,6 +6,22 @@ release_always = false
 repo_url = "https://github.com/freshtonic/pg-proto"
 semver_check = true
 
+[changelog]
+protect_breaking_commits = true
+sort_commits = "oldest"
+commit_parsers = [
+    { message = "^feat", group = "Added" },
+    { message = "^(add|implement|support)", group = "Added" },
+    { message = "^(fix|bound|reject)", group = "Fixed" },
+    { message = "^docs?", group = "Documentation" },
+    { message = "^(document|show)", group = "Documentation" },
+    { message = "^perf", group = "Performance" },
+    { message = "^security", group = "Security" },
+    { message = "^test", group = "Testing" },
+    { message = "^chore", group = "Maintenance" },
+    { message = ".*", group = "Changed" },
+]
+
 [[package]]
 name = "pg-proto"
 changelog_include = ["pg-proto-fsm"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.97.1"
+components = ["clippy", "rustfmt"]
+profile = "minimal"

--- a/src/intermediary.rs
+++ b/src/intermediary.rs
@@ -119,7 +119,7 @@ impl<Downstream, Upstream, Policy: PipelinePolicy> Intermediary<Downstream, Upst
                 output,
             )),
             Err((downstream, error)) => Err((
-                Intermediary {
+                Self {
                     downstream,
                     upstream,
                     pipeline,
@@ -155,7 +155,7 @@ impl<Downstream, Upstream, Policy: PipelinePolicy> Intermediary<Downstream, Upst
                 output,
             )),
             Err((upstream, error)) => Err((
-                Intermediary {
+                Self {
                     downstream,
                     upstream,
                     pipeline,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("../README.md")]
+#![allow(clippy::doc_markdown)]
 
 pub mod auth;
 pub mod cancel;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! Session-typed `PostgreSQL` wire protocol primitives.
+#![doc = include_str!("../README.md")]
 
 pub mod auth;
 pub mod cancel;


### PR DESCRIPTION
## Summary

- use the repository README as the crate-level Rustdoc landing page
- license both published crates and the repository under MIT
- add author, discovery, MSRV, README, and package metadata
- pin the development and CI toolchain while testing the verified Rust 1.88 MSRV
- add contribution, conduct, security, ownership, and issue/PR guidance
- add Dependabot, cargo-deny, packaging, MSRV, documentation, compatibility, benchmark, and fuzz checks
- configure structured release-plz changelog groups
- record every completed housekeeping item in `PLAN.md`

Repository settings configured alongside this PR:

- description, docs.rs homepage, and topics
- Dependabot vulnerability alerts and security updates
- private vulnerability reporting
- protected `main` requiring pull requests, linear history, resolved conversations, and all substantive CI checks

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- `cargo +1.88.0 check --workspace --all-targets`
- `cargo package --workspace`
- `cargo deny check`
