### PR TITLE
fix: preserve fuzz checks when reusing CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,9 +276,7 @@ jobs:
   fuzz:
     name: Fuzz ${{ matrix.target }}
     needs: reuse-pr-ci
-    if: >-
-      always() &&
-      needs.reuse-pr-ci.outputs.tested != 'true'
+    if: always()
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -290,14 +288,22 @@ jobs:
           - scram
           - runtime_fsm
     steps:
+      - name: Reuse successful CI result
+        if: needs.reuse-pr-ci.outputs.tested == 'true'
+        run: echo "Fuzz coverage was already verified by the release parent."
+
       - name: Checkout repository
+        if: needs.reuse-pr-ci.outputs.tested != 'true'
         uses: actions/checkout@v7
 
       - name: Install nightly Rust
+        if: needs.reuse-pr-ci.outputs.tested != 'true'
         uses: dtolnay/rust-toolchain@nightly
 
       - name: Install cargo-fuzz
+        if: needs.reuse-pr-ci.outputs.tested != 'true'
         run: cargo install cargo-fuzz --locked
 
       - name: Run fuzz target
+        if: needs.reuse-pr-ci.outputs.tested != 'true'
         run: cargo +nightly fuzz run --fuzz-dir fuzz ${{ matrix.target }} -- -max_total_time=60

--- a/tests/workflow_audit.rs
+++ b/tests/workflow_audit.rs
@@ -1,0 +1,38 @@
+//! Structural checks for required GitHub Actions status names.
+
+use std::{fs, path::PathBuf};
+
+#[test]
+fn reused_ci_still_expands_every_required_fuzz_check() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let workflow = fs::read_to_string(root.join(".github/workflows/ci.yml")).unwrap();
+    let fuzz = workflow
+        .split_once("\n  fuzz:\n")
+        .expect("CI workflow defines the fuzz job")
+        .1;
+    let (job, steps) = fuzz
+        .split_once("    steps:\n")
+        .expect("fuzz job defines steps");
+
+    assert!(job.contains("    if: always()"));
+    assert!(
+        !job.contains("needs.reuse-pr-ci.outputs.tested != 'true'"),
+        "the reuse predicate at job level prevents GitHub from expanding matrix check names"
+    );
+    assert!(
+        steps.contains("needs.reuse-pr-ci.outputs.tested != 'true'"),
+        "expensive fuzz steps must remain conditional when CI is reused"
+    );
+    for target in [
+        "pre_startup",
+        "scram",
+        "frontend_codec",
+        "runtime_fsm",
+        "backend_codec",
+    ] {
+        assert!(
+            fuzz.contains(target),
+            "missing required fuzz check {target}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- always expand the fuzz matrix so every branch-protection check name exists
- skip only the expensive fuzz steps when release CI reuses its parent's successful run
- retain `if: always()` so ordinary PRs still run fuzz jobs when the reuse probe is skipped
- add a structural regression test for the workflow invariant and required fuzz targets

## Verification

- `cargo test --test workflow_audit`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `git diff --check`
