### PR TITLE
docs: clarify middleware validation timing

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -292,6 +292,36 @@ checked middleware belongs on the state-aware session APIs above it.
 
 ## Optional future work
 
+### Compile-time-checked message middleware
+
+- [ ] Generate a state-specific owned message enum for every role and protocol
+  phase, containing only the frontend, backend, pre-startup, authentication,
+  COPY, replication, error-recovery, and asynchronous messages legal there.
+- [ ] Add a `TypedMiddleware<Role, Phase, UserState>` abstraction whose input and
+  output are the generated `Phase::Message` type. An illegal replacement should
+  be unrepresentable rather than rejected using a `RuntimeState` value.
+  - [ ] Infer `Role` and `Phase` from the existing `Conn` typestate so callers
+    cannot supply a mismatched runtime state.
+  - [ ] Retain caller-owned mutable state, closure adapters, identity middleware,
+    deterministic chaining, and typed short-circuit errors.
+  - [ ] Represent asynchronous backend traffic in each applicable phase without
+    advancing the connection state or disturbing wire order.
+- [ ] Generate projection result enums whose variants carry the correctly typed
+  next `Conn`, because replacing one legal message variant with another may
+  select a different transition and therefore a different next phase.
+- [ ] Keep wire-shape validation at runtime for constraints such as embedded NUL
+  bytes and frame-size overflow, unless message fields later adopt prevalidated
+  refinement types. Document this separately from compile-time protocol legality.
+- [ ] Provide default pass-through adapters so policies can specialize only the
+  phases or message families they inspect without manually implementing every
+  generated state.
+- [ ] Add compile-fail coverage proving illegal replacements and role/state
+  mismatches do not compile, plus runtime tests for reconstruction failures,
+  composition, state threading, asynchronous traffic, and next-state selection.
+- [ ] Introduce the typed API alongside `intercept_checked`, migrate examples and
+  transport/session entry points, then consider deprecating the runtime-state API
+  only after the typed API covers every generated grammar phase.
+
 - [x] Add optional operation-bounded intermediary pipeline orchestration with
   payload-free ordering records, local responses, COPY, and Sync error recovery.
 - [x] Use the repository README as the crate-level Rustdoc landing page.

--- a/README.md
+++ b/README.md
@@ -108,11 +108,14 @@ mutable access to a caller-defined state value, so statistics and other
 connection-local policy do not require global storage. Returning the message
 unchanged is the identity operation.
 
-`intercept_checked` validates the final replacement against a generated runtime
-protocol state and verifies that it can be encoded. Illegal replacements are
-returned without advancing the session. `MessageMiddlewareExt::then` chains
-stages in order, passing each replacement to the next stage and stopping at the
-first error.
+`intercept_checked` validates the final replacement at runtime against a
+generated `RuntimeState` value and verifies that it can be encoded. The compiler
+still enforces message direction and that the state type supplies the correct
+validator, but replacement-variant legality cannot be decided at compile time
+because middleware may choose a different variant dynamically. Illegal
+replacements are returned without advancing the session.
+`MessageMiddlewareExt::then` chains stages in order, passing each replacement to
+the next stage and stopping at the first error.
 
 ```rust
 use bytes::Bytes;

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -278,10 +278,15 @@ impl<State, Handler> Middleware<State, Handler> {
         self.handler.intercept(&mut self.state, message)
     }
 
-    /// Intercepts a message and checks the result against `protocol_state`.
+    /// Intercepts a message and checks the result against `protocol_state` at runtime.
     ///
-    /// Validation happens after the complete middleware chain, immediately
-    /// before a caller projects and advances its protocol state.
+    /// The compiler enforces the message direction and requires `ProtocolState`
+    /// to implement [`AcceptsMessage`] for that message type. The replacement's
+    /// concrete variant and the supplied generated [`crate::grammar`] runtime
+    /// state value are dynamic, however, so protocol legality and wire
+    /// reconstructability are checked at runtime after the complete middleware
+    /// chain. Call this immediately before projecting and advancing the same
+    /// protocol state.
     ///
     /// # Errors
     ///


### PR DESCRIPTION
## Summary
- state explicitly that intercept_checked validates protocol legality and wire reconstruction at runtime
- distinguish runtime variant legality from compile-time direction and validator-type guarantees
- save the proposed compile-time-checked middleware API as optional future work in PLAN.md

## Verification
- cargo fmt --all -- --check
- cargo test --doc
- cargo clippy --lib -- -D warnings
- git diff --check