### PR TITLE
ci: preserve explicit Rust toolchain policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,11 +134,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install development Rust
-        uses: dtolnay/rust-toolchain@1.97.1
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: 1.97.1
           components: clippy, rustfmt
 
       - name: Check formatting
@@ -176,10 +177,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install development Rust
-        uses: dtolnay/rust-toolchain@1.97.1
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.97.1
 
       - name: Run all benchmarks
         run: cargo bench --workspace
@@ -193,10 +196,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install minimum supported Rust
-        uses: dtolnay/rust-toolchain@1.88.0
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.88.0
 
       - name: Check every workspace target
         run: cargo check --workspace --all-targets
@@ -210,10 +215,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install development Rust
-        uses: dtolnay/rust-toolchain@1.97.1
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.97.1
 
       - name: Verify publishable packages
         run: cargo package --workspace
@@ -236,7 +243,7 @@ jobs:
           - runtime_fsm
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install nightly Rust
         uses: dtolnay/rust-toolchain@nightly

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,6 +12,8 @@ jobs:
     env:
       RUSTDOCFLAGS: -D warnings
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.97.1
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.97.1
       - run: cargo doc --workspace --no-deps

--- a/.github/workflows/postgres-compatibility.yml
+++ b/.github/workflows/postgres-compatibility.yml
@@ -18,7 +18,9 @@ jobs:
     env:
       PG_PROTO_POSTGRES_VERSION: ${{ matrix.version }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.97.1
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.97.1
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --lib internal_tests::postgres_container -- --ignored

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -17,13 +17,15 @@ jobs:
       pull-requests: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Install development Rust
-        uses: dtolnay/rust-toolchain@1.97.1
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.97.1
 
       - name: Publish release
         uses: release-plz/action@v0.5
@@ -43,13 +45,15 @@ jobs:
       cancel-in-progress: false
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Install development Rust
-        uses: dtolnay/rust-toolchain@1.97.1
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.97.1
 
       - name: Prepare release pull request
         uses: release-plz/action@v0.5

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,7 +13,7 @@ jobs:
     name: RustSec audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: rustsec/audit-check@v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -22,6 +22,6 @@ jobs:
     name: Dependency policy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: taiki-e/install-action@cargo-deny
       - run: cargo deny check

--- a/README.md
+++ b/README.md
@@ -310,6 +310,26 @@ PG_PROTO_POSTGRES_VERSION=18 \
 See [`SUPPORTED_VERSIONS.md`](SUPPORTED_VERSIONS.md) for the tested protocol
 matrix.
 
+## PostgreSQL wire protocol documentation
+
+The primary reference for the wire protocol is PostgreSQL's official
+[Frontend/Backend Protocol documentation](https://www.postgresql.org/docs/current/protocol.html).
+Its key sections are:
+
+- [Message flow](https://www.postgresql.org/docs/current/protocol-flow.html) —
+  connections, authentication, queries, `COPY`, and cancellation.
+- [Message formats](https://www.postgresql.org/docs/current/protocol-message-formats.html) —
+  byte-level packet layouts.
+- [Message data types](https://www.postgresql.org/docs/current/protocol-message-types.html) —
+  integer, string, and byte encodings.
+- [SASL/SCRAM authentication](https://www.postgresql.org/docs/current/sasl-authentication.html) —
+  modern password authentication.
+
+> **Compatibility note:** PostgreSQL 18 introduced protocol 3.2, but most
+> clients still negotiate version 3.0 for compatibility. Read the documentation
+> for the oldest PostgreSQL version you intend to support, and use an
+> established driver's source code as an executable reference.
+
 ## Known limitations
 
 - The API is pre-1.0 and may change as it is integrated into a production proxy.


### PR DESCRIPTION
## Summary
- upgrade actions/checkout independently to v7
- select fixed Rust compilers through the rust-toolchain action's explicit toolchain input
- keep the MSRV verification pinned to Rust 1.88.0
- prevent Dependabot from mistaking compiler versions for action versions

Replaces #5, which would have changed the MSRV job to Rust 1.100.0.

## Verification
- parsed every workflow as YAML
- git diff --check