### PR TITLE
feat: add checked stateful message middleware

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -244,6 +244,52 @@ neutral composition harnesses and examples.
 - [x] Extend differential testing from canonical runtime events to codec-message
   projections and handwritten sessions.
 
+## Stateful message middleware
+
+- [ ] Move the examples' protocol observation and rewriting mechanism into a
+  policy-neutral core `middleware` module.
+  - [ ] Define direction-specific middleware for owned `FrontendMessage` and
+    `BackendMessage` values. Returning the input value is the no-op; middleware
+    may mutate it or replace it with another message of the same direction.
+  - [ ] Pass caller-owned mutable state through every invocation, with accessors
+    to borrow or recover that state for statistics and other accumulated policy.
+  - [ ] Provide closure adapters and an identity middleware so simple observers
+    do not require bespoke wrapper types.
+  - [ ] Compose middleware in deterministic order, feeding each stage's output
+    into the next stage and stopping at the first error.
+- [ ] Integrate middleware at state-aware protocol boundaries after decoding and
+  before projection, demultiplexing, or typestate advancement.
+  - [ ] Validate every replacement with the generated state-aware message
+    projection for the current authentication, query, COPY, replication, or
+    error-recovery state.
+  - [ ] Return rejected replacements without advancing either protocol session;
+    preserve the original APIs as no-middleware compatibility paths.
+  - [ ] Apply backend middleware before `Demux` so asynchronous messages are
+    interceptable and rewritten parameter, cancellation, and transaction state
+    is recorded consistently.
+  - [ ] Cover untagged pre-startup packets with a separate typed hook; keep raw
+    TLS/GSS decision bytes outside message middleware unless they gain a typed
+    protocol representation.
+- [ ] Refactor the proxy examples onto the core abstraction.
+  - [ ] Express protocol logging, SQL extraction, and row statistics as separate
+    composable middleware while retaining connection-local user state.
+  - [ ] Update the rewriting example and crate documentation to demonstrate
+    no-op, mutation, replacement, state accumulation, and chaining.
+  - [ ] Retain `Intermediary::inspect` only as a low-level escape hatch, clearly
+    distinguishing it from checked state-aware middleware.
+- [ ] Verify the abstraction at unit, state-machine, and network boundaries.
+  - [ ] Test no-op identity, mutation, replacement, state access, ordering,
+    composition, and error short-circuiting.
+  - [ ] Reject messages illegal in authentication, extended-query recovery,
+    COPY, replication, and pre-startup states.
+  - [ ] Confirm rewritten messages reach the peer and backend rewrites update
+    demultiplexer bookkeeping without changing wire order.
+
+The intended lifecycle is `decode -> middleware chain -> state validation ->
+projection/demux -> encode/forward`. Generic `Buffered::receive_wire` remains a
+codec boundary because it knows direction but not the current protocol state;
+checked middleware belongs on the state-aware session APIs above it.
+
 ## Optional future work
 
 - [x] Add optional operation-bounded intermediary pipeline orchestration with

--- a/PLAN.md
+++ b/PLAN.md
@@ -246,7 +246,7 @@ neutral composition harnesses and examples.
 
 ## Stateful message middleware
 
-- [ ] Move the examples' protocol observation and rewriting mechanism into a
+- [x] Move the examples' protocol observation and rewriting mechanism into a
   policy-neutral core `middleware` module.
   - [x] Define direction-specific middleware for owned `FrontendMessage` and
     `BackendMessage` values. Returning the input value is the no-op; middleware
@@ -257,32 +257,32 @@ neutral composition harnesses and examples.
     do not require bespoke wrapper types.
   - [x] Compose middleware in deterministic order, feeding each stage's output
     into the next stage and stopping at the first error.
-- [ ] Integrate middleware at state-aware protocol boundaries after decoding and
+- [x] Integrate middleware at state-aware protocol boundaries after decoding and
   before projection, demultiplexing, or typestate advancement.
-  - [ ] Validate every replacement with the generated state-aware message
+  - [x] Validate every replacement with the generated state-aware message
     projection for the current authentication, query, COPY, replication, or
     error-recovery state.
-  - [ ] Return rejected replacements without advancing either protocol session;
+  - [x] Return rejected replacements without advancing either protocol session;
     preserve the original APIs as no-middleware compatibility paths.
-  - [ ] Apply backend middleware before `Demux` so asynchronous messages are
+  - [x] Apply backend middleware before `Demux` so asynchronous messages are
     interceptable and rewritten parameter, cancellation, and transaction state
     is recorded consistently.
-  - [ ] Cover untagged pre-startup packets with a separate typed hook; keep raw
+  - [x] Cover untagged pre-startup packets with a separate typed hook; keep raw
     TLS/GSS decision bytes outside message middleware unless they gain a typed
     protocol representation.
-- [ ] Refactor the proxy examples onto the core abstraction.
-  - [ ] Express protocol logging, SQL extraction, and row statistics as separate
+- [x] Refactor the proxy examples onto the core abstraction.
+  - [x] Express protocol logging, SQL extraction, and row statistics as separate
     composable middleware while retaining connection-local user state.
-  - [ ] Update the rewriting example and crate documentation to demonstrate
+  - [x] Update the rewriting example and crate documentation to demonstrate
     no-op, mutation, replacement, state accumulation, and chaining.
-  - [ ] Retain `Intermediary::inspect` only as a low-level escape hatch, clearly
+  - [x] Retain `Intermediary::inspect` only as a low-level escape hatch, clearly
     distinguishing it from checked state-aware middleware.
-- [ ] Verify the abstraction at unit, state-machine, and network boundaries.
+- [x] Verify the abstraction at unit, state-machine, and network boundaries.
   - [x] Test no-op identity, mutation, replacement, state access, ordering,
     composition, and error short-circuiting.
-  - [ ] Reject messages illegal in authentication, extended-query recovery,
+  - [x] Reject messages illegal in authentication, extended-query recovery,
     COPY, replication, and pre-startup states.
-  - [ ] Confirm rewritten messages reach the peer and backend rewrites update
+  - [x] Confirm rewritten messages reach the peer and backend rewrites update
     demultiplexer bookkeeping without changing wire order.
 
 The intended lifecycle is `decode -> middleware chain -> state validation ->

--- a/PLAN.md
+++ b/PLAN.md
@@ -248,14 +248,14 @@ neutral composition harnesses and examples.
 
 - [ ] Move the examples' protocol observation and rewriting mechanism into a
   policy-neutral core `middleware` module.
-  - [ ] Define direction-specific middleware for owned `FrontendMessage` and
+  - [x] Define direction-specific middleware for owned `FrontendMessage` and
     `BackendMessage` values. Returning the input value is the no-op; middleware
     may mutate it or replace it with another message of the same direction.
-  - [ ] Pass caller-owned mutable state through every invocation, with accessors
+  - [x] Pass caller-owned mutable state through every invocation, with accessors
     to borrow or recover that state for statistics and other accumulated policy.
-  - [ ] Provide closure adapters and an identity middleware so simple observers
+  - [x] Provide closure adapters and an identity middleware so simple observers
     do not require bespoke wrapper types.
-  - [ ] Compose middleware in deterministic order, feeding each stage's output
+  - [x] Compose middleware in deterministic order, feeding each stage's output
     into the next stage and stopping at the first error.
 - [ ] Integrate middleware at state-aware protocol boundaries after decoding and
   before projection, demultiplexing, or typestate advancement.
@@ -278,7 +278,7 @@ neutral composition harnesses and examples.
   - [ ] Retain `Intermediary::inspect` only as a low-level escape hatch, clearly
     distinguishing it from checked state-aware middleware.
 - [ ] Verify the abstraction at unit, state-machine, and network boundaries.
-  - [ ] Test no-op identity, mutation, replacement, state access, ordering,
+  - [x] Test no-op identity, mutation, replacement, state access, ordering,
     composition, and error short-circuiting.
   - [ ] Reject messages illegal in authentication, extended-query recovery,
     COPY, replication, and pre-startup states.

--- a/README.md
+++ b/README.md
@@ -100,19 +100,38 @@ let ready = building.sync().ready();
 let _terminated = ready.terminate();
 ```
 
-A proxy can inspect or replace a typed message before reconstructing its checked
-wire frame:
+## Stateful message middleware
+
+A proxy can inspect or replace any owned frontend, backend, or pre-startup
+message before reconstructing its checked wire representation. Middleware has
+mutable access to a caller-defined state value, so statistics and other
+connection-local policy do not require global storage. Returning the message
+unchanged is the identity operation.
+
+`intercept_checked` validates the final replacement against a generated runtime
+protocol state and verifies that it can be encoded. Illegal replacements are
+returned without advancing the session. `MessageMiddlewareExt::then` chains
+stages in order, passing each replacement to the next stage and stopping at the
+first error.
 
 ```rust
-use std::convert::Infallible;
-
 use bytes::Bytes;
 use pg_proto::{
     codec::{FrontendMessage, Parse},
-    intermediary::Intermediary,
+    grammar::backend,
+    middleware::Middleware,
 };
 
-let mut proxy = Intermediary::new((), ());
+let mut proxy = Middleware::new(0_usize, |rewrites: &mut usize, message| {
+    let FrontendMessage::Parse(mut parse) = message else {
+        return Ok::<_, std::convert::Infallible>(message);
+    };
+    *rewrites += 1;
+    parse.query = Bytes::from_static(
+        b"select decrypt_email(email) from customers where active",
+    );
+    Ok(FrontendMessage::Parse(parse))
+});
 let message = FrontendMessage::Parse(Parse {
     statement: Bytes::from_static(b"report"),
     query: Bytes::from_static(b"select email from customers"),
@@ -120,20 +139,21 @@ let message = FrontendMessage::Parse(Parse {
 });
 
 let rewritten = proxy
-    .inspect(message, |(), (), message| {
-        let FrontendMessage::Parse(mut parse) = message else {
-            unreachable!("the caller selected a Parse message")
-        };
-        parse.query = Bytes::from_static(
-            b"select decrypt_email(email) from customers where active",
-        );
-        Ok::<_, Infallible>(FrontendMessage::Parse(parse))
-    })
+    .intercept_checked(&backend::RuntimeState::Ready, message)
     .unwrap();
 
 let frame = rewritten.to_frame()?;
+assert_eq!(*proxy.state(), 1);
 # Ok::<(), std::io::Error>(())
 ```
+
+The buffered connection helpers
+`receive_frontend_wire_with_middleware`,
+`receive_backend_wire_with_middleware`, and
+`receive_pre_startup_wire_with_middleware` apply this lifecycle directly after
+decoding. `receive_with_middleware` additionally places backend interception
+before asynchronous-message demultiplexing, ensuring rewritten parameter,
+cancellation-key, and transaction-status values become the recorded values.
 
 For a complete networked example, see the TLS-terminating
 [`SQL logging proxy`](examples/sql_logging_proxy/README.md). The companion
@@ -153,6 +173,7 @@ proxy composition boundary.
 - [Client-role query sessions](https://docs.rs/pg-proto/latest/pg_proto/session/)
 - [Server-role query sessions](https://docs.rs/pg-proto/latest/pg_proto/server_session/)
 - [Proxy-side composition hooks](https://docs.rs/pg-proto/latest/pg_proto/intermediary/)
+- [Stateful message middleware](https://docs.rs/pg-proto/latest/pg_proto/middleware/)
 - [Bounded intermediary pipeline](https://docs.rs/pg-proto/latest/pg_proto/pipeline/)
 - [Prepared-statement and portal resources](https://docs.rs/pg-proto/latest/pg_proto/resources/)
 - [Generated protocol grammars and railroad diagrams](https://docs.rs/pg-proto/latest/pg_proto/grammar/)

--- a/examples/protocol_logging_proxy/README.md
+++ b/examples/protocol_logging_proxy/README.md
@@ -3,6 +3,8 @@
 This companion example forwards the same traffic while printing every decoded
 pre-startup, frontend, and backend message with its direction and connection
 number. `PasswordResponse` uses pg-proto's redacted `Debug` implementation.
+Logging is implemented as a core message-middleware stage and composed with the
+SQL and row-statistics stages used by the companion example.
 
 Run without arguments to start and retain a PostgreSQL 18 test container loaded
 with the customer/orders fixture:

--- a/examples/proxy_support/mod.rs
+++ b/examples/proxy_support/mod.rs
@@ -42,10 +42,11 @@ pub enum Observation {
 
 pub type Reporter = Arc<dyn Fn(Observation) + Send + Sync>;
 
-#[derive(Debug)]
 struct ExampleState {
     connection: u64,
     rows: usize,
+    reporter: Reporter,
+    pre_startup_direction: &'static str,
 }
 
 #[derive(Clone)]
@@ -65,6 +66,8 @@ fn middleware(connection: u64, reporter: Reporter) -> ExampleMiddleware {
         ExampleState {
             connection,
             rows: 0,
+            reporter: Arc::clone(&reporter),
+            pre_startup_direction: "client -> server",
         },
         ProtocolLogger(Arc::clone(&reporter))
             .then(SqlLogger(Arc::clone(&reporter)))
@@ -98,7 +101,7 @@ impl MessageMiddleware<PreStartupMessage, ExampleState> for ProtocolLogger {
     ) -> Result<PreStartupMessage, Self::Error> {
         (self.0)(Observation::Protocol {
             connection: state.connection,
-            direction: "client -> server",
+            direction: state.pre_startup_direction,
             message: format!("{message:?}"),
         });
         Ok(message)
@@ -309,12 +312,22 @@ async fn proxy_connection(
             PreStartupOffer::Ssl(decision) => {
                 let mut handshake = decision.approve_ssl();
                 handshake.flush().await?;
+                (middleware.state().reporter)(Observation::Protocol {
+                    connection: middleware.state().connection,
+                    direction: "server -> client",
+                    message: "SslAccepted".to_owned(),
+                });
                 let encrypted = handshake.accept_tls(tls.config, tls.certificate).await?;
                 return encrypted_startup(encrypted, upstream, middleware).await;
             }
             PreStartupOffer::Gss(decision) => {
                 pre_startup = decision.decline_gss();
                 pre_startup.flush().await?;
+                (middleware.state().reporter)(Observation::Protocol {
+                    connection: middleware.state().connection,
+                    direction: "server -> client",
+                    message: "GssEncryptionRejected".to_owned(),
+                });
             }
             PreStartupOffer::Cancel {
                 conn,
@@ -343,6 +356,7 @@ async fn encrypted_startup(
     upstream: SocketAddr,
     mut middleware: ExampleMiddleware,
 ) -> io::Result<()> {
+    middleware.state_mut().pre_startup_direction = "client -> server (TLS plaintext)";
     let message = middleware
         .intercept(pre_startup.receive_pre_startup_wire().await?)
         .expect("example middleware is infallible");

--- a/examples/proxy_support/mod.rs
+++ b/examples/proxy_support/mod.rs
@@ -1,8 +1,9 @@
-use std::{error::Error, io, net::SocketAddr, sync::Arc};
+use std::{convert::Infallible, error::Error, io, net::SocketAddr, sync::Arc};
 
 use pg_proto::{
     Conn,
     codec::{Backend, BackendMessage, Frontend, FrontendMessage},
+    middleware::{MessageMiddleware, MessageMiddlewareExt as _, Middleware, Then},
     pre_startup::{PreStartup, PreStartupMessage, PreStartupOffer, Startup},
     tls::ServerTls,
     transport::Buffered,
@@ -39,7 +40,158 @@ pub enum Observation {
     },
 }
 
-pub type Observer = Arc<dyn Fn(Observation) + Send + Sync>;
+pub type Reporter = Arc<dyn Fn(Observation) + Send + Sync>;
+
+#[derive(Debug)]
+struct ExampleState {
+    connection: u64,
+    rows: usize,
+}
+
+#[derive(Clone)]
+struct ProtocolLogger(Reporter);
+
+#[derive(Clone)]
+struct SqlLogger(Reporter);
+
+#[derive(Clone)]
+struct RowStatistics(Reporter);
+
+type ExampleHandler = Then<Then<ProtocolLogger, SqlLogger>, RowStatistics>;
+type ExampleMiddleware = Middleware<ExampleState, ExampleHandler>;
+
+fn middleware(connection: u64, reporter: Reporter) -> ExampleMiddleware {
+    Middleware::new(
+        ExampleState {
+            connection,
+            rows: 0,
+        },
+        ProtocolLogger(Arc::clone(&reporter))
+            .then(SqlLogger(Arc::clone(&reporter)))
+            .then(RowStatistics(reporter)),
+    )
+}
+
+macro_rules! pass_through {
+    ($handler:ty, $message:ty) => {
+        impl MessageMiddleware<$message, ExampleState> for $handler {
+            type Error = Infallible;
+
+            fn intercept(
+                &mut self,
+                _state: &mut ExampleState,
+                message: $message,
+            ) -> Result<$message, Self::Error> {
+                Ok(message)
+            }
+        }
+    };
+}
+
+impl MessageMiddleware<PreStartupMessage, ExampleState> for ProtocolLogger {
+    type Error = Infallible;
+
+    fn intercept(
+        &mut self,
+        state: &mut ExampleState,
+        message: PreStartupMessage,
+    ) -> Result<PreStartupMessage, Self::Error> {
+        (self.0)(Observation::Protocol {
+            connection: state.connection,
+            direction: "client -> server",
+            message: format!("{message:?}"),
+        });
+        Ok(message)
+    }
+}
+
+impl MessageMiddleware<FrontendMessage, ExampleState> for ProtocolLogger {
+    type Error = Infallible;
+
+    fn intercept(
+        &mut self,
+        state: &mut ExampleState,
+        message: FrontendMessage,
+    ) -> Result<FrontendMessage, Self::Error> {
+        (self.0)(Observation::Protocol {
+            connection: state.connection,
+            direction: "client -> server",
+            message: format!("{message:?}"),
+        });
+        Ok(message)
+    }
+}
+
+impl MessageMiddleware<BackendMessage, ExampleState> for ProtocolLogger {
+    type Error = Infallible;
+
+    fn intercept(
+        &mut self,
+        state: &mut ExampleState,
+        message: BackendMessage,
+    ) -> Result<BackendMessage, Self::Error> {
+        (self.0)(Observation::Protocol {
+            connection: state.connection,
+            direction: "server -> client",
+            message: format!("{message:?}"),
+        });
+        Ok(message)
+    }
+}
+
+pass_through!(SqlLogger, PreStartupMessage);
+pass_through!(SqlLogger, BackendMessage);
+
+impl MessageMiddleware<FrontendMessage, ExampleState> for SqlLogger {
+    type Error = Infallible;
+
+    fn intercept(
+        &mut self,
+        state: &mut ExampleState,
+        message: FrontendMessage,
+    ) -> Result<FrontendMessage, Self::Error> {
+        let statement = match &message {
+            FrontendMessage::Query(sql) => Some(sql),
+            FrontendMessage::Parse(parse) => Some(&parse.query),
+            _ => None,
+        };
+        if let Some(statement) = statement {
+            (self.0)(Observation::Sql {
+                connection: state.connection,
+                statement: String::from_utf8_lossy(statement).into_owned(),
+            });
+        }
+        Ok(message)
+    }
+}
+
+pass_through!(RowStatistics, PreStartupMessage);
+pass_through!(RowStatistics, FrontendMessage);
+
+impl MessageMiddleware<BackendMessage, ExampleState> for RowStatistics {
+    type Error = Infallible;
+
+    fn intercept(
+        &mut self,
+        state: &mut ExampleState,
+        message: BackendMessage,
+    ) -> Result<BackendMessage, Self::Error> {
+        match &message {
+            BackendMessage::DataRow(_) => state.rows = state.rows.saturating_add(1),
+            BackendMessage::CommandComplete(tag) => {
+                (self.0)(Observation::RowCount {
+                    connection: state.connection,
+                    rows: state.rows,
+                    command: String::from_utf8_lossy(tag).into_owned(),
+                });
+                state.rows = 0;
+            }
+            BackendMessage::ErrorResponse(_) => state.rows = 0,
+            _ => {}
+        }
+        Ok(message)
+    }
+}
 
 #[derive(Clone)]
 pub struct ExampleTlsIdentity {
@@ -125,18 +277,17 @@ pub async fn serve(
     listener: TcpListener,
     upstream: SocketAddr,
     tls: ExampleTlsIdentity,
-    observer: Observer,
+    reporter: Reporter,
 ) -> io::Result<()> {
     let mut next_connection = 1_u64;
     loop {
         let (client, _) = listener.accept().await?;
         let connection = next_connection;
         next_connection = next_connection.wrapping_add(1);
-        let observer = Arc::clone(&observer);
+        let middleware = middleware(connection, Arc::clone(&reporter));
         let tls = tls.clone();
         tokio::spawn(async move {
-            if let Err(error) = proxy_connection(client, upstream, tls, connection, observer).await
-            {
+            if let Err(error) = proxy_connection(client, upstream, tls, middleware).await {
                 eprintln!("connection {connection}: {error}");
             }
         });
@@ -147,37 +298,23 @@ async fn proxy_connection(
     client: TcpStream,
     upstream: SocketAddr,
     tls: ExampleTlsIdentity,
-    connection: u64,
-    observer: Observer,
+    mut middleware: ExampleMiddleware,
 ) -> io::Result<()> {
     let mut pre_startup = Conn::new(Buffered::new_frontend(client));
     loop {
-        let message = pre_startup.receive_pre_startup_wire().await?;
-        observer(Observation::Protocol {
-            connection,
-            direction: "client -> server",
-            message: format!("{message:?}"),
-        });
+        let message = middleware
+            .intercept(pre_startup.receive_pre_startup_wire().await?)
+            .expect("example middleware is infallible");
         match pre_startup.offer_pre_startup(message) {
             PreStartupOffer::Ssl(decision) => {
                 let mut handshake = decision.approve_ssl();
                 handshake.flush().await?;
-                observer(Observation::Protocol {
-                    connection,
-                    direction: "server -> client",
-                    message: "SslAccepted".to_owned(),
-                });
                 let encrypted = handshake.accept_tls(tls.config, tls.certificate).await?;
-                return encrypted_startup(encrypted, upstream, connection, observer).await;
+                return encrypted_startup(encrypted, upstream, middleware).await;
             }
             PreStartupOffer::Gss(decision) => {
                 pre_startup = decision.decline_gss();
                 pre_startup.flush().await?;
-                observer(Observation::Protocol {
-                    connection,
-                    direction: "server -> client",
-                    message: "GssEncryptionRejected".to_owned(),
-                });
             }
             PreStartupOffer::Cancel {
                 conn,
@@ -195,7 +332,7 @@ async fn proxy_connection(
                 .await;
             }
             PreStartupOffer::Startup { conn, message } => {
-                return begin_forwarding(conn, message, upstream, connection, observer).await;
+                return begin_forwarding(conn, message, upstream, middleware).await;
             }
         }
     }
@@ -204,18 +341,14 @@ async fn proxy_connection(
 async fn encrypted_startup(
     mut pre_startup: Conn<Buffered<ServerTls<TcpStream>, Frontend>, PreStartup>,
     upstream: SocketAddr,
-    connection: u64,
-    observer: Observer,
+    mut middleware: ExampleMiddleware,
 ) -> io::Result<()> {
-    let message = pre_startup.receive_pre_startup_wire().await?;
-    observer(Observation::Protocol {
-        connection,
-        direction: "client -> server (TLS plaintext)",
-        message: format!("{message:?}"),
-    });
+    let message = middleware
+        .intercept(pre_startup.receive_pre_startup_wire().await?)
+        .expect("example middleware is infallible");
     match pre_startup.offer_pre_startup(message) {
         PreStartupOffer::Startup { conn, message } => {
-            begin_forwarding(conn, message, upstream, connection, observer).await
+            begin_forwarding(conn, message, upstream, middleware).await
         }
         PreStartupOffer::Cancel {
             conn,
@@ -257,8 +390,7 @@ async fn begin_forwarding<S>(
     conn: Conn<Buffered<S, Frontend>, Startup>,
     message: pg_proto::startup::StartupMessage,
     upstream: SocketAddr,
-    connection: u64,
-    observer: Observer,
+    middleware: ExampleMiddleware,
 ) -> io::Result<()>
 where
     S: AsyncRead + AsyncWrite + Unpin,
@@ -268,42 +400,25 @@ where
     server
         .write_all(&PreStartupMessage::Startup(message).to_packet()?)
         .await?;
-    forward_tagged(client, server, connection, observer).await
+    forward_tagged(client, server, middleware).await
 }
 
 async fn forward_tagged<S>(
     client: S,
     server: TcpStream,
-    connection: u64,
-    observer: Observer,
+    mut middleware: ExampleMiddleware,
 ) -> io::Result<()>
 where
     S: AsyncRead + AsyncWrite + Unpin,
 {
     let mut downstream: Buffered<_, Frontend> = Buffered::new_frontend(client);
     let mut upstream: Buffered<_, Backend> = Buffered::new(server);
-    let mut rows = 0_usize;
-
     loop {
         tokio::select! {
             frontend = downstream.receive_wire() => {
-                let frontend = frontend?;
-                observer(Observation::Protocol {
-                    connection,
-                    direction: "client -> server",
-                    message: format!("{frontend:?}"),
-                });
-                match &frontend {
-                    FrontendMessage::Query(sql) => observer(Observation::Sql {
-                        connection,
-                        statement: String::from_utf8_lossy(sql).into_owned(),
-                    }),
-                    FrontendMessage::Parse(parse) => observer(Observation::Sql {
-                        connection,
-                        statement: String::from_utf8_lossy(&parse.query).into_owned(),
-                    }),
-                    _ => {}
-                }
+                let frontend = middleware
+                    .intercept(frontend?)
+                    .expect("example middleware is infallible");
                 let terminate = matches!(frontend, FrontendMessage::Terminate);
                 upstream.push(frontend.to_frame()?)?;
                 upstream.flush().await?;
@@ -312,25 +427,9 @@ where
                 }
             }
             backend = upstream.receive_wire() => {
-                let backend = backend?;
-                observer(Observation::Protocol {
-                    connection,
-                    direction: "server -> client",
-                    message: format!("{backend:?}"),
-                });
-                match &backend {
-                    BackendMessage::DataRow(_) => rows = rows.saturating_add(1),
-                    BackendMessage::CommandComplete(tag) => {
-                        observer(Observation::RowCount {
-                            connection,
-                            rows,
-                            command: String::from_utf8_lossy(tag).into_owned(),
-                        });
-                        rows = 0;
-                    }
-                    BackendMessage::ErrorResponse(_) => rows = 0,
-                    _ => {}
-                }
+                let backend = middleware
+                    .intercept(backend?)
+                    .expect("example middleware is infallible");
                 downstream.push(backend.to_frame()?)?;
                 downstream.flush().await?;
             }

--- a/examples/rewriting_intermediary.rs
+++ b/examples/rewriting_intermediary.rs
@@ -1,4 +1,4 @@
-//! A policy-neutral example of typed message inspection and replacement.
+//! Stateful, checked frontend and backend message rewriting.
 
 use std::convert::Infallible;
 
@@ -8,27 +8,68 @@ use pg_proto::{
         BackendMessage, Bind, Describe, DescribeTarget, FieldDescription, FrontendMessage, Parse,
         RowDescription,
     },
-    intermediary::Intermediary,
+    grammar::{backend, frontend},
+    middleware::{MessageMiddleware, Middleware},
 };
 
+#[derive(Default)]
+struct RewriteStatistics {
+    frontend: usize,
+    backend: usize,
+}
+
+struct Rewriter;
+
+impl MessageMiddleware<FrontendMessage, RewriteStatistics> for Rewriter {
+    type Error = Infallible;
+
+    fn intercept(
+        &mut self,
+        statistics: &mut RewriteStatistics,
+        message: FrontendMessage,
+    ) -> Result<FrontendMessage, Self::Error> {
+        statistics.frontend += 1;
+        Ok(match message {
+            FrontendMessage::Parse(mut parse) => {
+                parse.query = Bytes::from_static(
+                    b"select amount from ledger where account = $1 and visible = true",
+                );
+                FrontendMessage::Parse(parse)
+            }
+            message => message,
+        })
+    }
+}
+
+impl MessageMiddleware<BackendMessage, RewriteStatistics> for Rewriter {
+    type Error = Infallible;
+
+    fn intercept(
+        &mut self,
+        statistics: &mut RewriteStatistics,
+        message: BackendMessage,
+    ) -> Result<BackendMessage, Self::Error> {
+        statistics.backend += 1;
+        Ok(match message {
+            BackendMessage::RowDescription(mut rows) => {
+                rows.fields[0].name = Bytes::from_static(b"visible_amount");
+                BackendMessage::RowDescription(rows)
+            }
+            message => message,
+        })
+    }
+}
+
 fn main() {
-    let mut intermediary = Intermediary::new((), ());
+    let mut middleware = Middleware::new(RewriteStatistics::default(), Rewriter);
 
     let parse = FrontendMessage::Parse(Parse {
         statement: Bytes::from_static(b"report"),
         query: Bytes::from_static(b"select amount from ledger where account = $1"),
         parameter_types: vec![25],
     });
-    let parse = intermediary
-        .inspect(parse, |(), (), message| {
-            let FrontendMessage::Parse(mut parse) = message else {
-                unreachable!("the caller selected a Parse message")
-            };
-            parse.query = Bytes::from_static(
-                b"select amount from ledger where account = $1 and visible = true",
-            );
-            Ok::<_, Infallible>(FrontendMessage::Parse(parse))
-        })
+    let parse = middleware
+        .intercept_checked(&backend::RuntimeState::Ready, parse)
         .unwrap();
 
     let bind = FrontendMessage::Bind(Bind {
@@ -38,16 +79,16 @@ fn main() {
         parameters: vec![Some(Bytes::from_static(b"assets"))],
         result_formats: vec![1],
     });
-    let bind = intermediary
-        .inspect(bind, |(), (), message| Ok::<_, Infallible>(message))
+    let bind = middleware
+        .intercept_checked(&backend::RuntimeState::Building, bind)
         .unwrap();
 
     let describe = FrontendMessage::Describe(Describe {
         target: DescribeTarget::Portal,
         name: Bytes::from_static(b"page-1"),
     });
-    let describe = intermediary
-        .inspect(describe, |(), (), message| Ok::<_, Infallible>(message))
+    let describe = middleware
+        .intercept_checked(&backend::RuntimeState::Building, describe)
         .unwrap();
 
     let rows = BackendMessage::RowDescription(RowDescription {
@@ -61,14 +102,8 @@ fn main() {
             format: 1,
         }],
     });
-    let rows = intermediary
-        .inspect(rows, |(), (), message| {
-            let BackendMessage::RowDescription(mut rows) = message else {
-                unreachable!("the caller selected a RowDescription message")
-            };
-            rows.fields[0].name = Bytes::from_static(b"visible_amount");
-            Ok::<_, Infallible>(BackendMessage::RowDescription(rows))
-        })
+    let rows = middleware
+        .intercept_checked(&frontend::RuntimeState::Simple, rows)
         .unwrap();
 
     // Every modified value remains reconstructable as a checked wire frame.
@@ -76,4 +111,6 @@ fn main() {
     bind.to_frame().unwrap();
     describe.to_frame().unwrap();
     rows.to_frame().unwrap();
+    assert_eq!(middleware.state().frontend, 3);
+    assert_eq!(middleware.state().backend, 1);
 }

--- a/examples/sql_logging_proxy/README.md
+++ b/examples/sql_logging_proxy/README.md
@@ -5,6 +5,10 @@ direction-parameterised codecs. It prints every inbound simple-query `Query`
 and extended-query `Parse` statement, then prints the number of `DataRow`
 messages in each result when `CommandComplete` arrives.
 
+Protocol logging, SQL extraction, and row counting are independent core
+middleware stages chained in deterministic order. Their shared per-connection
+state carries the connection number and accumulated row count.
+
 The example forwards authentication and all tagged protocol messages without
 changing them. It terminates client TLS using pg-proto's typed pre-startup
 transport transition, then inspects and forwards the decrypted messages. The

--- a/src/intermediary.rs
+++ b/src/intermediary.rs
@@ -169,6 +169,9 @@ impl<Downstream, Upstream, Policy: PipelinePolicy> Intermediary<Downstream, Upst
     ///
     /// The message and result types are chosen by downstream code; `pg-proto`
     /// neither prescribes a rewrite policy nor advances either session implicitly.
+    /// This is a low-level escape hatch: prefer
+    /// [`crate::middleware::Middleware::intercept_checked`] when rewriting wire
+    /// messages so replacements are checked against the current protocol state.
     ///
     /// # Errors
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod erased;
 pub mod grammar;
 pub mod integrations;
 pub mod intermediary;
+pub mod middleware;
 pub mod net;
 pub mod pipeline;
 pub mod pre_startup;

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -6,7 +6,121 @@
 //! session APIs remain responsible for checking that the result is legal in their
 //! current state before advancing.
 
-use std::convert::Infallible;
+use std::{convert::Infallible, io};
+
+use crate::{
+    codec::{BackendMessage, FrontendMessage},
+    demux::Demux,
+    grammar::{
+        authentication, backend, frontend, pre_startup, server_authentication, server_pre_startup,
+    },
+    pre_startup::{EncryptionReply, PreStartupMessage},
+};
+
+/// State-aware validation of one directional protocol message type.
+pub trait AcceptsMessage<Message> {
+    /// Reports whether `message` is legal without advancing this state.
+    fn accepts(&self, message: &Message) -> bool;
+}
+
+/// A protocol message which can verify that it has a valid wire representation.
+pub trait ReconstructableMessage {
+    /// Reports whether this typed value can be encoded on the wire.
+    fn is_reconstructable(&self) -> bool;
+}
+
+impl ReconstructableMessage for FrontendMessage {
+    fn is_reconstructable(&self) -> bool {
+        self.to_frame().is_ok()
+    }
+}
+
+impl ReconstructableMessage for BackendMessage {
+    fn is_reconstructable(&self) -> bool {
+        self.to_frame().is_ok()
+    }
+}
+
+impl ReconstructableMessage for PreStartupMessage {
+    fn is_reconstructable(&self) -> bool {
+        self.to_packet().is_ok()
+    }
+}
+
+impl ReconstructableMessage for EncryptionReply {
+    fn is_reconstructable(&self) -> bool {
+        true
+    }
+}
+
+macro_rules! projected_messages {
+    ($state:path, $internal:ty, $external:ty, $project_internal:path, $project_external:path) => {
+        impl AcceptsMessage<$internal> for $state {
+            fn accepts(&self, message: &$internal) -> bool {
+                $project_internal(*self, message).is_some()
+            }
+        }
+
+        impl AcceptsMessage<$external> for $state {
+            fn accepts(&self, message: &$external) -> bool {
+                $project_external(*self, message).is_some()
+            }
+        }
+    };
+}
+
+projected_messages!(
+    pre_startup::RuntimeState,
+    PreStartupMessage,
+    EncryptionReply,
+    pre_startup::project_internal,
+    pre_startup::project_external
+);
+projected_messages!(
+    server_pre_startup::RuntimeState,
+    EncryptionReply,
+    PreStartupMessage,
+    server_pre_startup::project_internal,
+    server_pre_startup::project_external
+);
+projected_messages!(
+    authentication::RuntimeState,
+    FrontendMessage,
+    BackendMessage,
+    authentication::project_internal,
+    authentication::project_external
+);
+projected_messages!(
+    server_authentication::RuntimeState,
+    BackendMessage,
+    FrontendMessage,
+    server_authentication::project_internal,
+    server_authentication::project_external
+);
+
+impl AcceptsMessage<FrontendMessage> for frontend::RuntimeState {
+    fn accepts(&self, message: &FrontendMessage) -> bool {
+        frontend::project_internal(*self, message).is_some()
+    }
+}
+
+impl AcceptsMessage<BackendMessage> for frontend::RuntimeState {
+    fn accepts(&self, message: &BackendMessage) -> bool {
+        Demux::is_asynchronous(message) || frontend::project_external(*self, message).is_some()
+    }
+}
+
+impl AcceptsMessage<BackendMessage> for backend::RuntimeState {
+    fn accepts(&self, message: &BackendMessage) -> bool {
+        Demux::is_asynchronous(message) || backend::project_internal(*self, message).is_some()
+    }
+}
+
+impl AcceptsMessage<FrontendMessage> for backend::RuntimeState {
+    fn accepts(&self, message: &FrontendMessage) -> bool {
+        backend::project_external(*self, message).is_some()
+    }
+}
 
 /// Intercepts an owned message with access to caller-defined state.
 ///
@@ -96,6 +210,24 @@ pub enum ChainError<First, Second> {
     Second(Second),
 }
 
+/// Failure while applying or validating middleware output.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum InterceptError<Error, Message> {
+    /// Middleware rejected the message according to its own policy.
+    Middleware(Error),
+    /// Middleware returned a message which is illegal in the supplied state.
+    Invalid(Message),
+}
+
+/// I/O or interception failure while receiving a middleware-checked message.
+#[derive(Debug)]
+pub enum ReceiveError<Error, Message> {
+    /// Reading or decoding the message failed.
+    Io(io::Error),
+    /// Middleware rejected the message or produced an illegal replacement.
+    Intercept(InterceptError<Error, Message>),
+}
+
 /// Owns user state and middleware as one reusable interception unit.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct Middleware<State, Handler> {
@@ -145,11 +277,52 @@ impl<State, Handler> Middleware<State, Handler> {
     {
         self.handler.intercept(&mut self.state, message)
     }
+
+    /// Intercepts a message and checks the result against `protocol_state`.
+    ///
+    /// Validation happens after the complete middleware chain, immediately
+    /// before a caller projects and advances its protocol state.
+    ///
+    /// # Errors
+    ///
+    /// Returns a middleware policy error, or the unchanged replacement when it
+    /// is not legal in `protocol_state`.
+    pub fn intercept_checked<Message, ProtocolState>(
+        &mut self,
+        protocol_state: &ProtocolState,
+        message: Message,
+    ) -> Result<Message, InterceptError<Handler::Error, Message>>
+    where
+        Message: ReconstructableMessage,
+        Handler: MessageMiddleware<Message, State>,
+        ProtocolState: AcceptsMessage<Message>,
+    {
+        let message = self
+            .intercept(message)
+            .map_err(InterceptError::Middleware)?;
+        if message.is_reconstructable() && protocol_state.accepts(&message) {
+            Ok(message)
+        } else {
+            Err(InterceptError::Invalid(message))
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{ChainError, Identity, MessageMiddlewareExt as _, Middleware};
+    use std::convert::Infallible;
+
+    use bytes::Bytes;
+
+    use super::{
+        AcceptsMessage as _, ChainError, Identity, InterceptError, MessageMiddlewareExt as _,
+        Middleware,
+    };
+    use crate::{
+        codec::{FrontendMessage, Parse},
+        grammar::{backend, server_authentication, server_pre_startup},
+        pre_startup::PreStartupMessage,
+    };
 
     #[test]
     fn identity_is_a_no_op() {
@@ -213,5 +386,98 @@ mod tests {
             Err(ChainError::First("rejected"))
         );
         assert_eq!(*middleware.state(), 1);
+    }
+
+    #[test]
+    fn checked_interception_accepts_a_legal_replacement() {
+        let mut middleware = Middleware::new((), |_state: &mut (), _message: FrontendMessage| {
+            Ok::<_, Infallible>(FrontendMessage::Terminate)
+        });
+
+        assert_eq!(
+            middleware.intercept_checked(
+                &backend::RuntimeState::Ready,
+                FrontendMessage::Query(Bytes::from_static(b"select 1")),
+            ),
+            Ok(FrontendMessage::Terminate)
+        );
+    }
+
+    #[test]
+    fn checked_interception_returns_an_illegal_replacement() {
+        let replacement = FrontendMessage::Parse(Parse {
+            statement: Bytes::new(),
+            query: Bytes::from_static(b"select 2"),
+            parameter_types: Vec::new(),
+        });
+        let expected = replacement.clone();
+        let mut middleware =
+            Middleware::new((), move |_state: &mut (), _message: FrontendMessage| {
+                Ok::<_, Infallible>(replacement.clone())
+            });
+
+        assert_eq!(
+            middleware.intercept_checked(
+                &backend::RuntimeState::Simple,
+                FrontendMessage::Query(Bytes::from_static(b"select 1")),
+            ),
+            Err(InterceptError::Invalid(expected))
+        );
+    }
+
+    #[test]
+    fn generated_states_cover_authentication_extended_query_copy_and_replication() {
+        let password = FrontendMessage::PasswordResponse(Bytes::from_static(b"secret"));
+        assert!(server_authentication::RuntimeState::PasswordResponse.accepts(&password));
+        assert!(
+            !server_authentication::RuntimeState::PasswordResponse
+                .accepts(&FrontendMessage::Query(Bytes::from_static(b"select 1")))
+        );
+
+        let parse = FrontendMessage::Parse(Parse {
+            statement: Bytes::from_static(b"statement"),
+            query: Bytes::from_static(b"select 1"),
+            parameter_types: Vec::new(),
+        });
+        assert!(backend::RuntimeState::Building.accepts(&parse));
+        assert!(
+            !backend::RuntimeState::Building
+                .accepts(&FrontendMessage::Query(Bytes::from_static(b"select 1")))
+        );
+        assert!(backend::RuntimeState::ExtendedError.accepts(&parse));
+        assert!(backend::RuntimeState::ExtendedError.accepts(&FrontendMessage::Sync));
+
+        let copy = FrontendMessage::CopyData(Bytes::from_static(b"data"));
+        assert!(backend::RuntimeState::SimpleCopyIn.accepts(&copy));
+        assert!(backend::RuntimeState::ExtendedCopyBoth.accepts(&copy));
+        assert!(
+            !backend::RuntimeState::ExtendedCopyBoth
+                .accepts(&FrontendMessage::Query(Bytes::from_static(b"select 1")))
+        );
+
+        assert!(
+            server_pre_startup::RuntimeState::PreStartup.accepts(&PreStartupMessage::SslRequest)
+        );
+        assert!(
+            !server_pre_startup::RuntimeState::SslDecision.accepts(&PreStartupMessage::SslRequest)
+        );
+    }
+
+    #[test]
+    fn checked_interception_rejects_an_unencodable_message() {
+        let invalid = FrontendMessage::Parse(Parse {
+            statement: Bytes::from_static(b"invalid\0name"),
+            query: Bytes::from_static(b"select 1"),
+            parameter_types: Vec::new(),
+        });
+        let expected = invalid.clone();
+        let mut middleware = Middleware::new((), move |_state: &mut (), _message| {
+            Ok::<_, Infallible>(invalid.clone())
+        });
+
+        assert_eq!(
+            middleware.intercept_checked(&backend::RuntimeState::Ready, FrontendMessage::Terminate),
+            Err(InterceptError::Invalid(expected))
+        );
     }
 }

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -1,0 +1,217 @@
+//! Stateful, composable interception of owned protocol messages.
+//!
+//! Middleware receives ownership of a decoded message and a mutable reference to
+//! caller-defined state. Returning the input unchanged is a no-op; implementations
+//! may instead mutate it or return another message of the same type. Protocol
+//! session APIs remain responsible for checking that the result is legal in their
+//! current state before advancing.
+
+use std::convert::Infallible;
+
+/// Intercepts an owned message with access to caller-defined state.
+///
+/// The message type determines the direction at compile time: middleware over
+/// `FrontendMessage` cannot accidentally return a `BackendMessage`, and vice
+/// versa.
+pub trait MessageMiddleware<Message, State> {
+    /// An error which prevents the message from continuing through the chain.
+    type Error;
+
+    /// Observes, mutates, or replaces one message.
+    ///
+    /// # Errors
+    ///
+    /// Returns a policy-defined error to stop message processing.
+    fn intercept(&mut self, state: &mut State, message: Message) -> Result<Message, Self::Error>;
+}
+
+/// Adds composition to every sized middleware implementation.
+pub trait MessageMiddlewareExt: Sized {
+    /// Runs this value followed by `next` whenever both implement middleware for
+    /// the intercepted message and state types.
+    fn then<Next>(self, next: Next) -> Then<Self, Next> {
+        Then {
+            first: self,
+            second: next,
+        }
+    }
+}
+
+impl<Handler> MessageMiddlewareExt for Handler {}
+
+impl<Message, State, Error, F> MessageMiddleware<Message, State> for F
+where
+    F: FnMut(&mut State, Message) -> Result<Message, Error>,
+{
+    type Error = Error;
+
+    fn intercept(&mut self, state: &mut State, message: Message) -> Result<Message, Self::Error> {
+        self(state, message)
+    }
+}
+
+/// Middleware which returns every message unchanged.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct Identity;
+
+impl<Message, State> MessageMiddleware<Message, State> for Identity {
+    type Error = Infallible;
+
+    fn intercept(&mut self, _state: &mut State, message: Message) -> Result<Message, Self::Error> {
+        Ok(message)
+    }
+}
+
+/// Two middleware stages evaluated from `first` to `second`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Then<First, Second> {
+    first: First,
+    second: Second,
+}
+
+impl<Message, State, First, Second> MessageMiddleware<Message, State> for Then<First, Second>
+where
+    First: MessageMiddleware<Message, State>,
+    Second: MessageMiddleware<Message, State>,
+{
+    type Error = ChainError<First::Error, Second::Error>;
+
+    fn intercept(&mut self, state: &mut State, message: Message) -> Result<Message, Self::Error> {
+        let message = self
+            .first
+            .intercept(state, message)
+            .map_err(ChainError::First)?;
+        self.second
+            .intercept(state, message)
+            .map_err(ChainError::Second)
+    }
+}
+
+/// Identifies which stage of a two-part middleware chain failed.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ChainError<First, Second> {
+    /// The first stage rejected the message.
+    First(First),
+    /// The second stage rejected the message.
+    Second(Second),
+}
+
+/// Owns user state and middleware as one reusable interception unit.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Middleware<State, Handler> {
+    state: State,
+    handler: Handler,
+}
+
+impl<State, Handler> Middleware<State, Handler> {
+    /// Creates middleware with its connection- or application-local state.
+    pub const fn new(state: State, handler: Handler) -> Self {
+        Self { state, handler }
+    }
+
+    /// Borrows the accumulated user state.
+    pub const fn state(&self) -> &State {
+        &self.state
+    }
+
+    /// Mutably borrows the accumulated user state.
+    pub const fn state_mut(&mut self) -> &mut State {
+        &mut self.state
+    }
+
+    /// Borrows the middleware implementation.
+    pub const fn handler(&self) -> &Handler {
+        &self.handler
+    }
+
+    /// Mutably borrows the middleware implementation.
+    pub const fn handler_mut(&mut self) -> &mut Handler {
+        &mut self.handler
+    }
+
+    /// Separates the accumulated state from its middleware implementation.
+    pub fn into_parts(self) -> (State, Handler) {
+        (self.state, self.handler)
+    }
+
+    /// Intercepts one owned message.
+    ///
+    /// # Errors
+    ///
+    /// Returns the middleware's policy-defined error.
+    pub fn intercept<Message>(&mut self, message: Message) -> Result<Message, Handler::Error>
+    where
+        Handler: MessageMiddleware<Message, State>,
+    {
+        self.handler.intercept(&mut self.state, message)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ChainError, Identity, MessageMiddlewareExt as _, Middleware};
+
+    #[test]
+    fn identity_is_a_no_op() {
+        let mut middleware = Middleware::new((), Identity);
+        assert_eq!(
+            middleware.intercept(String::from("message")),
+            Ok(String::from("message"))
+        );
+    }
+
+    #[test]
+    fn closure_can_replace_message_and_accumulate_state() {
+        let mut middleware =
+            Middleware::new(Vec::new(), |seen: &mut Vec<String>, message: String| {
+                seen.push(message.clone());
+                Ok::<_, &'static str>(message.to_uppercase())
+            });
+
+        assert_eq!(
+            middleware.intercept(String::from("hello")),
+            Ok(String::from("HELLO"))
+        );
+        assert_eq!(middleware.state(), &[String::from("hello")]);
+    }
+
+    #[test]
+    fn chain_passes_replacement_to_next_stage_in_order() {
+        let first = |order: &mut Vec<&'static str>, mut message: String| {
+            order.push("first");
+            message.push('1');
+            Ok::<_, &'static str>(message)
+        };
+        let second = |order: &mut Vec<&'static str>, mut message: String| {
+            order.push("second");
+            message.push('2');
+            Ok::<_, u8>(message)
+        };
+        let mut middleware = Middleware::new(Vec::new(), first.then(second));
+
+        assert_eq!(
+            middleware.intercept(String::from("m")),
+            Ok(String::from("m12"))
+        );
+        assert_eq!(middleware.state(), &["first", "second"]);
+    }
+
+    #[test]
+    fn chain_stops_after_first_error() {
+        let first = |calls: &mut usize, _message: String| {
+            *calls += 1;
+            Err::<String, _>("rejected")
+        };
+        let second = |calls: &mut usize, message: String| {
+            *calls += 1;
+            Ok::<_, u8>(message)
+        };
+        let mut middleware = Middleware::new(0, first.then(second));
+
+        assert_eq!(
+            middleware.intercept(String::from("message")),
+            Err(ChainError::First("rejected"))
+        );
+        assert_eq!(*middleware.state(), 1);
+    }
+}

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -18,6 +18,7 @@ use crate::{
         CancelKey, Demux, Notification, OrderedAsyncEvent, ParameterStatus, SessionItem,
         TaggedNotice,
     },
+    middleware::{AcceptsMessage, MessageMiddleware, Middleware, ReceiveError},
     pre_startup::{
         AwaitingSslReply, DEFAULT_MAX_PRE_STARTUP_PACKET_LEN, EncryptionReply, Negotiation,
         PreStartup, PreStartupMessage, ServerSslDecision, SslMode, SslModeNegotiation,
@@ -527,6 +528,29 @@ impl<S: AsyncRead + Unpin, Phase, Cleanliness> Conn<Buffered<S, Backend>, Phase,
         self.transport_mut().receive_backend().await
     }
 
+    /// Receives, intercepts, and validates one backend message before projection.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O, decoding, middleware-policy, or state-validation error.
+    pub async fn receive_backend_wire_with_middleware<State, Handler, ProtocolState>(
+        &mut self,
+        middleware: &mut Middleware<State, Handler>,
+        protocol_state: &ProtocolState,
+    ) -> Result<BackendMessage, ReceiveError<Handler::Error, BackendMessage>>
+    where
+        Handler: MessageMiddleware<BackendMessage, State>,
+        ProtocolState: AcceptsMessage<BackendMessage>,
+    {
+        let message = self
+            .receive_backend_wire()
+            .await
+            .map_err(ReceiveError::Io)?;
+        middleware
+            .intercept_checked(protocol_state, message)
+            .map_err(ReceiveError::Intercept)
+    }
+
     /// Projects an inspected or modified message into the filtered session stream.
     pub fn project_backend(&mut self, message: BackendMessage) -> Option<SessionItem> {
         self.transport_mut().project_backend(message)
@@ -539,6 +563,33 @@ impl<S: AsyncRead + Unpin, Phase, Cleanliness> Conn<Buffered<S, Backend>, Phase,
     /// Returns decoding and underlying transport read errors, or `UnexpectedEof`.
     pub async fn receive(&mut self) -> io::Result<SessionItem> {
         self.transport_mut().receive_session().await
+    }
+
+    /// Receives backend messages through middleware before demultiplexing.
+    ///
+    /// Asynchronous messages are intercepted and then recorded by the demux;
+    /// this method continues until a protocol-advancing item is available.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O, decoding, middleware-policy, or state-validation error.
+    pub async fn receive_with_middleware<State, Handler, ProtocolState>(
+        &mut self,
+        middleware: &mut Middleware<State, Handler>,
+        protocol_state: &ProtocolState,
+    ) -> Result<SessionItem, ReceiveError<Handler::Error, BackendMessage>>
+    where
+        Handler: MessageMiddleware<BackendMessage, State>,
+        ProtocolState: AcceptsMessage<BackendMessage>,
+    {
+        loop {
+            let message = self
+                .receive_backend_wire_with_middleware(middleware, protocol_state)
+                .await?;
+            if let Some(item) = self.project_backend(message) {
+                return Ok(item);
+            }
+        }
     }
 
     #[must_use]
@@ -595,6 +646,29 @@ impl<S: AsyncRead + Unpin, Phase, Cleanliness> Conn<Buffered<S, Frontend>, Phase
     pub async fn receive_frontend_wire(&mut self) -> io::Result<FrontendMessage> {
         self.transport_mut().receive_wire().await
     }
+
+    /// Receives, intercepts, and validates one frontend message before projection.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O, decoding, middleware-policy, or state-validation error.
+    pub async fn receive_frontend_wire_with_middleware<State, Handler, ProtocolState>(
+        &mut self,
+        middleware: &mut Middleware<State, Handler>,
+        protocol_state: &ProtocolState,
+    ) -> Result<FrontendMessage, ReceiveError<Handler::Error, FrontendMessage>>
+    where
+        Handler: MessageMiddleware<FrontendMessage, State>,
+        ProtocolState: AcceptsMessage<FrontendMessage>,
+    {
+        let message = self
+            .receive_frontend_wire()
+            .await
+            .map_err(ReceiveError::Io)?;
+        middleware
+            .intercept_checked(protocol_state, message)
+            .map_err(ReceiveError::Intercept)
+    }
 }
 
 impl<S: AsyncRead + Unpin, Cleanliness> Conn<Buffered<S, Frontend>, PreStartup, Cleanliness> {
@@ -606,11 +680,35 @@ impl<S: AsyncRead + Unpin, Cleanliness> Conn<Buffered<S, Frontend>, PreStartup, 
     pub async fn receive_pre_startup_wire(&mut self) -> io::Result<PreStartupMessage> {
         self.transport_mut().receive_pre_startup().await
     }
+
+    /// Receives, intercepts, and validates one untagged pre-startup message.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O, decoding, middleware-policy, or state-validation error.
+    pub async fn receive_pre_startup_wire_with_middleware<State, Handler, ProtocolState>(
+        &mut self,
+        middleware: &mut Middleware<State, Handler>,
+        protocol_state: &ProtocolState,
+    ) -> Result<PreStartupMessage, ReceiveError<Handler::Error, PreStartupMessage>>
+    where
+        Handler: MessageMiddleware<PreStartupMessage, State>,
+        ProtocolState: AcceptsMessage<PreStartupMessage>,
+    {
+        let message = self
+            .receive_pre_startup_wire()
+            .await
+            .map_err(ReceiveError::Io)?;
+        middleware
+            .intercept_checked(protocol_state, message)
+            .map_err(ReceiveError::Intercept)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use std::{
+        convert::Infallible,
         future::Future,
         pin::Pin,
         task::{Context, Poll},
@@ -620,6 +718,10 @@ mod tests {
     use tokio::io::AsyncWrite;
 
     use super::*;
+    use crate::{
+        grammar::{backend, frontend, server_pre_startup},
+        middleware::{InterceptError, Middleware, ReceiveError},
+    };
 
     #[derive(Debug, Default)]
     struct ShortWriter {
@@ -809,6 +911,195 @@ mod tests {
                 .get(&Bytes::from_static(b"application_name")),
             Some(&Bytes::from_static(b"proxy"))
         );
+    }
+
+    #[tokio::test]
+    async fn middleware_rewrites_backend_before_demux_bookkeeping() {
+        let (client, mut server) = tokio::io::duplex(256);
+        let mut wire = BytesMut::new();
+        let mut encoder = PgCodec::<Backend>::default();
+        for message in [
+            BackendMessage::BackendKeyData {
+                process_id: 7,
+                secret_key: Bytes::from_static(b"old!"),
+            },
+            BackendMessage::ParameterStatus {
+                name: Bytes::from_static(b"application_name"),
+                value: Bytes::from_static(b"upstream"),
+            },
+            BackendMessage::ReadyForQuery(crate::codec::TransactionStatus::Idle),
+        ] {
+            encoder
+                .encode(
+                    message.to_frame().expect("reconstructable message"),
+                    &mut wire,
+                )
+                .expect("encodable message");
+        }
+        server.write_all(&wire).await.expect("writable test peer");
+
+        let transport = Buffered::new(client);
+        let mut conn: Conn<_, crate::auth::Ready> = Conn::new(transport).transition();
+        let mut middleware = Middleware::new(0_usize, |seen: &mut usize, mut message| {
+            *seen += 1;
+            if let BackendMessage::ParameterStatus { value, .. } = &mut message {
+                *value = Bytes::from_static(b"proxy");
+            }
+            if let BackendMessage::BackendKeyData {
+                process_id,
+                secret_key,
+            } = &mut message
+            {
+                *process_id = 9;
+                *secret_key = Bytes::from_static(b"new!");
+            }
+            if let BackendMessage::ReadyForQuery(status) = &mut message {
+                *status = crate::codec::TransactionStatus::InTransaction;
+            }
+            Ok::<_, Infallible>(message)
+        });
+
+        assert!(matches!(
+            conn.receive_with_middleware(&mut middleware, &frontend::RuntimeState::Simple)
+                .await,
+            Ok(SessionItem::Message(BackendMessage::BackendKeyData { .. }))
+        ));
+        assert!(matches!(
+            conn.receive_with_middleware(&mut middleware, &frontend::RuntimeState::Simple)
+                .await,
+            Ok(SessionItem::ReadyForQuery { .. })
+        ));
+        assert_eq!(*middleware.state(), 3);
+        assert_eq!(
+            conn.parameters().get(b"application_name".as_slice()),
+            Some(&Bytes::from_static(b"proxy"))
+        );
+        assert_eq!(
+            conn.cancel_key(),
+            Some(&CancelKey {
+                process_id: 9,
+                secret_key: Bytes::from_static(b"new!"),
+            })
+        );
+        assert_eq!(
+            conn.transaction_status(),
+            Some(crate::codec::TransactionStatus::InTransaction)
+        );
+        conn.into_transport();
+    }
+
+    #[tokio::test]
+    async fn frontend_middleware_returns_illegal_replacement_before_projection() {
+        let (proxy, mut client) = tokio::io::duplex(128);
+        let original = FrontendMessage::CopyData(Bytes::from_static(b"row"));
+        let mut bytes = BytesMut::new();
+        PgCodec::<Frontend>::default()
+            .encode(
+                original.to_frame().expect("reconstructable message"),
+                &mut bytes,
+            )
+            .expect("encodable message");
+        client.write_all(&bytes).await.expect("writable client");
+
+        let mut conn = Conn::new(Buffered::<_, Frontend>::new_frontend(proxy));
+        let mut middleware = Middleware::new((), |_state: &mut (), _message| {
+            Ok::<_, Infallible>(FrontendMessage::Query(Bytes::from_static(b"select 1")))
+        });
+        let result = conn
+            .receive_frontend_wire_with_middleware(
+                &mut middleware,
+                &backend::RuntimeState::SimpleCopyIn,
+            )
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(ReceiveError::Intercept(InterceptError::Invalid(
+                FrontendMessage::Query(_)
+            )))
+        ));
+        conn.into_transport();
+    }
+
+    #[tokio::test]
+    async fn middleware_replacement_reaches_the_forwarded_peer() {
+        let (client_side, mut client) = tokio::io::duplex(128);
+        let original = FrontendMessage::Query(Bytes::from_static(b"select plaintext"));
+        let mut bytes = BytesMut::new();
+        PgCodec::<Frontend>::default()
+            .encode(
+                original.to_frame().expect("reconstructable message"),
+                &mut bytes,
+            )
+            .expect("encodable message");
+        client.write_all(&bytes).await.expect("writable client");
+
+        let mut downstream = Conn::new(Buffered::<_, Frontend>::new_frontend(client_side));
+        let mut middleware = Middleware::new((), |_state: &mut (), _message| {
+            Ok::<_, Infallible>(FrontendMessage::Query(Bytes::from_static(
+                b"select encrypted",
+            )))
+        });
+        let rewritten = downstream
+            .receive_frontend_wire_with_middleware(&mut middleware, &backend::RuntimeState::Ready)
+            .await
+            .expect("legal rewritten query");
+
+        let (upstream_side, mut server) = tokio::io::duplex(128);
+        let mut upstream = Buffered::<_, Backend>::new(upstream_side);
+        upstream
+            .push(rewritten.to_frame().expect("reconstructable replacement"))
+            .expect("encodable replacement");
+        upstream.flush().await.expect("writable upstream");
+
+        let mut received = BytesMut::new();
+        server
+            .read_buf(&mut received)
+            .await
+            .expect("readable upstream peer");
+        assert_eq!(
+            PgCodec::<Frontend>::default()
+                .decode(&mut received)
+                .expect("decodable frame"),
+            Some(FrontendMessage::Query(Bytes::from_static(
+                b"select encrypted"
+            )))
+        );
+        downstream.into_transport();
+    }
+
+    #[tokio::test]
+    async fn pre_startup_middleware_can_replace_with_another_legal_choice() {
+        let (proxy, mut client) = tokio::io::duplex(128);
+        client
+            .write_all(
+                &PreStartupMessage::SslRequest
+                    .to_packet()
+                    .expect("encodable SSLRequest"),
+            )
+            .await
+            .expect("writable client");
+
+        let mut conn = Conn::new(Buffered::<_, Frontend>::new_frontend(proxy));
+        let replacement = PreStartupMessage::CancelRequest {
+            process_id: 42,
+            secret_key: Bytes::from_static(b"key!"),
+        };
+        let expected = replacement.clone();
+        let mut middleware = Middleware::new((), move |_state: &mut (), _message| {
+            Ok::<_, Infallible>(replacement.clone())
+        });
+
+        assert_eq!(
+            conn.receive_pre_startup_wire_with_middleware(
+                &mut middleware,
+                &server_pre_startup::RuntimeState::PreStartup,
+            )
+            .await
+            .expect("legal replacement"),
+            expected
+        );
+        conn.into_transport();
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- add stateful, composable middleware for frontend, backend, and pre-startup messages
- validate replacements against generated protocol states and wire reconstruction rules
- intercept backend messages before demultiplexing and migrate proxy examples to chained middleware
- document the feature in the README and complete the implementation plan

## Verification
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --lib --all-features
- cargo test --doc
- cargo check --examples
- non-container integration suites