### PR TITLE
refactor: consolidate inbound interception

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -351,6 +351,9 @@ checked middleware belongs on the state-aware session APIs above it.
   - [x] Deepen the pipeline ledger interface by removing overlapping projection,
     action-remapping, and session-item entry points, leaving one frontend
     admission seam and one backend response seam.
+  - [x] Consolidate inbound receipt, middleware interception, phase legality,
+    and reconstruction validation across backend, frontend, pre-startup, and
+    encryption-reply traffic without combining receipt with projection.
 - [x] Use the repository README as the crate-level Rustdoc landing page.
 - [x] License both published crates and the repository under the MIT License.
 - [x] Add descriptive crates.io keywords and categories to both package manifests.

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1,6 +1,9 @@
-//! Buffered, cancellation-safe outbound transport.
+//! Buffered, cancellation-safe transport with one inbound interception workflow.
+//!
+//! Wire-family-specific readers feed shared typed or runtime-checked validation,
+//! while receipt and session projection remain separate operations.
 
-use std::{collections::BTreeMap, io, sync::Arc};
+use std::{collections::BTreeMap, future::Future, io, sync::Arc};
 
 use bytes::{Buf, Bytes, BytesMut};
 use rustls::{
@@ -20,7 +23,7 @@ use crate::{
     },
     middleware::{
         AcceptsMessage, ClientRole, Inbound, MessageMiddleware, Middleware, PhaseAssociation,
-        ReceiveError, ReconstructableMessage as _, ServerRole, TypedMiddleware, TypedReceiveError,
+        ReceiveError, ReconstructableMessage, ServerRole, TypedMiddleware, TypedReceiveError,
     },
     pre_startup::{
         AwaitingSslReply, DEFAULT_MAX_PRE_STARTUP_PACKET_LEN, EncryptionReply, Negotiation,
@@ -29,6 +32,60 @@ use crate::{
     },
     tls::{ClientTls, ServerTls},
 };
+
+async fn receive_typed<Role, Phase, Wire, State, Handler, Read>(
+    read: Read,
+    middleware: &mut Middleware<State, Handler>,
+) -> Result<
+    <Phase as PhaseAssociation<Inbound, Role, Wire>>::Message,
+    TypedReceiveError<Handler::Error, Wire>,
+>
+where
+    Read: Future<Output = io::Result<Wire>>,
+    Phase: PhaseAssociation<Inbound, Role, Wire>,
+    Wire: ReconstructableMessage,
+    Handler: TypedMiddleware<
+            Role,
+            <Phase as PhaseAssociation<Inbound, Role, Wire>>::ProtocolPhase,
+            <Phase as PhaseAssociation<Inbound, Role, Wire>>::Message,
+            State,
+        >,
+{
+    let message = read.await.map_err(TypedReceiveError::Io)?;
+    let message = <Phase as PhaseAssociation<Inbound, Role, Wire>>::Message::try_from(message)
+        .map_err(TypedReceiveError::Illegal)?;
+    let message = middleware
+        .intercept_typed::<
+            Role,
+            <Phase as PhaseAssociation<Inbound, Role, Wire>>::ProtocolPhase,
+            _,
+        >(message)
+        .await
+        .map_err(TypedReceiveError::Middleware)?;
+    if message.as_ref().is_reconstructable() {
+        Ok(message)
+    } else {
+        Err(TypedReceiveError::InvalidWire(message.into()))
+    }
+}
+
+async fn receive_checked<Message, State, Handler, ProtocolState, Read>(
+    read: Read,
+    middleware: &mut Middleware<State, Handler>,
+    protocol_state: &ProtocolState,
+) -> Result<Message, ReceiveError<Handler::Error, Message>>
+where
+    Read: Future<Output = io::Result<Message>>,
+    Message: ReconstructableMessage,
+    Handler: MessageMiddleware<Message, State>,
+    ProtocolState: AcceptsMessage<Message>,
+{
+    let message = read.await.map_err(ReceiveError::Io)?;
+    middleware
+        .intercept_checked(protocol_state, message)
+        .await
+        .map_err(ReceiveError::Intercept)
+}
 
 /// Transport wrapper which retains bytes until each write has completed.
 #[derive(Debug)]
@@ -557,28 +614,11 @@ impl<S: AsyncRead + Unpin, Phase, Cleanliness> Conn<Buffered<S, Backend>, Phase,
                 State,
             >,
     {
-        let message = self
-            .receive_backend_wire()
-            .await
-            .map_err(TypedReceiveError::Io)?;
-        let message =
-            <Phase as PhaseAssociation<Inbound, ServerRole, BackendMessage>>::Message::try_from(
-                message,
-            )
-            .map_err(TypedReceiveError::Illegal)?;
-        let message = middleware
-            .intercept_typed::<
-                ServerRole,
-                <Phase as PhaseAssociation<Inbound, ServerRole, BackendMessage>>::ProtocolPhase,
-                _,
-            >(message)
-            .await
-            .map_err(TypedReceiveError::Middleware)?;
-        if message.as_ref().is_reconstructable() {
-            Ok(message)
-        } else {
-            Err(TypedReceiveError::InvalidWire(message.into()))
-        }
+        receive_typed::<ServerRole, Phase, BackendMessage, _, _, _>(
+            self.receive_backend_wire(),
+            middleware,
+        )
+        .await
     }
 
     /// Receives typed backend traffic until one protocol-advancing item remains.
@@ -635,29 +675,11 @@ impl<S: AsyncRead + Unpin, Phase, Cleanliness> Conn<Buffered<S, Backend>, Phase,
                 State,
             >,
     {
-        let message = self
-            .transport_mut()
-            .receive_encryption_reply()
-            .await
-            .map_err(TypedReceiveError::Io)?;
-        let message =
-            <Phase as PhaseAssociation<Inbound, ServerRole, EncryptionReply>>::Message::try_from(
-                message,
-            )
-            .map_err(TypedReceiveError::Illegal)?;
-        let message = middleware
-            .intercept_typed::<
-                ServerRole,
-                <Phase as PhaseAssociation<Inbound, ServerRole, EncryptionReply>>::ProtocolPhase,
-                _,
-            >(message)
-            .await
-            .map_err(TypedReceiveError::Middleware)?;
-        if message.as_ref().is_reconstructable() {
-            Ok(message)
-        } else {
-            Err(TypedReceiveError::InvalidWire(message.into()))
-        }
+        receive_typed::<ServerRole, Phase, EncryptionReply, _, _, _>(
+            self.transport_mut().receive_encryption_reply(),
+            middleware,
+        )
+        .await
     }
 
     /// Receives, intercepts, and validates one backend message before projection.
@@ -674,14 +696,7 @@ impl<S: AsyncRead + Unpin, Phase, Cleanliness> Conn<Buffered<S, Backend>, Phase,
         Handler: MessageMiddleware<BackendMessage, State>,
         ProtocolState: AcceptsMessage<BackendMessage>,
     {
-        let message = self
-            .receive_backend_wire()
-            .await
-            .map_err(ReceiveError::Io)?;
-        middleware
-            .intercept_checked(protocol_state, message)
-            .await
-            .map_err(ReceiveError::Intercept)
+        receive_checked(self.receive_backend_wire(), middleware, protocol_state).await
     }
 
     /// Projects an inspected or modified message into the filtered session stream.
@@ -805,28 +820,11 @@ impl<S: AsyncRead + Unpin, Phase, Cleanliness> Conn<Buffered<S, Frontend>, Phase
                 State,
             >,
     {
-        let message = self
-            .receive_frontend_wire()
-            .await
-            .map_err(TypedReceiveError::Io)?;
-        let message =
-            <Phase as PhaseAssociation<Inbound, ClientRole, FrontendMessage>>::Message::try_from(
-                message,
-            )
-            .map_err(TypedReceiveError::Illegal)?;
-        let message = middleware
-            .intercept_typed::<
-                ClientRole,
-                <Phase as PhaseAssociation<Inbound, ClientRole, FrontendMessage>>::ProtocolPhase,
-                _,
-            >(message)
-            .await
-            .map_err(TypedReceiveError::Middleware)?;
-        if message.as_ref().is_reconstructable() {
-            Ok(message)
-        } else {
-            Err(TypedReceiveError::InvalidWire(message.into()))
-        }
+        receive_typed::<ClientRole, Phase, FrontendMessage, _, _, _>(
+            self.receive_frontend_wire(),
+            middleware,
+        )
+        .await
     }
 
     /// Receives, intercepts, and validates one frontend message before projection.
@@ -843,14 +841,7 @@ impl<S: AsyncRead + Unpin, Phase, Cleanliness> Conn<Buffered<S, Frontend>, Phase
         Handler: MessageMiddleware<FrontendMessage, State>,
         ProtocolState: AcceptsMessage<FrontendMessage>,
     {
-        let message = self
-            .receive_frontend_wire()
-            .await
-            .map_err(ReceiveError::Io)?;
-        middleware
-            .intercept_checked(protocol_state, message)
-            .await
-            .map_err(ReceiveError::Intercept)
+        receive_checked(self.receive_frontend_wire(), middleware, protocol_state).await
     }
 }
 
@@ -885,26 +876,11 @@ impl<S: AsyncRead + Unpin, Cleanliness> Conn<Buffered<S, Frontend>, PreStartup, 
                 State,
             >,
     {
-        let message = self
-            .receive_pre_startup_wire()
-            .await
-            .map_err(TypedReceiveError::Io)?;
-        let message =
-            <PreStartup as PhaseAssociation<Inbound, ClientRole, PreStartupMessage>>::Message::try_from(message)
-                .map_err(TypedReceiveError::Illegal)?;
-        let message = middleware
-            .intercept_typed::<
-                ClientRole,
-                <PreStartup as PhaseAssociation<Inbound, ClientRole, PreStartupMessage>>::ProtocolPhase,
-                _,
-            >(message)
-            .await
-            .map_err(TypedReceiveError::Middleware)?;
-        if message.as_ref().is_reconstructable() {
-            Ok(message)
-        } else {
-            Err(TypedReceiveError::InvalidWire(message.into()))
-        }
+        receive_typed::<ClientRole, PreStartup, PreStartupMessage, _, _, _>(
+            self.receive_pre_startup_wire(),
+            middleware,
+        )
+        .await
     }
 
     /// Receives, intercepts, and validates one untagged pre-startup message.
@@ -921,14 +897,7 @@ impl<S: AsyncRead + Unpin, Cleanliness> Conn<Buffered<S, Frontend>, PreStartup, 
         Handler: MessageMiddleware<PreStartupMessage, State>,
         ProtocolState: AcceptsMessage<PreStartupMessage>,
     {
-        let message = self
-            .receive_pre_startup_wire()
-            .await
-            .map_err(ReceiveError::Io)?;
-        middleware
-            .intercept_checked(protocol_state, message)
-            .await
-            .map_err(ReceiveError::Intercept)
+        receive_checked(self.receive_pre_startup_wire(), middleware, protocol_state).await
     }
 }
 
@@ -946,7 +915,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        grammar::{backend, frontend, server_pre_startup},
+        grammar::{backend, frontend, pre_startup as pre_startup_grammar, server_pre_startup},
         middleware::{InterceptError, Middleware, ReceiveError},
     };
 
@@ -1217,6 +1186,112 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn typed_pre_startup_receive_intercepts_without_projecting() {
+        let (proxy, mut client) = tokio::io::duplex(128);
+        client
+            .write_all(
+                &PreStartupMessage::SslRequest
+                    .to_packet()
+                    .expect("encodable SSLRequest"),
+            )
+            .await
+            .expect("writable client");
+
+        let transport = Buffered::<_, Frontend>::new_frontend(proxy);
+        let mut conn = Conn::new(transport);
+        let mut middleware = Middleware::new(0_usize, async |seen: &mut usize, _message| {
+            *seen += 1;
+            match server_pre_startup::PreStartupExternalMessage::try_from(
+                PreStartupMessage::CancelRequest {
+                    process_id: 42,
+                    secret_key: Bytes::from_static(b"key!"),
+                },
+            ) {
+                Ok(replacement) => Ok::<_, Infallible>(replacement),
+                Err(message) => panic!("cancel request must be legal before startup: {message:?}"),
+            }
+        });
+
+        let message = conn
+            .receive_pre_startup_typed(&mut middleware)
+            .await
+            .expect("phase-legal pre-startup packet");
+
+        assert_eq!(
+            PreStartupMessage::from(message),
+            PreStartupMessage::CancelRequest {
+                process_id: 42,
+                secret_key: Bytes::from_static(b"key!"),
+            }
+        );
+        assert_eq!(*middleware.state(), 1);
+        let conn: Conn<_, PreStartup> = conn;
+        conn.into_transport();
+    }
+
+    #[tokio::test]
+    async fn typed_encryption_reply_receive_intercepts_without_projecting() {
+        let (client, mut server) = tokio::io::duplex(16);
+        server.write_all(b"S").await.expect("writable test peer");
+
+        let transport = Buffered::new(client);
+        let mut conn: Conn<_, AwaitingSslReply> = Conn::new(transport).transition();
+        let mut middleware = Middleware::new(0_usize, async |seen: &mut usize, _message| {
+            *seen += 1;
+            match pre_startup_grammar::AwaitingSslReplyExternalMessage::try_from(
+                EncryptionReply::Rejected,
+            ) {
+                Ok(replacement) => Ok::<_, Infallible>(replacement),
+                Err(message) => panic!("SSL rejection must be phase legal: {message:?}"),
+            }
+        });
+
+        let message = conn
+            .receive_encryption_reply_typed(&mut middleware)
+            .await
+            .expect("phase-legal SSL reply");
+
+        assert_eq!(EncryptionReply::from(message), EncryptionReply::Rejected);
+        assert_eq!(*middleware.state(), 1);
+        let conn: Conn<_, AwaitingSslReply> = conn;
+        conn.into_transport();
+    }
+
+    #[tokio::test]
+    async fn typed_receive_preserves_large_replacement_allocation() {
+        let (proxy, mut client) = tokio::io::duplex(128);
+        let query = FrontendMessage::Query(Bytes::from_static(b"select 1"));
+        let mut bytes = BytesMut::new();
+        PgCodec::<Frontend>::default()
+            .encode(query.to_frame().expect("reconstructable Query"), &mut bytes)
+            .expect("encodable Query");
+        client.write_all(&bytes).await.expect("writable client");
+
+        let transport = Buffered::<_, Frontend>::new_frontend(proxy);
+        let mut conn: Conn<_, crate::auth::Ready> = Conn::new(transport).transition();
+        let replacement_payload = Bytes::from(vec![b'x'; 2 * 1024 * 1024]);
+        let replacement_pointer = replacement_payload.as_ptr();
+        let mut middleware = Middleware::new((), async move |_state: &mut (), _message| {
+            match backend::ReadyExternalMessage::try_from(FrontendMessage::Query(
+                replacement_payload.clone(),
+            )) {
+                Ok(replacement) => Ok::<_, Infallible>(replacement),
+                Err(message) => panic!("query must be legal while ready: {message:?}"),
+            }
+        });
+
+        let message = conn
+            .receive_frontend_typed(&mut middleware)
+            .await
+            .expect("phase-legal replacement");
+        let FrontendMessage::Query(replacement) = FrontendMessage::from(message) else {
+            panic!("expected replacement Query")
+        };
+        assert_eq!(replacement.as_ptr(), replacement_pointer);
+        conn.into_transport();
+    }
+
+    #[tokio::test]
     async fn typed_receive_keeps_wire_shape_validation_at_runtime() {
         let (client, mut peer) = tokio::io::duplex(256);
         let query = FrontendMessage::Query(Bytes::from_static(b"select 1"));
@@ -1228,9 +1303,11 @@ mod tests {
 
         let transport = Buffered::<_, Frontend>::new_frontend(client);
         let mut conn: Conn<_, crate::auth::Ready> = Conn::new(transport).transition();
+        let replacement_payload = Bytes::from(vec![b'x'; 2 * 1024 * 1024]);
+        let replacement_pointer = replacement_payload.as_ptr();
         let invalid = FrontendMessage::Parse(crate::codec::Parse {
             statement: Bytes::from_static(b"invalid\0statement"),
-            query: Bytes::from_static(b"select 2"),
+            query: replacement_payload,
             parameter_types: Vec::new(),
         });
         let mut middleware = Middleware::new((), async move |_state: &mut (), _message| {
@@ -1242,11 +1319,243 @@ mod tests {
         });
 
         let result = conn.receive_frontend_typed(&mut middleware).await;
-        assert!(matches!(
-            result,
-            Err(TypedReceiveError::InvalidWire(FrontendMessage::Parse(_)))
-        ));
+        let Err(TypedReceiveError::InvalidWire(FrontendMessage::Parse(replacement))) = result
+        else {
+            panic!("expected the invalid replacement wire value")
+        };
+        assert_eq!(replacement.query.as_ptr(), replacement_pointer);
         conn.into_transport();
+    }
+
+    #[tokio::test]
+    async fn typed_receive_rejects_illegal_peer_input_before_middleware() {
+        let (proxy, mut client) = tokio::io::duplex(2 * 1024 * 1024 + 64);
+        let illegal_payload = Bytes::from(vec![b'x'; 2 * 1024 * 1024]);
+        let illegal = FrontendMessage::CopyData(illegal_payload);
+        let mut bytes = BytesMut::new();
+        PgCodec::<Frontend>::default()
+            .encode(
+                illegal.to_frame().expect("reconstructable CopyData"),
+                &mut bytes,
+            )
+            .expect("encodable CopyData");
+        client.write_all(&bytes).await.expect("writable client");
+
+        let transport = Buffered::<_, Frontend>::new_frontend(proxy);
+        let mut conn: Conn<_, crate::auth::Ready> = Conn::new(transport).transition();
+        let mut middleware = Middleware::new(0_usize, async |seen: &mut usize, message| {
+            *seen += 1;
+            Ok::<_, Infallible>(message)
+        });
+
+        let result = conn.receive_frontend_typed(&mut middleware).await;
+
+        let Err(TypedReceiveError::Illegal(FrontendMessage::CopyData(illegal))) = result else {
+            panic!("expected the phase-illegal CopyData")
+        };
+        assert_eq!(illegal.len(), 2 * 1024 * 1024);
+        assert!(illegal.iter().all(|byte| *byte == b'x'));
+        assert_eq!(*middleware.state(), 0);
+        conn.into_transport();
+    }
+
+    #[tokio::test]
+    async fn typed_backend_receive_rejects_illegal_peer_input_before_middleware() {
+        let (client, mut server) = tokio::io::duplex(64);
+        let mut bytes = BytesMut::new();
+        PgCodec::<Backend>::default()
+            .encode(
+                BackendMessage::ParseComplete
+                    .to_frame()
+                    .expect("reconstructable ParseComplete"),
+                &mut bytes,
+            )
+            .expect("encodable ParseComplete");
+        server.write_all(&bytes).await.expect("writable server");
+
+        let mut conn: Conn<_, crate::auth::Ready> = Conn::new(Buffered::new(client)).transition();
+        let mut middleware = Middleware::new(0_usize, async |seen: &mut usize, message| {
+            *seen += 1;
+            Ok::<_, Infallible>(message)
+        });
+
+        assert!(matches!(
+            conn.receive_backend_typed(&mut middleware).await,
+            Err(TypedReceiveError::Illegal(BackendMessage::ParseComplete))
+        ));
+        assert_eq!(*middleware.state(), 0);
+        conn.into_transport();
+    }
+
+    #[tokio::test]
+    async fn typed_backend_and_pre_startup_receive_return_invalid_replacements() {
+        let (backend_side, mut server) = tokio::io::duplex(128);
+        let mut backend_bytes = BytesMut::new();
+        PgCodec::<Backend>::default()
+            .encode(
+                BackendMessage::ParameterStatus {
+                    name: Bytes::from_static(b"application_name"),
+                    value: Bytes::from_static(b"upstream"),
+                }
+                .to_frame()
+                .expect("reconstructable ParameterStatus"),
+                &mut backend_bytes,
+            )
+            .expect("encodable ParameterStatus");
+        server
+            .write_all(&backend_bytes)
+            .await
+            .expect("writable server");
+        let mut backend: Conn<_, crate::auth::Ready> =
+            Conn::new(Buffered::new(backend_side)).transition();
+        let mut backend_middleware = Middleware::new((), async |_state: &mut (), _message| {
+            let invalid = BackendMessage::ParameterStatus {
+                name: Bytes::from_static(b"invalid\0name"),
+                value: Bytes::from_static(b"value"),
+            };
+            match crate::middleware::TypedBackendMessage::try_from(invalid) {
+                Ok(replacement) => Ok::<_, Infallible>(replacement),
+                Err(message) => panic!("ParameterStatus must be phase legal: {message:?}"),
+            }
+        });
+        assert!(matches!(
+            backend.receive_backend_typed(&mut backend_middleware).await,
+            Err(TypedReceiveError::InvalidWire(
+                BackendMessage::ParameterStatus { .. }
+            ))
+        ));
+        backend.into_transport();
+
+        let (pre_startup_side, mut client) = tokio::io::duplex(128);
+        client
+            .write_all(
+                &PreStartupMessage::SslRequest
+                    .to_packet()
+                    .expect("encodable SSLRequest"),
+            )
+            .await
+            .expect("writable client");
+        let mut pre_startup = Conn::new(Buffered::<_, Frontend>::new_frontend(pre_startup_side));
+        let invalid_key = Bytes::from_static(b"bad");
+        let mut pre_startup_middleware =
+            Middleware::new((), async move |_state: &mut (), _message| {
+                match server_pre_startup::PreStartupExternalMessage::try_from(
+                    PreStartupMessage::CancelRequest {
+                        process_id: 42,
+                        secret_key: invalid_key.clone(),
+                    },
+                ) {
+                    Ok(replacement) => Ok::<_, Infallible>(replacement),
+                    Err(message) => {
+                        panic!("CancelRequest must be phase legal before startup: {message:?}")
+                    }
+                }
+            });
+        assert!(matches!(
+            pre_startup
+                .receive_pre_startup_typed(&mut pre_startup_middleware)
+                .await,
+            Err(TypedReceiveError::InvalidWire(
+                PreStartupMessage::CancelRequest { .. }
+            ))
+        ));
+        pre_startup.into_transport();
+    }
+
+    #[tokio::test]
+    async fn typed_receive_preserves_middleware_errors_for_every_wire_family() {
+        let (backend_side, mut server) = tokio::io::duplex(128);
+        let mut backend_bytes = BytesMut::new();
+        PgCodec::<Backend>::default()
+            .encode(
+                BackendMessage::ParameterStatus {
+                    name: Bytes::from_static(b"application_name"),
+                    value: Bytes::from_static(b"upstream"),
+                }
+                .to_frame()
+                .expect("reconstructable ParameterStatus"),
+                &mut backend_bytes,
+            )
+            .expect("encodable ParameterStatus");
+        server
+            .write_all(&backend_bytes)
+            .await
+            .expect("writable server");
+        let mut backend: Conn<_, crate::auth::Ready> =
+            Conn::new(Buffered::new(backend_side)).transition();
+        let mut backend_middleware = Middleware::new((), async |_state: &mut (), _message| {
+            Err::<crate::middleware::TypedBackendMessage<frontend::ReadyExternalMessage>, _>(
+                "blocked",
+            )
+        });
+        assert!(matches!(
+            backend.receive_backend_typed(&mut backend_middleware).await,
+            Err(TypedReceiveError::Middleware("blocked"))
+        ));
+        backend.into_transport();
+
+        let (frontend_side, mut client) = tokio::io::duplex(128);
+        let mut frontend_bytes = BytesMut::new();
+        PgCodec::<Frontend>::default()
+            .encode(
+                FrontendMessage::Query(Bytes::from_static(b"select 1"))
+                    .to_frame()
+                    .expect("reconstructable Query"),
+                &mut frontend_bytes,
+            )
+            .expect("encodable Query");
+        client
+            .write_all(&frontend_bytes)
+            .await
+            .expect("writable client");
+        let mut frontend: Conn<_, crate::auth::Ready> =
+            Conn::new(Buffered::<_, Frontend>::new_frontend(frontend_side)).transition();
+        let mut frontend_middleware = Middleware::new((), async |_state: &mut (), _message| {
+            Err::<backend::ReadyExternalMessage, _>("blocked")
+        });
+        assert!(matches!(
+            frontend
+                .receive_frontend_typed(&mut frontend_middleware)
+                .await,
+            Err(TypedReceiveError::Middleware("blocked"))
+        ));
+        frontend.into_transport();
+
+        let (pre_startup_side, mut client) = tokio::io::duplex(128);
+        client
+            .write_all(
+                &PreStartupMessage::SslRequest
+                    .to_packet()
+                    .expect("encodable SSLRequest"),
+            )
+            .await
+            .expect("writable client");
+        let mut pre_startup = Conn::new(Buffered::<_, Frontend>::new_frontend(pre_startup_side));
+        let mut pre_startup_middleware = Middleware::new((), async |_state: &mut (), _message| {
+            Err::<server_pre_startup::PreStartupExternalMessage, _>("blocked")
+        });
+        assert!(matches!(
+            pre_startup
+                .receive_pre_startup_typed(&mut pre_startup_middleware)
+                .await,
+            Err(TypedReceiveError::Middleware("blocked"))
+        ));
+        pre_startup.into_transport();
+
+        let (encryption_side, mut server) = tokio::io::duplex(16);
+        server.write_all(b"S").await.expect("writable server");
+        let mut encryption: Conn<_, AwaitingSslReply> =
+            Conn::new(Buffered::new(encryption_side)).transition();
+        let mut encryption_middleware = Middleware::new((), async |_state: &mut (), _message| {
+            Err::<pre_startup_grammar::AwaitingSslReplyExternalMessage, _>("blocked")
+        });
+        assert!(matches!(
+            encryption
+                .receive_encryption_reply_typed(&mut encryption_middleware)
+                .await,
+            Err(TypedReceiveError::Middleware("blocked"))
+        ));
+        encryption.into_transport();
     }
 
     #[tokio::test]
@@ -1436,6 +1745,64 @@ mod tests {
             expected
         );
         conn.into_transport();
+    }
+
+    #[tokio::test]
+    async fn runtime_checked_receive_rejects_illegal_backend_and_pre_startup_messages() {
+        let (backend_side, mut server) = tokio::io::duplex(64);
+        let mut backend_bytes = BytesMut::new();
+        PgCodec::<Backend>::default()
+            .encode(
+                BackendMessage::ParseComplete
+                    .to_frame()
+                    .expect("reconstructable ParseComplete"),
+                &mut backend_bytes,
+            )
+            .expect("encodable ParseComplete");
+        server
+            .write_all(&backend_bytes)
+            .await
+            .expect("writable server");
+        let mut backend = Conn::new(Buffered::new(backend_side));
+        let mut backend_middleware = Middleware::new((), crate::middleware::Identity);
+
+        assert!(matches!(
+            backend
+                .receive_backend_wire_with_middleware(
+                    &mut backend_middleware,
+                    &frontend::RuntimeState::Ready,
+                )
+                .await,
+            Err(ReceiveError::Intercept(InterceptError::Invalid(
+                BackendMessage::ParseComplete
+            )))
+        ));
+        backend.into_transport();
+
+        let (pre_startup_side, mut client) = tokio::io::duplex(64);
+        client
+            .write_all(
+                &PreStartupMessage::SslRequest
+                    .to_packet()
+                    .expect("encodable SSLRequest"),
+            )
+            .await
+            .expect("writable client");
+        let mut pre_startup = Conn::new(Buffered::<_, Frontend>::new_frontend(pre_startup_side));
+        let mut pre_startup_middleware = Middleware::new((), crate::middleware::Identity);
+
+        assert!(matches!(
+            pre_startup
+                .receive_pre_startup_wire_with_middleware(
+                    &mut pre_startup_middleware,
+                    &server_pre_startup::RuntimeState::SslDecision,
+                )
+                .await,
+            Err(ReceiveError::Intercept(InterceptError::Invalid(
+                PreStartupMessage::SslRequest
+            )))
+        ));
+        pre_startup.into_transport();
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- centralise typed inbound receipt, phase legality, middleware, and reconstruction validation
- centralise runtime-checked receipt while preserving the separate projection boundary
- cover all wire families, error ordering, non-projection, and owned payload recovery at the public Conn seam

## Verification

- cargo test --lib transport::tests
- cargo test --workspace (path-sensitive trybuild suites verified separately)
- cargo clippy --workspace --all-targets -- -D warnings
- RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps
- cargo package --workspace --allow-dirty

Closes #25