### PR TITLE
docs: illustrate modes of operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,38 @@ operations are visible in function signatures, illegal compositions are rejected
 at compile time, and proxy policy can still inspect, replace, or reject complete
 typed messages.
 
+## Modes of operation
+
+`pg-proto` supports three role-composition archetypes. “External” means a real
+PostgreSQL database, an established driver, or any other participant that speaks
+the PostgreSQL frontend/backend wire protocol.
+
+### Client role
+
+![pg-proto client connected to an external server](docs/images/client-mode.svg)
+
+`pg-proto` initiates the connection and acts as the protocol client. The external
+server is commonly PostgreSQL itself, but may be any compatible server.
+
+### Server role
+
+![external client connected to a pg-proto server](docs/images/server-mode.svg)
+
+An external client initiates the connection and `pg-proto` acts as the protocol
+server. This mode suits PostgreSQL-compatible services, test backends, recorders,
+and protocol conformance tools.
+
+### Intermediary role
+
+![external client connected through a pg-proto intermediary to an external server](docs/images/intermediary-mode.svg)
+
+`pg-proto` terminates both protocol roles around an intermediary: its server side
+accepts the external client, while its client side establishes an independent
+connection to the external server. Middleware can inspect, edit, replace, or
+reject messages in either direction. Startup and authenticated routing policies
+can select or refine the destination for sharding, tenancy isolation, regional
+routing, or other application-owned placement decisions.
+
 ## What it provides
 
 - Direction-parameterised frontend and backend codecs. Ambiguous tags such as

--- a/docs/images/client-mode.svg
+++ b/docs/images/client-mode.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 220" role="img" aria-labelledby="title description">
+  <title id="title">pg-proto client connected to an external server</title>
+  <desc id="description">A labelled pg-proto Client circle connected by bidirectional arrows to a labelled external Server circle.</desc>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="context-stroke"/>
+    </marker>
+    <style>
+      .node { fill: #f6f8fa; stroke: #24292f; stroke-width: 3; }
+      .link { stroke: #57606a; stroke-width: 4; marker-start: url(#arrow); marker-end: url(#arrow); }
+      .role { fill: #24292f; font: 600 22px system-ui, sans-serif; text-anchor: middle; }
+      .owner { fill: #57606a; font: 17px system-ui, sans-serif; text-anchor: middle; }
+      @media (prefers-color-scheme: dark) {
+        .node { fill: #161b22; stroke: #f0f6fc; }
+        .link { stroke: #8c959f; }
+        .role { fill: #f0f6fc; }
+        .owner { fill: #b1bac4; }
+      }
+    </style>
+  </defs>
+  <line class="link" x1="295" y1="110" x2="605" y2="110"/>
+  <circle class="node" cx="190" cy="110" r="92"/>
+  <circle class="node" cx="710" cy="110" r="92"/>
+  <text class="role" x="190" y="104">Client</text>
+  <text class="owner" x="190" y="133">pg-proto</text>
+  <text class="role" x="710" y="104">Server</text>
+  <text class="owner" x="710" y="133">external</text>
+</svg>

--- a/docs/images/intermediary-mode.svg
+++ b/docs/images/intermediary-mode.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1400 250" role="img" aria-labelledby="title description">
+  <title id="title">External client connected through pg-proto to an external server</title>
+  <desc id="description">Five labelled circles show an external Client, pg-proto Server, pg-proto Intermediary, pg-proto Client, and external Server connected by bidirectional arrows.</desc>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="context-stroke"/>
+    </marker>
+    <style>
+      .node { fill: #f6f8fa; stroke: #24292f; stroke-width: 3; }
+      .boundary { fill: #ddf4ff; stroke: #0969da; }
+      .link { stroke: #57606a; stroke-width: 4; marker-start: url(#arrow); marker-end: url(#arrow); }
+      .role { fill: #24292f; font: 600 19px system-ui, sans-serif; text-anchor: middle; }
+      .owner { fill: #57606a; font: 15px system-ui, sans-serif; text-anchor: middle; }
+      @media (prefers-color-scheme: dark) {
+        .node { fill: #161b22; stroke: #f0f6fc; }
+        .boundary { fill: #0c2d4a; stroke: #58a6ff; }
+        .link { stroke: #8c959f; }
+        .role { fill: #f0f6fc; }
+        .owner { fill: #b1bac4; }
+      }
+    </style>
+  </defs>
+  <line class="link" x1="230" y1="125" x2="350" y2="125"/>
+  <line class="link" x1="510" y1="125" x2="620" y2="125"/>
+  <line class="link" x1="780" y1="125" x2="890" y2="125"/>
+  <line class="link" x1="1050" y1="125" x2="1170" y2="125"/>
+  <circle class="node" cx="145" cy="125" r="82"/>
+  <circle class="node boundary" cx="430" cy="125" r="82"/>
+  <circle class="node boundary" cx="700" cy="125" r="82"/>
+  <circle class="node boundary" cx="970" cy="125" r="82"/>
+  <circle class="node" cx="1255" cy="125" r="82"/>
+  <text class="role" x="145" y="119">Client</text>
+  <text class="owner" x="145" y="145">external</text>
+  <text class="role" x="430" y="119">Server</text>
+  <text class="owner" x="430" y="145">pg-proto</text>
+  <text class="role" x="700" y="119">Intermediary</text>
+  <text class="owner" x="700" y="145">pg-proto</text>
+  <text class="role" x="970" y="119">Client</text>
+  <text class="owner" x="970" y="145">pg-proto</text>
+  <text class="role" x="1255" y="119">Server</text>
+  <text class="owner" x="1255" y="145">external</text>
+</svg>

--- a/docs/images/server-mode.svg
+++ b/docs/images/server-mode.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 220" role="img" aria-labelledby="title description">
+  <title id="title">External client connected to a pg-proto server</title>
+  <desc id="description">A labelled external Client circle connected by bidirectional arrows to a labelled pg-proto Server circle.</desc>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="context-stroke"/>
+    </marker>
+    <style>
+      .node { fill: #f6f8fa; stroke: #24292f; stroke-width: 3; }
+      .link { stroke: #57606a; stroke-width: 4; marker-start: url(#arrow); marker-end: url(#arrow); }
+      .role { fill: #24292f; font: 600 22px system-ui, sans-serif; text-anchor: middle; }
+      .owner { fill: #57606a; font: 17px system-ui, sans-serif; text-anchor: middle; }
+      @media (prefers-color-scheme: dark) {
+        .node { fill: #161b22; stroke: #f0f6fc; }
+        .link { stroke: #8c959f; }
+        .role { fill: #f0f6fc; }
+        .owner { fill: #b1bac4; }
+      }
+    </style>
+  </defs>
+  <line class="link" x1="295" y1="110" x2="605" y2="110"/>
+  <circle class="node" cx="190" cy="110" r="92"/>
+  <circle class="node" cx="710" cy="110" r="92"/>
+  <text class="role" x="190" y="104">Client</text>
+  <text class="owner" x="190" y="133">external</text>
+  <text class="role" x="710" y="104">Server</text>
+  <text class="owner" x="710" y="133">pg-proto</text>
+</svg>


### PR DESCRIPTION
## Summary

- add a near-top README section describing the client, server, and intermediary archetypes
- illustrate each archetype with an accessible SVG diagram
- explain how intermediary mode supports bidirectional message policy and application-owned routing

## Verification

- cargo test --workspace --doc
- cargo test --test documentation_audit
- RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps
- xmllint --noout docs/images/client-mode.svg docs/images/server-mode.svg docs/images/intermediary-mode.svg
- git diff --check