### PR TITLE
feat: expose async intermediary middleware decisions

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -137,6 +137,21 @@ Cancellation resolves this mapping directly, without startup routing. Call
 Establishment failures close silently by default; `SafeDiagnostic` emits one
 fixed, non-disclosing error through outbound server middleware before closing.
 
+Forwarding-boundary middleware is now asynchronous and fallible. Implement
+`IntermediaryMiddleware::frontend` and `backend` by returning a borrowed boxed
+future and declare the handler's `Error` type. Return
+`FrontendMiddlewareOutput::Forward` for replacement, `Suppress` to consume a
+message, or `Respond` to register a locally handled operation and provide its
+ordered backend responses. Backend middleware returns
+`BackendMiddlewareOutput::Forward` or `Suppress`.
+
+`forward_frontend` and `forward_backend` now return `FrontendForwarding` and
+`BackendForwarding`, respectively. Match these outcomes when application code
+needs the forwarding decision, or call `into_message` when only the owned
+message matters. A middleware failure is preserved as `ForwardError::Middleware`;
+locally generated responses remain owned by the connection and are emitted only
+when the pipeline ledger reaches their operation.
+
 ## Errors, COPY, and pooling
 
 After `ErrorResponse`, keep the returned `Draining` connection and consume only

--- a/PLAN.md
+++ b/PLAN.md
@@ -281,6 +281,14 @@ neutral composition harnesses and examples.
 
 ## Stateful message middleware
 
+- [x] Expose asynchronous, fallible intermediary-boundary middleware through
+  the builder facade.
+  - [x] Support owned forward, suppress, and locally respond decisions.
+  - [x] Preserve application errors in the public forwarding error layer.
+  - [x] Admit local operations and emit generated responses through the
+    connection-owned pipeline without allowing response reordering.
+  - [x] Report forwarding outcomes through the duplex and directional drivers.
+
 - [x] Move the examples' protocol observation and rewriting mechanism into a
   policy-neutral core `middleware` module.
   - [x] Define direction-specific middleware for owned `FrontendMessage` and

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ## Stateful message middleware
 
-A proxy can inspect or replace owned frontend and backend messages through
+A role component can inspect or replace owned messages through synchronous
 builder middleware. Each accepted connection gets a fresh handler with mutable
 access to the application-supplied per-connection state. Repeated `.middleware`
 calls compose stages in declaration order.
@@ -305,6 +305,19 @@ let _client = Client::builder()
     .build()?;
 # Ok::<(), pg_proto::BuildError>(())
 ```
+
+Forwarding-boundary middleware configured by `Intermediary::builder()` is
+asynchronous and fallible. Its frontend decision can forward a replacement,
+suppress the owned message, or handle the operation locally with an ordered list
+of backend responses. Its backend decision can forward a replacement or
+suppress the response after protocol state advances. `IntermediaryConnection`
+admits local operations and emits their responses through its connection-owned
+pipeline, so they cannot overtake earlier PostgreSQL responses. Middleware
+failures retain their application error in `ForwardError::Middleware`.
+
+`forward_frontend()` and `forward_backend()` report whether traffic was
+forwarded, suppressed, or locally handled; `forward_next()` reports the same
+decisions while driving both directions.
 
 For a complete networked example, see the TLS-terminating
 [`SQL logging proxy`](examples/sql_logging_proxy/README.md). The companion

--- a/docs/public-api.txt
+++ b/docs/public-api.txt
@@ -16,8 +16,9 @@ pub use codec::{
 pub use demux::CancelKey;
 pub use intermediary_component::{
     AllowAuthenticatedRoute, AuthenticatedRouteContext, AuthenticatedRoutePolicy,
-    CancellationPolicy, CancellationRoute, EstablishmentFailurePolicy, ForwardError,
-    ForwardedMessage, IdentityIntermediaryMiddleware, InitialServerContext, Intermediary,
+    BackendForwarding, BackendMiddlewareOutput, CancellationPolicy, CancellationRoute,
+    EstablishmentFailurePolicy, ForwardError, ForwardedMessage, FrontendForwarding,
+    FrontendMiddlewareOutput, IdentityIntermediaryMiddleware, InitialServerContext, Intermediary,
     IntermediaryAccept, IntermediaryAcceptError, IntermediaryBuildError, IntermediaryBuilder,
     IntermediaryCancellationRegistry, IntermediaryConnection, IntermediaryContexts,
     IntermediaryMiddleware, IntermediaryMiddlewareFactory, RejectCancellation,

--- a/examples/intermediary_pipeline.rs
+++ b/examples/intermediary_pipeline.rs
@@ -56,7 +56,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     loop {
         if matches!(
             session.forward_frontend().await?,
-            pg_proto::FrontendMessage::Terminate
+            pg_proto::FrontendForwarding::Forwarded(pg_proto::FrontendMessage::Terminate)
         ) {
             return Ok(());
         }
@@ -66,14 +66,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             ))) => {
                 println!("capacity reached: the second owned request is retained");
             }
-            Ok(pg_proto::FrontendMessage::Terminate) => return Ok(()),
+            Ok(pg_proto::FrontendForwarding::Forwarded(pg_proto::FrontendMessage::Terminate)) => {
+                return Ok(());
+            }
             Ok(_) => unreachable!("capacity one must reject a second outstanding operation"),
             Err(error) => return Err(error.into()),
         }
         loop {
             if matches!(
                 session.forward_backend().await?,
-                pg_proto::BackendMessage::ReadyForQuery(_)
+                pg_proto::BackendForwarding::Forwarded(pg_proto::BackendMessage::ReadyForQuery(_))
             ) {
                 break;
             }

--- a/examples/protocol_logging_proxy/main.rs
+++ b/examples/protocol_logging_proxy/main.rs
@@ -34,26 +34,43 @@ impl
         ClientConnectionContext<()>,
     > for ProtocolLogger
 {
-    fn frontend(
-        &mut self,
-        _: &ServerConnectionContext<SocketAddr, TrustIdentity>,
-        _: &ClientConnectionContext<()>,
-        state: &mut ProtocolState,
+    type Error = std::convert::Infallible;
+
+    fn frontend<'a>(
+        &'a mut self,
+        _: &'a ServerConnectionContext<SocketAddr, TrustIdentity>,
+        _: &'a ClientConnectionContext<()>,
+        state: &'a mut ProtocolState,
         message: FrontendMessage,
-    ) -> FrontendMessage {
-        println!("[{}] client -> server: {message:?}", state.connection);
-        message
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<
+                    Output = Result<pg_proto::FrontendMiddlewareOutput, Self::Error>,
+                > + 'a,
+        >,
+    > {
+        Box::pin(async move {
+            println!("[{}] client -> server: {message:?}", state.connection);
+            Ok(pg_proto::FrontendMiddlewareOutput::Forward(message))
+        })
     }
 
-    fn backend(
-        &mut self,
-        _: &ServerConnectionContext<SocketAddr, TrustIdentity>,
-        _: &ClientConnectionContext<()>,
-        state: &mut ProtocolState,
+    fn backend<'a>(
+        &'a mut self,
+        _: &'a ServerConnectionContext<SocketAddr, TrustIdentity>,
+        _: &'a ClientConnectionContext<()>,
+        state: &'a mut ProtocolState,
         message: BackendMessage,
-    ) -> BackendMessage {
-        println!("[{}] server -> client: {message:?}", state.connection);
-        message
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<Output = Result<pg_proto::BackendMiddlewareOutput, Self::Error>>
+                + 'a,
+        >,
+    > {
+        Box::pin(async move {
+            println!("[{}] server -> client: {message:?}", state.connection);
+            Ok(pg_proto::BackendMiddlewareOutput::Forward(message))
+        })
     }
 }
 

--- a/examples/rewriting_intermediary.rs
+++ b/examples/rewriting_intermediary.rs
@@ -32,38 +32,56 @@ impl
         ClientConnectionContext<()>,
     > for Rewrite
 {
-    fn frontend(
-        &mut self,
-        _: &ServerConnectionContext<(), TrustIdentity>,
-        _: &ClientConnectionContext<()>,
-        (): &mut (),
+    type Error = std::convert::Infallible;
+
+    fn frontend<'a>(
+        &'a mut self,
+        _: &'a ServerConnectionContext<(), TrustIdentity>,
+        _: &'a ClientConnectionContext<()>,
+        (): &'a mut (),
         message: FrontendMessage,
-    ) -> FrontendMessage {
-        match message {
-            FrontendMessage::Query(_) => FrontendMessage::Query(Bytes::from_static(
-                b"select amount from ledger where visible = true",
-            )),
-            FrontendMessage::Parse(mut parse) => {
-                parse.query = Bytes::from_static(b"select amount from ledger where visible = true");
-                FrontendMessage::Parse(parse)
-            }
-            other => other,
-        }
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<
+                    Output = Result<pg_proto::FrontendMiddlewareOutput, Self::Error>,
+                > + 'a,
+        >,
+    > {
+        Box::pin(async move {
+            Ok(pg_proto::FrontendMiddlewareOutput::Forward(match message {
+                FrontendMessage::Query(_) => FrontendMessage::Query(Bytes::from_static(
+                    b"select amount from ledger where visible = true",
+                )),
+                FrontendMessage::Parse(mut parse) => {
+                    parse.query =
+                        Bytes::from_static(b"select amount from ledger where visible = true");
+                    FrontendMessage::Parse(parse)
+                }
+                other => other,
+            }))
+        })
     }
-    fn backend(
-        &mut self,
-        _: &ServerConnectionContext<(), TrustIdentity>,
-        _: &ClientConnectionContext<()>,
-        (): &mut (),
+    fn backend<'a>(
+        &'a mut self,
+        _: &'a ServerConnectionContext<(), TrustIdentity>,
+        _: &'a ClientConnectionContext<()>,
+        (): &'a mut (),
         message: BackendMessage,
-    ) -> BackendMessage {
-        match message {
-            BackendMessage::RowDescription(mut rows) if !rows.fields.is_empty() => {
-                rows.fields[0].name = Bytes::from_static(b"visible_amount");
-                BackendMessage::RowDescription(rows)
-            }
-            other => other,
-        }
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<Output = Result<pg_proto::BackendMiddlewareOutput, Self::Error>>
+                + 'a,
+        >,
+    > {
+        Box::pin(async move {
+            Ok(pg_proto::BackendMiddlewareOutput::Forward(match message {
+                BackendMessage::RowDescription(mut rows) if !rows.fields.is_empty() => {
+                    rows.fields[0].name = Bytes::from_static(b"visible_amount");
+                    BackendMessage::RowDescription(rows)
+                }
+                other => other,
+            }))
+        })
     }
 }
 

--- a/examples/sql_logging_proxy/main.rs
+++ b/examples/sql_logging_proxy/main.rs
@@ -56,45 +56,62 @@ impl
         ClientConnectionContext<()>,
     > for SqlLogger
 {
-    fn frontend(
-        &mut self,
-        _: &ServerConnectionContext<SocketAddr, TrustIdentity>,
-        _: &ClientConnectionContext<()>,
-        state: &mut SqlState,
+    type Error = std::convert::Infallible;
+
+    fn frontend<'a>(
+        &'a mut self,
+        _: &'a ServerConnectionContext<SocketAddr, TrustIdentity>,
+        _: &'a ClientConnectionContext<()>,
+        state: &'a mut SqlState,
         message: FrontendMessage,
-    ) -> FrontendMessage {
-        if let FrontendMessage::Query(sql)
-        | FrontendMessage::Parse(pg_proto::Parse { query: sql, .. }) = &message
-        {
-            (state.reporter)(Observation::Sql {
-                connection: state.connection,
-                statement: String::from_utf8_lossy(sql).into_owned(),
-            });
-        }
-        message
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<
+                    Output = Result<pg_proto::FrontendMiddlewareOutput, Self::Error>,
+                > + 'a,
+        >,
+    > {
+        Box::pin(async move {
+            if let FrontendMessage::Query(sql)
+            | FrontendMessage::Parse(pg_proto::Parse { query: sql, .. }) = &message
+            {
+                (state.reporter)(Observation::Sql {
+                    connection: state.connection,
+                    statement: String::from_utf8_lossy(sql).into_owned(),
+                });
+            }
+            Ok(pg_proto::FrontendMiddlewareOutput::Forward(message))
+        })
     }
 
-    fn backend(
-        &mut self,
-        _: &ServerConnectionContext<SocketAddr, TrustIdentity>,
-        _: &ClientConnectionContext<()>,
-        state: &mut SqlState,
+    fn backend<'a>(
+        &'a mut self,
+        _: &'a ServerConnectionContext<SocketAddr, TrustIdentity>,
+        _: &'a ClientConnectionContext<()>,
+        state: &'a mut SqlState,
         message: BackendMessage,
-    ) -> BackendMessage {
-        match &message {
-            BackendMessage::DataRow(_) => state.rows = state.rows.saturating_add(1),
-            BackendMessage::CommandComplete(tag) => {
-                (state.reporter)(Observation::RowCount {
-                    connection: state.connection,
-                    rows: state.rows,
-                    command: String::from_utf8_lossy(tag).into_owned(),
-                });
-                state.rows = 0;
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<Output = Result<pg_proto::BackendMiddlewareOutput, Self::Error>>
+                + 'a,
+        >,
+    > {
+        Box::pin(async move {
+            match &message {
+                BackendMessage::DataRow(_) => state.rows = state.rows.saturating_add(1),
+                BackendMessage::CommandComplete(tag) => {
+                    (state.reporter)(Observation::RowCount {
+                        connection: state.connection,
+                        rows: state.rows,
+                        command: String::from_utf8_lossy(tag).into_owned(),
+                    });
+                    state.rows = 0;
+                }
+                BackendMessage::ErrorResponse(_) => state.rows = 0,
+                _ => {}
             }
-            BackendMessage::ErrorResponse(_) => state.rows = 0,
-            _ => {}
-        }
-        message
+            Ok(pg_proto::BackendMiddlewareOutput::Forward(message))
+        })
     }
 }
 

--- a/src/intermediary_component.rs
+++ b/src/intermediary_component.rs
@@ -1,6 +1,6 @@
 //! Builder-centred composition of the client-facing and PostgreSQL-facing roles.
 
-use std::{fmt, future::Future, io, pin::Pin};
+use std::{collections::VecDeque, fmt, future::Future, io, pin::Pin};
 
 use tokio::io::{AsyncRead, AsyncWrite};
 
@@ -219,30 +219,58 @@ impl<Peer, Identity> AuthenticatedRoutePolicy<Peer, Identity> for AllowAuthentic
     }
 }
 
-/// Middleware at the forwarding boundary between the two role components.
+/// Result of asynchronously intercepting a client-originated message.
+#[derive(Debug, Eq, PartialEq)]
+pub enum FrontendMiddlewareOutput {
+    /// Forward this owned message to PostgreSQL.
+    Forward(crate::codec::FrontendMessage),
+    /// Consume the message without forwarding it or registering a response.
+    Suppress(crate::codec::FrontendMessage),
+    /// Handle the request locally and emit these responses in protocol order.
+    Respond {
+        /// Consumed client request.
+        request: crate::codec::FrontendMessage,
+        /// Responses generated for this request, in emission order.
+        responses: Vec<crate::codec::BackendMessage>,
+    },
+}
+
+/// Result of asynchronously intercepting a PostgreSQL-originated message.
+#[derive(Debug, Eq, PartialEq)]
+pub enum BackendMiddlewareOutput {
+    /// Forward this owned message to the client.
+    Forward(crate::codec::BackendMessage),
+    /// Consume the response after advancing protocol and pipeline state.
+    Suppress(crate::codec::BackendMessage),
+}
+
+/// Asynchronous, fallible middleware at the forwarding boundary.
 pub trait IntermediaryMiddleware<State, ServerContext, ClientContext> {
+    /// Application-defined interception failure.
+    type Error;
+
     /// Intercepts a client-originated message after server-role middleware and
     /// before client-role middleware.
-    fn frontend(
-        &mut self,
-        _server: &ServerContext,
-        _client: &ClientContext,
-        _state: &mut State,
+    fn frontend<'a>(
+        &'a mut self,
+        _server: &'a ServerContext,
+        _client: &'a ClientContext,
+        _state: &'a mut State,
         message: crate::codec::FrontendMessage,
-    ) -> crate::codec::FrontendMessage {
-        message
+    ) -> Pin<Box<dyn Future<Output = Result<FrontendMiddlewareOutput, Self::Error>> + 'a>> {
+        Box::pin(async move { Ok(FrontendMiddlewareOutput::Forward(message)) })
     }
 
     /// Intercepts a PostgreSQL-originated message after client-role middleware
     /// and before server-role middleware.
-    fn backend(
-        &mut self,
-        _server: &ServerContext,
-        _client: &ClientContext,
-        _state: &mut State,
+    fn backend<'a>(
+        &'a mut self,
+        _server: &'a ServerContext,
+        _client: &'a ClientContext,
+        _state: &'a mut State,
         message: crate::codec::BackendMessage,
-    ) -> crate::codec::BackendMessage {
-        message
+    ) -> Pin<Box<dyn Future<Output = Result<BackendMiddlewareOutput, Self::Error>> + 'a>> {
+        Box::pin(async move { Ok(BackendMiddlewareOutput::Forward(message)) })
     }
 }
 
@@ -253,6 +281,7 @@ pub struct IdentityIntermediaryMiddleware;
 impl<State, ServerContext, ClientContext>
     IntermediaryMiddleware<State, ServerContext, ClientContext> for IdentityIntermediaryMiddleware
 {
+    type Error = std::convert::Infallible;
 }
 
 /// Creates fresh forwarding-boundary middleware for one established pair.
@@ -603,6 +632,7 @@ pub enum IntermediaryAcceptError<
     ClientError,
     RegistryError = std::convert::Infallible,
     CancellationError = std::convert::Infallible,
+    MiddlewareError = std::convert::Infallible,
 > {
     /// Client-facing TLS, startup, or authentication failed.
     Server(ServerError),
@@ -620,9 +650,11 @@ pub enum IntermediaryAcceptError<
     ServerOutput(io::Error),
     /// Opening or writing the one-shot upstream cancellation connection failed.
     Cancellation(CancellationError),
+    /// Forwarding-boundary middleware rejected generated establishment output.
+    Middleware(MiddlewareError),
 }
 
-impl<S, R, A, C, K, X> fmt::Debug for IntermediaryAcceptError<S, R, A, C, K, X> {
+impl<S, R, A, C, K, X, M> fmt::Debug for IntermediaryAcceptError<S, R, A, C, K, X, M> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str(match self {
             Self::Server(_) => "IntermediaryAcceptError::Server([REDACTED])",
@@ -637,11 +669,12 @@ impl<S, R, A, C, K, X> fmt::Debug for IntermediaryAcceptError<S, R, A, C, K, X> 
             }
             Self::ServerOutput(_) => "IntermediaryAcceptError::ServerOutput([REDACTED])",
             Self::Cancellation(_) => "IntermediaryAcceptError::Cancellation([REDACTED])",
+            Self::Middleware(_) => "IntermediaryAcceptError::Middleware([REDACTED])",
         })
     }
 }
 
-impl<S, R, A, C, K, X> fmt::Display for IntermediaryAcceptError<S, R, A, C, K, X> {
+impl<S, R, A, C, K, X, M> fmt::Display for IntermediaryAcceptError<S, R, A, C, K, X, M> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Server(_) => formatter.write_str("client-facing establishment failed"),
@@ -658,11 +691,14 @@ impl<S, R, A, C, K, X> fmt::Display for IntermediaryAcceptError<S, R, A, C, K, X
                 formatter.write_str("client-facing establishment output failed")
             }
             Self::Cancellation(_) => formatter.write_str("cancellation forwarding failed"),
+            Self::Middleware(_) => {
+                formatter.write_str("forwarding middleware rejected establishment output")
+            }
         }
     }
 }
 
-impl<S, R, A, C, K, X> std::error::Error for IntermediaryAcceptError<S, R, A, C, K, X>
+impl<S, R, A, C, K, X, M> std::error::Error for IntermediaryAcceptError<S, R, A, C, K, X, M>
 where
     S: std::error::Error + 'static,
     R: std::error::Error + 'static,
@@ -670,6 +706,7 @@ where
     C: std::error::Error + 'static,
     K: std::error::Error + 'static,
     X: std::error::Error + 'static,
+    M: std::error::Error + 'static,
 {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
@@ -681,6 +718,7 @@ where
             Self::CancellationRegistry(error) => Some(error),
             Self::ServerOutput(error) => Some(error),
             Self::Cancellation(error) => Some(error),
+            Self::Middleware(error) => Some(error),
         }
     }
 }
@@ -732,8 +770,14 @@ pub struct IntermediaryConnection<
     pipeline: Pipeline<Policy>,
     target: ConnectTarget,
     pending_frontend: Option<crate::codec::FrontendMessage>,
+    pending_local: VecDeque<PendingLocalResponses>,
     cancellation_registry: Cancellation,
     client_cancel_key: Option<crate::demux::CancelKey>,
+}
+
+struct PendingLocalResponses {
+    operation: crate::pipeline::OperationId,
+    messages: VecDeque<crate::codec::BackendMessage>,
 }
 
 /// Result of accepting either an ordinary session or an out-of-band request.
@@ -766,6 +810,54 @@ pub enum ForwardedMessage {
     Frontend(crate::codec::FrontendMessage),
     /// A PostgreSQL-originated message was forwarded to the client.
     Backend(crate::codec::BackendMessage),
+    /// A client-originated message was deliberately suppressed.
+    FrontendSuppressed(crate::codec::FrontendMessage),
+    /// A request was handled locally; responses were emitted or queued in order.
+    FrontendLocallyHandled(crate::codec::FrontendMessage),
+    /// A PostgreSQL-originated response advanced protocol state but was suppressed.
+    BackendSuppressed(crate::codec::BackendMessage),
+}
+
+/// Observable result of processing one client-originated message.
+#[derive(Debug, Eq, PartialEq)]
+pub enum FrontendForwarding {
+    /// The message was sent to PostgreSQL.
+    Forwarded(crate::codec::FrontendMessage),
+    /// The message was consumed without being sent.
+    Suppressed(crate::codec::FrontendMessage),
+    /// The request was admitted as local and its responses were emitted or queued.
+    LocallyHandled(crate::codec::FrontendMessage),
+}
+
+impl FrontendForwarding {
+    /// Returns the owned client message represented by this outcome.
+    #[must_use]
+    pub fn into_message(self) -> crate::codec::FrontendMessage {
+        match self {
+            Self::Forwarded(message)
+            | Self::Suppressed(message)
+            | Self::LocallyHandled(message) => message,
+        }
+    }
+}
+
+/// Observable result of processing one PostgreSQL-originated response.
+#[derive(Debug, Eq, PartialEq)]
+pub enum BackendForwarding {
+    /// The response was sent to the client.
+    Forwarded(crate::codec::BackendMessage),
+    /// The response advanced protocol state but was not sent.
+    Suppressed(crate::codec::BackendMessage),
+}
+
+impl BackendForwarding {
+    /// Returns the owned PostgreSQL response represented by this outcome.
+    #[must_use]
+    pub fn into_message(self) -> crate::codec::BackendMessage {
+        match self {
+            Self::Forwarded(message) | Self::Suppressed(message) => message,
+        }
+    }
 }
 
 impl<DT, UT, State, Peer, SI, CE, SH, CH, Boundary, Policy, K>
@@ -840,15 +932,15 @@ where
     Policy: PipelinePolicy,
     K: IntermediaryCancellationRegistry,
 {
-    /// Receives one legal client message and forwards it upstream in
-    /// source-role, boundary, destination-role middleware order.
+    /// Receives one client message and reports whether it was forwarded,
+    /// suppressed, or handled with pipeline-ordered local responses.
     ///
     /// # Errors
     ///
-    /// Returns transport, framing, protocol-legality, or capacity failures.
+    /// Returns middleware, transport, protocol-legality, or capacity failures.
     pub async fn forward_frontend(
         &mut self,
-    ) -> Result<crate::codec::FrontendMessage, ForwardError> {
+    ) -> Result<FrontendForwarding, ForwardError<Boundary::Error>> {
         if let Some(message) = self.pending_frontend.take() {
             self.process_frontend(message, false).await
         } else {
@@ -861,23 +953,54 @@ where
         &mut self,
         message: crate::codec::FrontendMessage,
         intercept_source_and_boundary: bool,
-    ) -> Result<crate::codec::FrontendMessage, ForwardError> {
-        let message = if intercept_source_and_boundary {
+    ) -> Result<FrontendForwarding, ForwardError<Boundary::Error>> {
+        let decision = if intercept_source_and_boundary {
             let message = self.downstream.intercept_frontend(&mut self.state, message);
-            let message = self.boundary.frontend(
-                self.downstream.context(),
-                self.upstream.context(),
-                &mut self.state,
-                message,
-            );
-            self.upstream.intercept_frontend(&mut self.state, message)
+            self.boundary
+                .frontend(
+                    self.downstream.context(),
+                    self.upstream.context(),
+                    &mut self.state,
+                    message,
+                )
+                .await
+                .map_err(ForwardError::Middleware)?
         } else {
-            message
+            FrontendMiddlewareOutput::Forward(message)
         };
-        let admission = match self
-            .pipeline
-            .accept_frontend(message.clone(), FrontendHandling::Forward)
-        {
+        let (message, handling) = match decision {
+            FrontendMiddlewareOutput::Forward(message) => {
+                let message = if intercept_source_and_boundary {
+                    self.upstream.intercept_frontend(&mut self.state, message)
+                } else {
+                    message
+                };
+                (message, FrontendHandling::Forward)
+            }
+            FrontendMiddlewareOutput::Suppress(message) => {
+                return Ok(FrontendForwarding::Suppressed(message));
+            }
+            FrontendMiddlewareOutput::Respond { request, responses } => {
+                let admission = self
+                    .pipeline
+                    .accept_frontend(request.clone(), FrontendHandling::Local)
+                    .map_err(ForwardError::Frontend)?;
+                let FrontendAction::Discard { id } = admission.into_action() else {
+                    unreachable!()
+                };
+                let messages = responses
+                    .into_iter()
+                    .map(|message| self.downstream.intercept_backend(&mut self.state, message))
+                    .collect();
+                self.pending_local.push_back(PendingLocalResponses {
+                    operation: id,
+                    messages,
+                });
+                self.flush_local_responses().await?;
+                return Ok(FrontendForwarding::LocallyHandled(request));
+            }
+        };
+        let admission = match self.pipeline.accept_frontend(message.clone(), handling) {
             Ok(admission) => admission,
             Err(error) => {
                 self.pending_frontend = Some(message);
@@ -888,7 +1011,7 @@ where
             unreachable!()
         };
         self.upstream.send_wire_raw(message.clone()).await?;
-        Ok(message)
+        Ok(FrontendForwarding::Forwarded(message))
     }
 
     /// Receives one legal PostgreSQL response and forwards it downstream in
@@ -897,7 +1020,14 @@ where
     /// # Errors
     ///
     /// Returns transport, framing, ordering, or protocol-legality failures.
-    pub async fn forward_backend(&mut self) -> Result<crate::codec::BackendMessage, ForwardError> {
+    /// Receives one PostgreSQL response and reports whether it was forwarded or suppressed.
+    ///
+    /// # Errors
+    ///
+    /// Returns middleware, transport, ordering, or protocol-legality failures.
+    pub async fn forward_backend(
+        &mut self,
+    ) -> Result<BackendForwarding, ForwardError<Boundary::Error>> {
         let message = self.upstream.receive_wire_raw().await?;
         self.process_backend(message).await
     }
@@ -905,15 +1035,25 @@ where
     async fn process_backend(
         &mut self,
         message: crate::codec::BackendMessage,
-    ) -> Result<crate::codec::BackendMessage, ForwardError> {
+    ) -> Result<BackendForwarding, ForwardError<Boundary::Error>> {
         let message = self.upstream.intercept_backend(&mut self.state, message);
-        let message = self.boundary.backend(
-            self.downstream.context(),
-            self.upstream.context(),
-            &mut self.state,
-            message,
-        );
-        let message = self.downstream.intercept_backend(&mut self.state, message);
+        let decision = self
+            .boundary
+            .backend(
+                self.downstream.context(),
+                self.upstream.context(),
+                &mut self.state,
+                message,
+            )
+            .await
+            .map_err(ForwardError::Middleware)?;
+        let (message, suppress) = match decision {
+            BackendMiddlewareOutput::Forward(message) => (
+                self.downstream.intercept_backend(&mut self.state, message),
+                false,
+            ),
+            BackendMiddlewareOutput::Suppress(message) => (message, true),
+        };
         let message = match self
             .pipeline
             .accept_backend(message)
@@ -922,8 +1062,36 @@ where
             BackendAction::Emit(message) => message,
             BackendAction::Deferred(message) => return Err(ForwardError::Deferred(message)),
         };
-        self.downstream.send_wire_raw(message.clone()).await?;
-        Ok(message)
+        if suppress {
+            self.flush_local_responses().await?;
+            Ok(BackendForwarding::Suppressed(message))
+        } else {
+            self.downstream.send_wire_raw(message.clone()).await?;
+            self.flush_local_responses().await?;
+            Ok(BackendForwarding::Forwarded(message))
+        }
+    }
+
+    async fn flush_local_responses(&mut self) -> Result<(), ForwardError<Boundary::Error>> {
+        loop {
+            let Some(pending) = self.pending_local.front_mut() else {
+                return Ok(());
+            };
+            let Some(message) = pending.messages.pop_front() else {
+                self.pending_local.pop_front();
+                continue;
+            };
+            match self.pipeline.try_emit_local(pending.operation, message) {
+                Ok(BackendAction::Emit(message)) => {
+                    self.downstream.send_wire_raw(message).await?;
+                }
+                Ok(BackendAction::Deferred(message)) => {
+                    pending.messages.push_front(message);
+                    return Ok(());
+                }
+                Err(error) => return Err(ForwardError::Backend(error)),
+            }
+        }
     }
 
     /// Waits on both transports and forwards whichever legal message becomes
@@ -936,22 +1104,36 @@ where
     /// # Errors
     ///
     /// Returns transport, framing, ordering, protocol-legality, or capacity failures.
-    pub async fn forward_next(&mut self) -> Result<ForwardedMessage, ForwardError> {
+    pub async fn forward_next(
+        &mut self,
+    ) -> Result<ForwardedMessage, ForwardError<Boundary::Error>> {
         if self.pending_frontend.is_some() {
             let message = self.upstream.receive_wire_raw().await?;
             return self
                 .process_backend(message)
                 .await
-                .map(ForwardedMessage::Backend);
+                .map(|outcome| match outcome {
+                    BackendForwarding::Forwarded(message) => ForwardedMessage::Backend(message),
+                    BackendForwarding::Suppressed(message) => {
+                        ForwardedMessage::BackendSuppressed(message)
+                    }
+                });
         }
         tokio::select! {
             result = self.downstream.receive_wire_raw() => {
                 let message = result?;
-                self.process_frontend(message, true).await.map(ForwardedMessage::Frontend)
+                self.process_frontend(message, true).await.map(|outcome| match outcome {
+                    FrontendForwarding::Forwarded(message) => ForwardedMessage::Frontend(message),
+                    FrontendForwarding::Suppressed(message) => ForwardedMessage::FrontendSuppressed(message),
+                    FrontendForwarding::LocallyHandled(message) => ForwardedMessage::FrontendLocallyHandled(message),
+                })
             }
             result = self.upstream.receive_wire_raw() => {
                 let message = result?;
-                self.process_backend(message).await.map(ForwardedMessage::Backend)
+                self.process_backend(message).await.map(|outcome| match outcome {
+                    BackendForwarding::Forwarded(message) => ForwardedMessage::Backend(message),
+                    BackendForwarding::Suppressed(message) => ForwardedMessage::BackendSuppressed(message),
+                })
             }
         }
     }
@@ -991,7 +1173,7 @@ where
 
 /// Operational forwarding or pipeline projection failure.
 #[derive(Debug)]
-pub enum ForwardError {
+pub enum ForwardError<MiddlewareError = std::convert::Infallible> {
     /// Transport, decoding, or encoding failure.
     Io(io::Error),
     /// Frontend backpressure or protocol-legality rejection.
@@ -1000,9 +1182,11 @@ pub enum ForwardError {
     Backend(crate::pipeline::BackendProjectionError),
     /// A bounded response arrived before its operation became emittable.
     Deferred(crate::codec::BackendMessage),
+    /// Forwarding-boundary middleware rejected a message.
+    Middleware(MiddlewareError),
 }
 
-impl fmt::Display for ForwardError {
+impl<E> fmt::Display for ForwardError<E> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Io(error) => error.fmt(formatter),
@@ -1011,20 +1195,25 @@ impl fmt::Display for ForwardError {
             }
             Self::Backend(_) => formatter.write_str("backend message violates pipeline legality"),
             Self::Deferred(_) => formatter.write_str("backend response is not yet emittable"),
+            Self::Middleware(_) => formatter.write_str("forwarding middleware rejected a message"),
         }
     }
 }
 
-impl std::error::Error for ForwardError {
+impl<E> std::error::Error for ForwardError<E>
+where
+    E: std::error::Error + 'static,
+{
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::Io(error) => Some(error),
-            _ => None,
+            Self::Middleware(error) => Some(error),
+            Self::Frontend(_) | Self::Backend(_) | Self::Deferred(_) => None,
         }
     }
 }
 
-impl From<io::Error> for ForwardError {
+impl<E> From<io::Error> for ForwardError<E> {
     fn from(error: io::Error) -> Self {
         Self::Io(error)
     }
@@ -1102,6 +1291,20 @@ where
             >,
             K::Error,
             crate::CancelError<CE>,
+            <<Boundary as IntermediaryMiddlewareFactory<
+                crate::ServerConnectionContext<
+                    Peer,
+                    <SA::Authentication as crate::ServerAuthentication<Peer>>::Identity,
+                >,
+                crate::ClientConnectionContext<CA::Evidence>,
+            >>::Handler as IntermediaryMiddleware<
+                State,
+                crate::ServerConnectionContext<
+                    Peer,
+                    <SA::Authentication as crate::ServerAuthentication<Peer>>::Identity,
+                >,
+                crate::ClientConnectionContext<CA::Evidence>,
+            >>::Error,
         >,
     >
     where
@@ -1298,17 +1501,37 @@ where
             pipeline: Pipeline::new(self.pipeline),
             target: selected,
             pending_frontend: None,
+            pending_local: VecDeque::new(),
             cancellation_registry: self.cancellation_registry.clone(),
             client_cancel_key,
         };
         if let Some(message) = backend_key_message {
             let expected = message.clone();
-            let message = connection.boundary.backend(
-                connection.downstream.context(),
-                connection.upstream.context(),
-                &mut connection.state,
-                message,
-            );
+            let message = connection
+                .boundary
+                .backend(
+                    connection.downstream.context(),
+                    connection.upstream.context(),
+                    &mut connection.state,
+                    message,
+                )
+                .await;
+            let message = match message {
+                Ok(BackendMiddlewareOutput::Forward(message)) => message,
+                Ok(BackendMiddlewareOutput::Suppress(_)) => {
+                    let _ = connection.detach_cancellation();
+                    let _ = connection.teardown();
+                    return Err(IntermediaryAcceptError::ServerOutput(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "middleware suppressed generated cancellation key",
+                    )));
+                }
+                Err(error) => {
+                    let _ = connection.detach_cancellation();
+                    let _ = connection.teardown();
+                    return Err(IntermediaryAcceptError::Middleware(error));
+                }
+            };
             let message = connection
                 .downstream
                 .intercept_backend(&mut connection.state, message);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,8 +75,9 @@ pub use codec::{
 pub use demux::CancelKey;
 pub use intermediary_component::{
     AllowAuthenticatedRoute, AuthenticatedRouteContext, AuthenticatedRoutePolicy,
-    CancellationPolicy, CancellationRoute, EstablishmentFailurePolicy, ForwardError,
-    ForwardedMessage, IdentityIntermediaryMiddleware, InitialServerContext, Intermediary,
+    BackendForwarding, BackendMiddlewareOutput, CancellationPolicy, CancellationRoute,
+    EstablishmentFailurePolicy, ForwardError, ForwardedMessage, FrontendForwarding,
+    FrontendMiddlewareOutput, IdentityIntermediaryMiddleware, InitialServerContext, Intermediary,
     IntermediaryAccept, IntermediaryAcceptError, IntermediaryBuildError, IntermediaryBuilder,
     IntermediaryCancellationRegistry, IntermediaryConnection, IntermediaryContexts,
     IntermediaryMiddleware, IntermediaryMiddlewareFactory, RejectCancellation,

--- a/tests/intermediary_builder.rs
+++ b/tests/intermediary_builder.rs
@@ -208,25 +208,45 @@ impl
         ClientConnectionContext<()>,
     > for BoundaryOrder
 {
-    fn frontend(
-        &mut self,
-        _: &ServerConnectionContext<String, TrustIdentity>,
-        _: &ClientConnectionContext<()>,
-        state: &mut Vec<&'static str>,
+    type Error = Infallible;
+
+    fn frontend<'a>(
+        &'a mut self,
+        _: &'a ServerConnectionContext<String, TrustIdentity>,
+        _: &'a ClientConnectionContext<()>,
+        state: &'a mut Vec<&'static str>,
         message: FrontendMessage,
-    ) -> FrontendMessage {
-        state.push("boundary-frontend");
-        message
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<
+                    Output = Result<pg_proto::FrontendMiddlewareOutput, Self::Error>,
+                > + 'a,
+        >,
+    > {
+        Box::pin(async move {
+            tokio::task::yield_now().await;
+            state.push("boundary-frontend");
+            Ok(pg_proto::FrontendMiddlewareOutput::Forward(message))
+        })
     }
-    fn backend(
-        &mut self,
-        _: &ServerConnectionContext<String, TrustIdentity>,
-        _: &ClientConnectionContext<()>,
-        state: &mut Vec<&'static str>,
+
+    fn backend<'a>(
+        &'a mut self,
+        _: &'a ServerConnectionContext<String, TrustIdentity>,
+        _: &'a ClientConnectionContext<()>,
+        state: &'a mut Vec<&'static str>,
         message: BackendMessage,
-    ) -> BackendMessage {
-        state.push("boundary-backend");
-        message
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<Output = Result<pg_proto::BackendMiddlewareOutput, Self::Error>>
+                + 'a,
+        >,
+    > {
+        Box::pin(async move {
+            tokio::task::yield_now().await;
+            state.push("boundary-backend");
+            Ok(pg_proto::BackendMiddlewareOutput::Forward(message))
+        })
     }
 }
 
@@ -475,7 +495,7 @@ async fn intermediary_routes_authenticates_and_forwards_a_simple_query() {
     let traffic_entries = session.state().len();
     assert!(matches!(
         session.forward_frontend().await.unwrap(),
-        FrontendMessage::Query(query) if query == "SELECT 1"
+        pg_proto::FrontendForwarding::Forwarded(FrontendMessage::Query(query)) if query == "SELECT 1"
     ));
     assert!(matches!(
         session.forward_frontend().await,
@@ -485,39 +505,39 @@ async fn intermediary_routes_authenticates_and_forwards_a_simple_query() {
     ));
     assert!(matches!(
         session.forward_backend().await.unwrap(),
-        BackendMessage::CommandComplete(tag) if tag == "SELECT 1"
+        pg_proto::BackendForwarding::Forwarded(BackendMessage::CommandComplete(tag)) if tag == "SELECT 1"
     ));
     assert!(matches!(
         session.forward_backend().await.unwrap(),
-        BackendMessage::ReadyForQuery(_)
+        pg_proto::BackendForwarding::Forwarded(BackendMessage::ReadyForQuery(_))
     ));
     assert!(
-        matches!(session.forward_frontend().await.unwrap(), FrontendMessage::Query(query) if query == "SELECT 2")
+        matches!(session.forward_frontend().await.unwrap(), pg_proto::FrontendForwarding::Forwarded(FrontendMessage::Query(query)) if query == "SELECT 2")
     );
     assert!(
-        matches!(session.forward_backend().await.unwrap(), BackendMessage::CommandComplete(tag) if tag == "SELECT 2")
+        matches!(session.forward_backend().await.unwrap(), pg_proto::BackendForwarding::Forwarded(BackendMessage::CommandComplete(tag)) if tag == "SELECT 2")
     );
     assert!(matches!(
         session.forward_backend().await.unwrap(),
-        BackendMessage::ReadyForQuery(_)
+        pg_proto::BackendForwarding::Forwarded(BackendMessage::ReadyForQuery(_))
     ));
     for (frontend, backend) in [(b'P', b'1'), (b'B', b'2'), (b'E', b'C'), (b'S', b'Z')] {
         assert_eq!(
-            frontend_bytes(&session.forward_frontend().await.unwrap())[0],
+            frontend_bytes(&session.forward_frontend().await.unwrap().into_message())[0],
             frontend
         );
         assert_eq!(
-            backend_bytes(&session.forward_backend().await.unwrap())[0],
+            backend_bytes(&session.forward_backend().await.unwrap().into_message())[0],
             backend
         );
     }
     assert!(matches!(
         session.forward_frontend().await.unwrap(),
-        FrontendMessage::Query(_)
+        pg_proto::FrontendForwarding::Forwarded(FrontendMessage::Query(_))
     ));
     assert!(matches!(
         session.forward_backend().await.unwrap(),
-        BackendMessage::CopyBothResponse(_)
+        pg_proto::BackendForwarding::Forwarded(BackendMessage::CopyBothResponse(_))
     ));
     assert!(
         matches!(session.forward_next().await.unwrap(), pg_proto::ForwardedMessage::Backend(BackendMessage::CopyData(data)) if data == "w-replication")
@@ -526,28 +546,214 @@ async fn intermediary_routes_authenticates_and_forwards_a_simple_query() {
         matches!(session.forward_next().await.unwrap(), pg_proto::ForwardedMessage::Frontend(FrontendMessage::CopyData(data)) if data == "r-standby-status")
     );
     let (_downstream, _upstream, state, _boundary, _handlers, contexts) = session.teardown();
-    assert!(state[traffic_entries..].starts_with(&[
-        "server-frontend",
-        "boundary-frontend",
-        "client-frontend",
-        "server-frontend",
-        "boundary-frontend",
-        "client-frontend",
-        "client-backend",
-        "boundary-backend",
-        "server-backend",
-        "client-backend",
-        "boundary-backend",
-        "server-backend",
-        "client-backend",
-        "boundary-backend",
-        "server-backend",
-        "client-backend",
-        "boundary-backend",
-        "server-backend",
-    ]));
+    assert!(
+        state[traffic_entries..].starts_with(&[
+            "server-frontend",
+            "boundary-frontend",
+            "client-frontend",
+            "server-frontend",
+            "boundary-frontend",
+            "client-frontend",
+            "client-backend",
+            "boundary-backend",
+            "server-backend",
+            "client-backend",
+            "boundary-backend",
+            "server-backend",
+            "client-backend",
+            "boundary-backend",
+            "server-backend",
+            "client-backend",
+            "boundary-backend",
+            "server-backend",
+        ]),
+        "traffic order: {:?}",
+        &state[traffic_entries..]
+    );
     assert_eq!(contexts.server().peer(), "downstream-peer");
     assert_eq!(contexts.client().target().name(), "tenant-a");
+    downstream.await.unwrap();
+    upstream.await.unwrap();
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct BoundaryFailure;
+
+impl std::fmt::Display for BoundaryFailure {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("boundary failure")
+    }
+}
+
+impl std::error::Error for BoundaryFailure {}
+
+struct AsyncDecisions;
+
+impl
+    IntermediaryMiddleware<
+        (),
+        ServerConnectionContext<String, TrustIdentity>,
+        ClientConnectionContext<()>,
+    > for AsyncDecisions
+{
+    type Error = BoundaryFailure;
+
+    fn frontend<'a>(
+        &'a mut self,
+        _: &'a ServerConnectionContext<String, TrustIdentity>,
+        _: &'a ClientConnectionContext<()>,
+        (): &'a mut (),
+        message: FrontendMessage,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<
+                    Output = Result<pg_proto::FrontendMiddlewareOutput, Self::Error>,
+                > + 'a,
+        >,
+    > {
+        Box::pin(async move {
+            tokio::task::yield_now().await;
+            match &message {
+                FrontendMessage::Query(query) if query == "LOCAL" => {
+                    Ok(pg_proto::FrontendMiddlewareOutput::Respond {
+                        request: message,
+                        responses: vec![
+                            BackendMessage::CommandComplete(Bytes::from_static(b"LOCAL")),
+                            BackendMessage::ReadyForQuery(pg_proto::TransactionStatus::Idle),
+                        ],
+                    })
+                }
+                FrontendMessage::Query(query) if query == "DROP" => {
+                    Ok(pg_proto::FrontendMiddlewareOutput::Suppress(message))
+                }
+                FrontendMessage::Query(query) if query == "FAIL" => Err(BoundaryFailure),
+                _ => Ok(pg_proto::FrontendMiddlewareOutput::Forward(message)),
+            }
+        })
+    }
+}
+
+#[tokio::test]
+#[allow(clippy::too_many_lines)]
+async fn async_middleware_suppresses_and_emits_local_responses_in_pipeline_order() {
+    let (downstream_transport, mut downstream_peer) = tokio::io::duplex(16 * 1024);
+    let (upstream_transport, mut upstream_peer) = tokio::io::duplex(16 * 1024);
+    let upstream_transport = std::sync::Mutex::new(Some(upstream_transport));
+
+    let server = Server::builder()
+        .tls(ServerTlsPolicy::Disabled)
+        .authentication(TrustServerAuthentication)
+        .build()
+        .unwrap();
+    let client = Client::builder()
+        .connector(move |_| {
+            let transport = upstream_transport.lock().unwrap().take().unwrap();
+            async move { Ok::<_, Infallible>(transport) }
+        })
+        .tls(ClientTlsPolicy::Disabled)
+        .authentication(TrustClientAuthentication)
+        .build()
+        .unwrap();
+    let intermediary = Intermediary::builder()
+        .server(server)
+        .client(client)
+        .startup_resolver(CandidateResolver)
+        .authenticated_route(RefineRoute)
+        .cancellation(CancellationPolicy::Reject)
+        .pipeline(BoundedPipeline::new(2).unwrap())
+        .middleware(
+            |_: &ServerConnectionContext<String, TrustIdentity>,
+             _: &ClientConnectionContext<()>| AsyncDecisions,
+        )
+        .build()
+        .unwrap();
+
+    let downstream = tokio::spawn(async move {
+        let startup = pg_proto::StartupMessage {
+            version: pg_proto::ProtocolVersion::V3_0,
+            parameters: std::iter::once((
+                Bytes::from_static(b"user"),
+                Bytes::from_static(b"alice"),
+            ))
+            .collect(),
+        };
+        downstream_peer
+            .write_all(&startup.encode().unwrap())
+            .await
+            .unwrap();
+        let mut authentication_and_ready = [0; 15];
+        downstream_peer
+            .read_exact(&mut authentication_and_ready)
+            .await
+            .unwrap();
+        for query in [b"FIRST".as_slice(), b"LOCAL", b"DROP", b"FAIL"] {
+            downstream_peer
+                .write_all(&frontend_bytes(&FrontendMessage::Query(
+                    Bytes::copy_from_slice(query),
+                )))
+                .await
+                .unwrap();
+        }
+        for expected in [b"FIRST\0".as_slice(), b"LOCAL\0"] {
+            let (tag, body) = read_tagged(&mut downstream_peer).await;
+            assert_eq!((tag, body.as_slice()), (b'C', expected));
+            assert_eq!(read_tagged(&mut downstream_peer).await.0, b'Z');
+        }
+    });
+    let upstream = tokio::spawn(async move {
+        let length = upstream_peer.read_u32().await.unwrap();
+        let mut startup = vec![0; usize::try_from(length).unwrap() - 4];
+        upstream_peer.read_exact(&mut startup).await.unwrap();
+        upstream_peer
+            .write_all(&[b'R', 0, 0, 0, 8, 0, 0, 0, 0, b'Z', 0, 0, 0, 5, b'I'])
+            .await
+            .unwrap();
+        let (tag, body) = read_tagged(&mut upstream_peer).await;
+        assert_eq!((tag, body.as_slice()), (b'Q', b"FIRST\0".as_slice()));
+        upstream_peer
+            .write_all(&backend_bytes(&BackendMessage::CommandComplete(
+                Bytes::from_static(b"FIRST"),
+            )))
+            .await
+            .unwrap();
+        upstream_peer
+            .write_all(&backend_bytes(&BackendMessage::ReadyForQuery(
+                pg_proto::TransactionStatus::Idle,
+            )))
+            .await
+            .unwrap();
+        let unexpected = tokio::time::timeout(
+            std::time::Duration::from_millis(50),
+            upstream_peer.read_u8(),
+        )
+        .await;
+        assert!(!matches!(unexpected, Ok(Ok(_))));
+    });
+
+    let mut session =
+        Box::pin(intermediary.accept(downstream_transport, "downstream-peer".to_owned(), ()))
+            .await
+            .unwrap()
+            .into_session();
+    assert!(matches!(
+        session.forward_frontend().await.unwrap(),
+        pg_proto::FrontendForwarding::Forwarded(FrontendMessage::Query(query)) if query == "FIRST"
+    ));
+    assert!(matches!(
+        session.forward_frontend().await.unwrap(),
+        pg_proto::FrontendForwarding::LocallyHandled(FrontendMessage::Query(query)) if query == "LOCAL"
+    ));
+    session.forward_backend().await.unwrap();
+    session.forward_backend().await.unwrap();
+    assert!(matches!(
+        session.forward_frontend().await.unwrap(),
+        pg_proto::FrontendForwarding::Suppressed(FrontendMessage::Query(query)) if query == "DROP"
+    ));
+    assert!(matches!(
+        session.forward_frontend().await,
+        Err(pg_proto::ForwardError::Middleware(BoundaryFailure))
+    ));
+    let _ = session.teardown();
     downstream.await.unwrap();
     upstream.await.unwrap();
 }


### PR DESCRIPTION
## Summary

- make intermediary boundary middleware asynchronous and fallible while retaining caller connection state and both role contexts
- expose explicit forward, suppress, and locally respond decisions for frontend traffic, plus forward and suppress decisions for backend traffic
- admit locally handled operations through the connection-owned pipeline and emit generated responses in order behind outstanding PostgreSQL work
- preserve concrete middleware errors in establishment and forwarding error layers
- return observable forwarding outcomes from directional and duplex drivers
- migrate examples and document the API change

## Verification

- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps
- cargo test --test intermediary_builder --test builder_examples --test documentation_audit --test public_surface
- git diff --check

Docker-dependent PostgreSQL tests remain ignored locally and are left to CI.