### PR TITLE
feat: support backend middleware fan-out

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -143,7 +143,10 @@ future and declare the handler's `Error` type. Return
 `FrontendMiddlewareOutput::Forward` for replacement, `Suppress` to consume a
 message, or `Respond` to register a locally handled operation and provide its
 ordered backend responses. Backend middleware returns
-`BackendMiddlewareOutput::Forward` or `Suppress`.
+`BackendMiddlewareOutput::Forward`, `Expand`, or `Suppress`. Use `Expand` when
+one upstream response, such as an encrypted buffered row, must become several
+ordered downstream responses. Empty expansions are rejected; use `Suppress`
+when no downstream response should be emitted.
 
 `forward_frontend` and `forward_backend` now return `FrontendForwarding` and
 `BackendForwarding`, respectively. Match these outcomes when application code

--- a/PLAN.md
+++ b/PLAN.md
@@ -284,6 +284,8 @@ neutral composition harnesses and examples.
 - [x] Expose asynchronous, fallible intermediary-boundary middleware through
   the builder facade.
   - [x] Support owned forward, suppress, and locally respond decisions.
+  - [x] Support backend fan-out without allowing expanded responses to bypass
+    pipeline legality or wire ordering.
   - [x] Preserve application errors in the public forwarding error layer.
   - [x] Admit local operations and emit generated responses through the
     connection-owned pipeline without allowing response reordering.

--- a/README.md
+++ b/README.md
@@ -309,8 +309,9 @@ let _client = Client::builder()
 Forwarding-boundary middleware configured by `Intermediary::builder()` is
 asynchronous and fallible. Its frontend decision can forward a replacement,
 suppress the owned message, or handle the operation locally with an ordered list
-of backend responses. Its backend decision can forward a replacement or
-suppress the response after protocol state advances. `IntermediaryConnection`
+of backend responses. Its backend decision can forward a replacement, expand
+one PostgreSQL response into multiple ordered client responses, or suppress the
+response after protocol state advances. `IntermediaryConnection`
 admits local operations and emits their responses through its connection-owned
 pipeline, so they cannot overtake earlier PostgreSQL responses. Middleware
 failures retain their application error in `ForwardError::Middleware`.

--- a/src/intermediary_component.rs
+++ b/src/intermediary_component.rs
@@ -240,6 +240,8 @@ pub enum FrontendMiddlewareOutput {
 pub enum BackendMiddlewareOutput {
     /// Forward this owned message to the client.
     Forward(crate::codec::BackendMessage),
+    /// Replace one PostgreSQL response with one or more ordered client responses.
+    Expand(Vec<crate::codec::BackendMessage>),
     /// Consume the response after advancing protocol and pipeline state.
     Suppress(crate::codec::BackendMessage),
 }
@@ -810,6 +812,13 @@ pub enum ForwardedMessage {
     Frontend(crate::codec::FrontendMessage),
     /// A PostgreSQL-originated message was forwarded to the client.
     Backend(crate::codec::BackendMessage),
+    /// One PostgreSQL response expanded into ordered client responses.
+    BackendExpanded {
+        /// Response received from PostgreSQL.
+        source: crate::codec::BackendMessage,
+        /// Responses emitted to the client.
+        messages: Vec<crate::codec::BackendMessage>,
+    },
     /// A client-originated message was deliberately suppressed.
     FrontendSuppressed(crate::codec::FrontendMessage),
     /// A request was handled locally; responses were emitted or queued in order.
@@ -846,6 +855,13 @@ impl FrontendForwarding {
 pub enum BackendForwarding {
     /// The response was sent to the client.
     Forwarded(crate::codec::BackendMessage),
+    /// One PostgreSQL response expanded into these ordered client responses.
+    Expanded {
+        /// Response received from PostgreSQL after client-role interception.
+        source: crate::codec::BackendMessage,
+        /// Responses emitted to the client after server-role interception.
+        messages: Vec<crate::codec::BackendMessage>,
+    },
     /// The response advanced protocol state but was not sent.
     Suppressed(crate::codec::BackendMessage),
 }
@@ -856,6 +872,7 @@ impl BackendForwarding {
     pub fn into_message(self) -> crate::codec::BackendMessage {
         match self {
             Self::Forwarded(message) | Self::Suppressed(message) => message,
+            Self::Expanded { source, .. } => source,
         }
     }
 }
@@ -1020,7 +1037,8 @@ where
     /// # Errors
     ///
     /// Returns transport, framing, ordering, or protocol-legality failures.
-    /// Receives one PostgreSQL response and reports whether it was forwarded or suppressed.
+    /// Receives one PostgreSQL response and reports whether it was forwarded,
+    /// expanded, or suppressed.
     ///
     /// # Errors
     ///
@@ -1037,6 +1055,7 @@ where
         message: crate::codec::BackendMessage,
     ) -> Result<BackendForwarding, ForwardError<Boundary::Error>> {
         let message = self.upstream.intercept_backend(&mut self.state, message);
+        let source = message.clone();
         let decision = self
             .boundary
             .backend(
@@ -1047,29 +1066,56 @@ where
             )
             .await
             .map_err(ForwardError::Middleware)?;
-        let (message, suppress) = match decision {
-            BackendMiddlewareOutput::Forward(message) => (
-                self.downstream.intercept_backend(&mut self.state, message),
-                false,
-            ),
-            BackendMiddlewareOutput::Suppress(message) => (message, true),
+        let outcome = match decision {
+            BackendMiddlewareOutput::Forward(message) => {
+                let message = self.downstream.intercept_backend(&mut self.state, message);
+                let message = self.emit_backend(message).await?;
+                BackendForwarding::Forwarded(message)
+            }
+            BackendMiddlewareOutput::Suppress(message) => {
+                let message = self.advance_backend(message)?;
+                BackendForwarding::Suppressed(message)
+            }
+            BackendMiddlewareOutput::Expand(messages) => {
+                if messages.is_empty() {
+                    return Err(ForwardError::EmptyExpansion(source));
+                }
+                let mut emitted = Vec::with_capacity(messages.len());
+                for message in messages {
+                    let message = self.downstream.intercept_backend(&mut self.state, message);
+                    emitted.push(self.emit_backend(message).await?);
+                }
+                BackendForwarding::Expanded {
+                    source,
+                    messages: emitted,
+                }
+            }
         };
-        let message = match self
+        self.flush_local_responses().await?;
+        Ok(outcome)
+    }
+
+    fn advance_backend(
+        &mut self,
+        message: crate::codec::BackendMessage,
+    ) -> Result<crate::codec::BackendMessage, ForwardError<Boundary::Error>> {
+        match self
             .pipeline
             .accept_backend(message)
             .map_err(ForwardError::Backend)?
         {
-            BackendAction::Emit(message) => message,
-            BackendAction::Deferred(message) => return Err(ForwardError::Deferred(message)),
-        };
-        if suppress {
-            self.flush_local_responses().await?;
-            Ok(BackendForwarding::Suppressed(message))
-        } else {
-            self.downstream.send_wire_raw(message.clone()).await?;
-            self.flush_local_responses().await?;
-            Ok(BackendForwarding::Forwarded(message))
+            BackendAction::Emit(message) => Ok(message),
+            BackendAction::Deferred(message) => Err(ForwardError::Deferred(message)),
         }
+    }
+
+    async fn emit_backend(
+        &mut self,
+        message: crate::codec::BackendMessage,
+    ) -> Result<crate::codec::BackendMessage, ForwardError<Boundary::Error>> {
+        let message = self.advance_backend(message)?;
+        self.downstream.send_wire_raw(message.clone()).await?;
+        Ok(message)
     }
 
     async fn flush_local_responses(&mut self) -> Result<(), ForwardError<Boundary::Error>> {
@@ -1114,6 +1160,9 @@ where
                 .await
                 .map(|outcome| match outcome {
                     BackendForwarding::Forwarded(message) => ForwardedMessage::Backend(message),
+                    BackendForwarding::Expanded { source, messages } => {
+                        ForwardedMessage::BackendExpanded { source, messages }
+                    }
                     BackendForwarding::Suppressed(message) => {
                         ForwardedMessage::BackendSuppressed(message)
                     }
@@ -1132,6 +1181,9 @@ where
                 let message = result?;
                 self.process_backend(message).await.map(|outcome| match outcome {
                     BackendForwarding::Forwarded(message) => ForwardedMessage::Backend(message),
+                    BackendForwarding::Expanded { source, messages } => {
+                        ForwardedMessage::BackendExpanded { source, messages }
+                    }
                     BackendForwarding::Suppressed(message) => ForwardedMessage::BackendSuppressed(message),
                 })
             }
@@ -1182,6 +1234,8 @@ pub enum ForwardError<MiddlewareError = std::convert::Infallible> {
     Backend(crate::pipeline::BackendProjectionError),
     /// A bounded response arrived before its operation became emittable.
     Deferred(crate::codec::BackendMessage),
+    /// Backend fan-out did not contain a replacement response.
+    EmptyExpansion(crate::codec::BackendMessage),
     /// Forwarding-boundary middleware rejected a message.
     Middleware(MiddlewareError),
 }
@@ -1195,6 +1249,9 @@ impl<E> fmt::Display for ForwardError<E> {
             }
             Self::Backend(_) => formatter.write_str("backend message violates pipeline legality"),
             Self::Deferred(_) => formatter.write_str("backend response is not yet emittable"),
+            Self::EmptyExpansion(_) => {
+                formatter.write_str("backend expansion must contain at least one response")
+            }
             Self::Middleware(_) => formatter.write_str("forwarding middleware rejected a message"),
         }
     }
@@ -1208,7 +1265,9 @@ where
         match self {
             Self::Io(error) => Some(error),
             Self::Middleware(error) => Some(error),
-            Self::Frontend(_) | Self::Backend(_) | Self::Deferred(_) => None,
+            Self::Frontend(_) | Self::Backend(_) | Self::Deferred(_) | Self::EmptyExpansion(_) => {
+                None
+            }
         }
     }
 }
@@ -1518,12 +1577,12 @@ where
                 .await;
             let message = match message {
                 Ok(BackendMiddlewareOutput::Forward(message)) => message,
-                Ok(BackendMiddlewareOutput::Suppress(_)) => {
+                Ok(BackendMiddlewareOutput::Suppress(_) | BackendMiddlewareOutput::Expand(_)) => {
                     let _ = connection.detach_cancellation();
                     let _ = connection.teardown();
                     return Err(IntermediaryAcceptError::ServerOutput(io::Error::new(
                         io::ErrorKind::InvalidData,
-                        "middleware suppressed generated cancellation key",
+                        "middleware suppressed or expanded generated cancellation key",
                     )));
                 }
                 Err(error) => {

--- a/tests/intermediary_builder.rs
+++ b/tests/intermediary_builder.rs
@@ -116,6 +116,22 @@ fn backend_bytes(message: &BackendMessage) -> Vec<u8> {
     let (tag, body) = match message {
         BackendMessage::ParseComplete => (b'1', Vec::new()),
         BackendMessage::BindComplete => (b'2', Vec::new()),
+        BackendMessage::DataRow(row) => {
+            let mut body = u16::try_from(row.columns.len())
+                .unwrap()
+                .to_be_bytes()
+                .to_vec();
+            for column in &row.columns {
+                match column {
+                    None => body.extend_from_slice(&(-1_i32).to_be_bytes()),
+                    Some(value) => {
+                        body.extend_from_slice(&i32::try_from(value.len()).unwrap().to_be_bytes());
+                        body.extend_from_slice(value);
+                    }
+                }
+            }
+            (b'D', body)
+        }
         BackendMessage::CommandComplete(command) => (b'C', [command.as_ref(), b"\0"].concat()),
         BackendMessage::ReadyForQuery(status) => (
             b'Z',
@@ -631,11 +647,39 @@ impl
             }
         })
     }
+
+    fn backend<'a>(
+        &'a mut self,
+        _: &'a ServerConnectionContext<String, TrustIdentity>,
+        _: &'a ClientConnectionContext<()>,
+        (): &'a mut (),
+        message: BackendMessage,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<Output = Result<pg_proto::BackendMiddlewareOutput, Self::Error>>
+                + 'a,
+        >,
+    > {
+        Box::pin(async move {
+            tokio::task::yield_now().await;
+            match message {
+                BackendMessage::DataRow(_) => Ok(pg_proto::BackendMiddlewareOutput::Expand(vec![
+                    BackendMessage::DataRow(pg_proto::DataRow {
+                        columns: vec![Some(Bytes::from_static(b"clear-one"))],
+                    }),
+                    BackendMessage::DataRow(pg_proto::DataRow {
+                        columns: vec![Some(Bytes::from_static(b"clear-two"))],
+                    }),
+                ])),
+                other => Ok(pg_proto::BackendMiddlewareOutput::Forward(other)),
+            }
+        })
+    }
 }
 
 #[tokio::test]
 #[allow(clippy::too_many_lines)]
-async fn async_middleware_suppresses_and_emits_local_responses_in_pipeline_order() {
+async fn async_middleware_supports_suppression_local_responses_and_backend_fanout() {
     let (downstream_transport, mut downstream_peer) = tokio::io::duplex(16 * 1024);
     let (upstream_transport, mut upstream_peer) = tokio::io::duplex(16 * 1024);
     let upstream_transport = std::sync::Mutex::new(Some(upstream_transport));
@@ -694,6 +738,11 @@ async fn async_middleware_suppresses_and_emits_local_responses_in_pipeline_order
                 .await
                 .unwrap();
         }
+        for cleartext in [b"clear-one".as_slice(), b"clear-two"] {
+            let (tag, body) = read_tagged(&mut downstream_peer).await;
+            assert_eq!(tag, b'D');
+            assert_eq!(&body[6..], cleartext);
+        }
         for expected in [b"FIRST\0".as_slice(), b"LOCAL\0"] {
             let (tag, body) = read_tagged(&mut downstream_peer).await;
             assert_eq!((tag, body.as_slice()), (b'C', expected));
@@ -710,6 +759,14 @@ async fn async_middleware_suppresses_and_emits_local_responses_in_pipeline_order
             .unwrap();
         let (tag, body) = read_tagged(&mut upstream_peer).await;
         assert_eq!((tag, body.as_slice()), (b'Q', b"FIRST\0".as_slice()));
+        upstream_peer
+            .write_all(&backend_bytes(&BackendMessage::DataRow(
+                pg_proto::DataRow {
+                    columns: vec![Some(Bytes::from_static(b"encrypted-batch"))],
+                },
+            )))
+            .await
+            .unwrap();
         upstream_peer
             .write_all(&backend_bytes(&BackendMessage::CommandComplete(
                 Bytes::from_static(b"FIRST"),
@@ -742,6 +799,10 @@ async fn async_middleware_suppresses_and_emits_local_responses_in_pipeline_order
     assert!(matches!(
         session.forward_frontend().await.unwrap(),
         pg_proto::FrontendForwarding::LocallyHandled(FrontendMessage::Query(query)) if query == "LOCAL"
+    ));
+    assert!(matches!(
+        session.forward_backend().await.unwrap(),
+        pg_proto::BackendForwarding::Expanded { messages, .. } if messages.len() == 2
     ));
     session.forward_backend().await.unwrap();
     session.forward_backend().await.unwrap();


### PR DESCRIPTION
## Summary

- add `BackendMiddlewareOutput::Expand` for one-to-many backend transformation
- pass every expanded response through server-role middleware and pipeline legality checks
- preserve wire order before the upstream terminating response
- expose expanded source and emitted messages through directional and duplex outcomes
- reject empty expansions explicitly; `Suppress` remains the zero-output decision
- document migration and add a wire-level encrypted-row fan-out regression

## Verification

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- `cargo test --test intermediary_builder`
- `cargo test --test documentation_audit --test public_surface`
- `git diff --check`
