### PR TITLE
Add ordered backend batch holding

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -143,10 +143,21 @@ future and declare the handler's `Error` type. Return
 `FrontendMiddlewareOutput::Forward` for replacement, `Suppress` to consume a
 message, or `Respond` to register a locally handled operation and provide its
 ordered backend responses. Backend middleware returns
-`BackendMiddlewareOutput::Forward`, `Expand`, or `Suppress`. Use `Expand` when
-one upstream response, such as an encrypted buffered row, must become several
-ordered downstream responses. Empty expansions are rejected; use `Suppress`
-when no downstream response should be emitted.
+`BackendMiddlewareOutput::Forward`, `Expand`, `Suppress`, or `Hold`. `Forward`
+replaces and emits one response immediately. `Expand` immediately replaces one
+upstream response with several ordered downstream responses; empty expansions
+are rejected. `Suppress` commits the source without output. `Hold` is different:
+it leaves the unchanged source uncommitted in pg-proto's connection-owned hold.
+
+Holding is opt-in and bounded. Construct non-zero `BackendHoldLimits`, pass them
+to `IntermediaryBuilder::backend_batching`, and implement `flush_backend` to
+return `BackendBatchOutput::ReplaceOneToOne` or `KeepHolding`. The borrowed
+`HeldBackendMessages` view preserves source ownership across cancellation. The
+driver flushes at conservative protocol barriers and capacity; applications can
+call `flush_backend_hold` for latency boundaries and
+`prepare_backend_teardown` before ordinary teardown. A required barrier,
+capacity, or teardown flush that keeps holding is reported as an error rather
+than discarding the span.
 
 `forward_frontend` and `forward_backend` now return `FrontendForwarding` and
 `BackendForwarding`, respectively. Match these outcomes when application code

--- a/README.md
+++ b/README.md
@@ -311,13 +311,19 @@ asynchronous and fallible. Its frontend decision can forward a replacement,
 suppress the owned message, or handle the operation locally with an ordered list
 of backend responses. Its backend decision can forward a replacement, expand
 one PostgreSQL response into multiple ordered client responses, or suppress the
-response after protocol state advances. `IntermediaryConnection`
+response after protocol state advances. A fourth decision, `Hold`, leaves the
+unchanged source unprojected in a bounded connection-owned hold. Configure
+non-zero count and byte limits with `backend_batching`, then implement
+`flush_backend` to return one ordered replacement per held source. Holds flush
+before protocol barriers, at capacity, on explicit `flush_backend_hold()` calls,
+or during `prepare_backend_teardown()`; `Expand` remains immediate one-to-many
+replacement and is not a delayed batch mechanism. `IntermediaryConnection`
 admits local operations and emits their responses through its connection-owned
 pipeline, so they cannot overtake earlier PostgreSQL responses. Middleware
 failures retain their application error in `ForwardError::Middleware`.
 
 `forward_frontend()` and `forward_backend()` report whether traffic was
-forwarded, suppressed, or locally handled; `forward_next()` reports the same
+forwarded, suppressed, held, or locally handled; `forward_next()` reports the same
 decisions while driving both directions.
 
 For a complete networked example, see the TLS-terminating

--- a/docs/design/backend-batching-comparison.md
+++ b/docs/design/backend-batching-comparison.md
@@ -1,0 +1,139 @@
+# Backend batching design comparison
+
+## Decision being made
+
+`pg-proto` 0.8.0 can immediately replace one PostgreSQL backend message with
+many messages, but it cannot defer a `DataRow` across middleware calls without
+advancing protocol state. This report compares two ways to add deferred batching:
+
+1. [crate-owned backend holds](backend-batching-crate-hold.md), where the
+   intermediary retains source messages; and
+2. [caller-defined connection-state buffering](backend-batching-connection-state.md),
+   where middleware moves source messages into the application's connection state.
+
+Both designs preserve ADR 0002's separation of wire receipt, policy, and session
+advancement. Both also require an atomic batch-projection operation inside the
+crate. Applying today's one-message `Pipeline::accept_backend` repeatedly is not
+sufficient: a failure part-way through a batch would otherwise leave the live
+ledger partially advanced.
+
+## Comparison
+
+| Concern | Crate-owned hold | Caller-defined connection state |
+| --- | --- | --- |
+| Public meaning | Explicit `Hold` and later release | Empty `Expand` means retained; later non-empty `Expand` flushes |
+| Payload owner while deferred | `IntermediaryConnection` | Caller-defined connection state |
+| Exact-once ownership | Enforceable by the crate | A contract custom middleware can violate |
+| Projection legality | Atomic held-span validation | Atomic expansion validation |
+| Memory bounds | Uniform count/byte limits | Application-defined; enforceable only through a participating adapter |
+| Backpressure | Connection can stop reads whenever its hold is full | Connection needs a pressure/drain interface into middleware state |
+| Error recovery | Requires hold-aware errors and fallible teardown | Existing state recovery helps, but prepared output still needs recovery |
+| Application storage policy | Limited to policies exposed by the crate | Fully flexible, including arenas or spill-to-disk |
+| Interface clarity | A deferred input is named directly | Empty `Expand` carries a surprising second meaning |
+| Crate implementation | Larger: queue, limits, cancellation guards, teardown | Smaller payload layer, but pressure and atomic projection remain substantial |
+| Caller implementation | Small and consistent | Each custom adapter owns correct storage, accounting, and draining |
+| Locality | Ownership bugs are fixed once in pg-proto | Storage bugs can be distributed across callers |
+
+## Crate-owned hold
+
+### Strengths
+
+The crate-owned design has the strongest invariant: once middleware returns
+`Hold(message)`, exactly one authoritative owner is known. The intermediary can
+stop transport reads at capacity, restore an in-flight batch when a future is
+cancelled, and ensure teardown cannot silently discard deferred messages. These
+behaviours form a deep module: a small middleware interface hides protocol-span
+validation, payload ownership, ordering, memory pressure, and recovery.
+
+The named decision is also difficult to misunderstand. `Suppress` means consume
+without output, `Hold` means do not consume yet, and `Expand` means replace the
+current source immediately. Those meanings remain distinct in logs, errors, and
+tests.
+
+### Weaknesses
+
+This design makes pg-proto a payload buffer. It must define byte accounting,
+capacity behaviour, protocol barriers, cancellation safety, and what teardown
+does with an unflushed batch. It also needs a second middleware hook for batch
+release, which makes the interface broader than the current one-message decision.
+
+Applications with specialised encrypted storage, secure-memory requirements, or
+disk spooling may have to copy messages out of the crate-owned hold or wait for
+more storage adapters to be added.
+
+## Caller-defined connection-state buffering
+
+### Strengths
+
+This design uses an ownership facility the intermediary already provides: one
+caller-defined connection state is passed to middleware and recovered on
+teardown. CipherStash can store encrypted blocks, decrypted rows, accounting
+metadata, or spill handles in the representation that matches its policy. The
+pipeline stays payload-free and pg-proto does not become a general-purpose queue.
+
+The initial interface change is small. Empty `Expand` can represent “no output or
+projection yet”, while a later expansion drains the state buffer and appends the
+current barrier. A supplied bounded `StateRowBatcher` adapter could make the safe
+case convenient without requiring every state type to implement a crate trait.
+
+### Weaknesses
+
+The interface cannot prove its most important ownership claim. Arbitrary
+middleware can return empty `Expand` without first retaining the message, losing
+it silently. Conversely, it can retain a message and accidentally return
+`Suppress`, producing the original double-advancement bug on a later flush.
+
+Empty `Expand` is also semantically overloaded: in 0.8.0 it is an error, while in
+this design it becomes deferred ownership. A named `Retained` outcome would be
+clearer, but it would effectively reintroduce `Hold` without giving the crate
+ownership of the held value.
+
+Backpressure is less local. Because pg-proto cannot inspect arbitrary connection
+state, middleware must expose pressure and draining through an additional
+interface. Custom middleware that bypasses that adapter can allocate without the
+connection knowing when to stop reading.
+
+## A third option: an ordered response collector
+
+A more ambitious design would make `IntermediaryConnection` an ordered response
+collector. Middleware would declare whether a frontend operation is forwarded or
+served by a local response stream, while the connection privately schedules local
+and PostgreSQL responses in operation order.
+
+This offers the simplest common calling pattern and the greatest locality: the
+crate owns buffering, fairness, ordering, retry, projection, and backpressure. It
+also naturally supports lazy local results. However, it is substantially broader
+than the reported DataRow requirement, complicates COPY and teardown, and moves
+pg-proto from a protocol substrate toward an opinionated runtime. It is better
+treated as a possible high-level module built over the lower-level receipt and
+projection seam, not as the immediate fix.
+
+## Recommendation
+
+Prefer the **crate-owned hold** design for the public forwarding interface.
+
+The decisive reason is not storage convenience; it is enforceability. Protocol
+advancement and payload ownership are one correctness problem here. If pg-proto
+owns advancement while arbitrary caller state owns the only evidence that an
+input remains pending, neither side can enforce exact-once handling independently.
+That produces a shallow seam whose correctness depends on undocumented
+coordination.
+
+The caller-state design remains useful as an implementation technique for
+application-specific decrypted data, but it should sit behind middleware's batch
+release policy rather than carry the authoritative received `BackendMessage`
+ownership. Middleware may derive and retain application data in connection state;
+pg-proto should retain the uncommitted protocol inputs until the release succeeds.
+
+Before implementation, prototype the crate-owned design against four tracer
+cases:
+
+1. hold several `DataRow` messages and release them at `CommandComplete`;
+2. suppress one held row and expand another while projecting the whole span once;
+3. cancel an async batch release and prove every input remains owned; and
+4. hit count and byte limits and prove the upstream transport is not polled again.
+
+If the required atomic span validator proves disproportionately complex, the
+fallback should be the caller-state adapter with an explicit named `Retained`
+decision—not an undocumented empty-vector convention—and with pressure/drain
+participation mandatory for middleware that can retain messages.

--- a/docs/design/backend-batching-connection-state.md
+++ b/docs/design/backend-batching-connection-state.md
@@ -1,0 +1,251 @@
+# Backend batching in caller-defined connection state
+
+## Summary
+
+Use the existing caller-defined connection `State` as the payload store. Extend the semantics of the v0.8.0 `BackendMiddlewareOutput::Expand` interface so an empty expansion means “middleware retained this input; emit and project nothing yet.” A batching middleware moves `DataRow` values into `State`, returns `Expand(Vec::new())`, and later returns one non-empty `Expand` containing the buffered rows followed by the message that triggered the flush.
+
+This deliberately avoids a crate-owned `Hold` variant and keeps `Pipeline` payload-free. The crate continues to own protocol legality, projection, and downstream order; the caller owns storage shape, capacity policy, and buffered values.
+
+## Target and constraints
+
+This proposal is based on `pg-proto-v0.8.0`, where:
+
+- `IntermediaryMiddleware::backend` is already async and fallible;
+- `BackendMiddlewareOutput` already supports `Forward`, `Expand`, and `Suppress`;
+- `process_backend` applies destination-role middleware, projects, and sends every expansion element in order;
+- `Suppress(message)` projects the supplied message without sending it;
+- `Pipeline` retains only lightweight operation obligations;
+- `teardown()` returns the sole caller-defined connection state.
+
+The new design must preserve async/fallible policy, zero-or-many output, ordered fan-out, intentional suppression, bounded memory/backpressure, exact-once projection, and recoverability on error or teardown.
+
+## Interface
+
+Keep the existing public enum and change only the documented meaning of an empty expansion:
+
+```rust
+pub enum BackendMiddlewareOutput {
+    /// Emit and project this message once.
+    Forward(BackendMessage),
+
+    /// Emit and project these messages once, in order.
+    ///
+    /// An empty vector means the input was retained in caller-defined
+    /// connection state. Nothing is emitted or projected by this call.
+    Expand(Vec<BackendMessage>),
+
+    /// Project this message once without emitting it.
+    Suppress(BackendMessage),
+}
+```
+
+The distinction is important:
+
+- `Suppress` consumes a protocol event now. It is appropriate for a genuine filter or policy replacement whose source must not later be replayed.
+- empty `Expand` postpones both emission and projection. It is appropriate only after middleware has moved the input into recoverable caller state.
+- non-empty `Expand` is an ordered fan-out. A batch flush returns all retained messages, then the triggering message, so each is projected exactly once.
+
+No public operation ID, projection token, or ledger handle crosses the seam. That keeps the pipeline a deep module: callers learn one output interface while the implementation hides phase selection, legality, ordering, and projection.
+
+### Batch capacity interface
+
+Capacity must be explicit rather than inferred from an arbitrary `State` type:
+
+```rust
+#[derive(Clone, Copy, Debug)]
+pub struct BatchLimits {
+    pub messages: NonZeroUsize,
+    pub bytes: NonZeroUsize,
+}
+
+pub enum OversizeRow {
+    PassThrough,
+    Reject,
+}
+
+pub struct StateRowBatcher<Access, Policy> {
+    access: Access,
+    policy: Policy,
+    limits: BatchLimits,
+    oversize: OversizeRow,
+}
+```
+
+`StateRowBatcher` is an optional middleware adapter. Accessor closures select fields in the caller's state; the state type need not implement a crate trait.
+
+```rust
+#[derive(Default)]
+struct ConnectionState {
+    rows: VecDeque<BackendMessage>,
+    row_bytes: usize,
+    tenant: TenantId,
+}
+
+let batcher = StateRowBatcher::new(
+    |state: &mut ConnectionState| (&mut state.rows, &mut state.row_bytes),
+    BatchLimits {
+        messages: NonZeroUsize::new(256).unwrap(),
+        bytes: NonZeroUsize::new(1 << 20).unwrap(),
+    },
+    FlushOn::RowsOrResponseEnd,
+    OversizeRow::PassThrough,
+);
+```
+
+Applications needing encrypted blocks, an arena, or spill-to-disk storage can implement `IntermediaryMiddleware` directly. The stock adapter should not force a general store trait until there are two real adapters.
+
+## Behaviour
+
+For a `DataRow`, the adapter computes reconstructable encoded length before moving it.
+
+- If it fits, move it into the state buffer and return empty `Expand`.
+- If it would exceed a non-empty buffer, first drain the existing rows and return them followed by this row as a non-empty `Expand`.
+- If it exceeds an empty buffer, either emit it alone (`PassThrough`) or return `BatchError::Oversize` containing the unchanged row (`Reject`).
+- When row count or byte threshold is reached exactly, drain immediately.
+- On `CommandComplete`, `PortalSuspended`, `EmptyQueryResponse`, `ErrorResponse`, `ReadyForQuery`, a COPY transition, or an asynchronous message, drain rows and append the triggering message.
+- On explicit connection teardown, rows remain in `State` and are returned to the caller.
+
+Appending the trigger is mandatory. It prevents a response terminator or asynchronous message from overtaking earlier rows.
+
+## Invariants
+
+1. **Single payload owner.** A decoded message is owned by the receive call, middleware, caller state, the current output vector, transport buffering, or an error value. Batching does not clone a message to simulate retention.
+2. **Exact-once projection.** Empty `Expand` performs no projection. Each element of a later non-empty expansion is projected once, immediately before send. `Suppress` projects once and its message may not later be emitted.
+3. **Source order.** Outputs caused by input `n` are completely emitted before input `n + 1` is received. A drained batch preserves insertion order and places its trigger last.
+4. **Atomic expansion validation.** The complete non-empty expansion is dry-run against a clone of the lightweight ledger before the authoritative ledger changes or any message is sent. If any element is illegal, no element is committed.
+5. **Recoverable retention.** Middleware may return empty `Expand` only after the source is reachable through caller state. The stock adapter enforces this structurally by returning empty only after successful insertion.
+6. **Bounded retention.** The stock adapter has non-zero message and byte limits. It never inserts beyond either limit.
+7. **Backpressure.** While state holds a full batch or a prepared output remains unsent, the driver does not poll another upstream backend frame.
+8. **No terminal retention.** The stock adapter never returns empty expansion for a state-advancing or response-terminal message.
+9. **Non-lossy failure.** On insertion failure the input is returned in the error; on validation failure the entire expansion is returned; on send failure the unsent values and caller state remain recoverable.
+
+The public empty-expansion contract cannot prove that arbitrary custom middleware retained its input. This is the design's central tradeoff. Documentation should mark loss on a dishonest implementation as a middleware contract violation, just as returning a semantically invalid replacement already is.
+
+## Hidden implementation
+
+Replace the v0.8.0 `EmptyExpansion` error branch in `process_backend` with a retained outcome:
+
+```rust
+match decision {
+    BackendMiddlewareOutput::Expand(messages) if messages.is_empty() => {
+        BackendForwarding::Retained
+    }
+    BackendMiddlewareOutput::Expand(messages) => {
+        let prepared = self.pipeline.prepare_backend_sequence(&messages)?;
+        self.send_prepared_backend(prepared, messages).await?
+    }
+    // Forward and Suppress retain their v0.8.0 meanings.
+}
+```
+
+`BackendForwarding` and `ForwardedMessage` gain payload-free observability cases:
+
+```rust
+pub enum BackendForwarding {
+    Forwarded(BackendMessage),
+    Expanded { source: BackendMessage, messages: Vec<BackendMessage> },
+    Suppressed(BackendMessage),
+    Retained,
+}
+```
+
+The implementation must also remove the unconditional `source = message.clone()` performed before middleware in v0.8.0. For `Expand`, the observable source cannot be returned without cloning or obtaining it from middleware. Prefer changing the expanded outcome to contain only emitted messages; callers that require source audit data can retain it in their state. This makes the single-owner invariant real.
+
+`Pipeline::prepare_backend_sequence` operates on a temporary copy of operation metadata. It validates reconstructability, phase legality, operation attribution, and terminal transitions for every output. Only a fully valid sequence is committed. This is an internal seam; it should not become public merely for tests.
+
+The send implementation moves messages one at a time into the downstream buffered transport. It retains the not-yet-pushed suffix in the connection until synchronous encoding succeeds. Async flush follows the transport's cancellation-safe push/flush contract.
+
+## Backpressure and driver integration
+
+Merely bounding the state buffer is insufficient if the driver continues receiving. The batch adapter reports pressure through a small optional interface implemented by the middleware handler:
+
+```rust
+pub trait BackendPressure<State> {
+    fn backend_pressure(&self, state: &State) -> Pressure;
+    fn drain_backend(&mut self, state: &mut State)
+        -> Result<Vec<BackendMessage>, Self::Error>;
+}
+```
+
+This seam is justified by two adapters: identity/no-pressure and `StateRowBatcher`. The duplex driver checks pressure after every backend decision. At the hard limit it drains before polling upstream again. It may continue frontend progress only where the existing operation ledger permits it.
+
+`drain_backend` enables an explicit `flush_backend_batch()` connection method and shutdown draining without manufacturing a backend input. It is synchronous because it only moves caller-owned values; policies needing async spill retrieval implement async middleware and arrange readiness before reporting pressure.
+
+Count and encoded-byte limits are independent of `BoundedPipeline`: the former bound retained payload, while the latter bounds incomplete protocol obligations.
+
+## Error and teardown recovery
+
+- `BatchError::Insert { message, source }` returns the uninserted message; previously buffered rows remain in `State`.
+- `BatchError::Oversize(message)` returns the unchanged row.
+- Expansion validation returns the complete ordered vector and leaves the authoritative ledger unchanged.
+- Encoding failure before a message is pushed returns that message plus the remaining suffix.
+- After a partial socket write, replay is not protocol-safe. Close the connection, but return the unsent suffix and state for audit or cleanup.
+- Cancellation before middleware completes leaves ownership in its future or in state. Cancellation after preparation leaves the prepared suffix owned by the connection.
+- `teardown()` already returns `State`; therefore retained rows naturally survive deliberate teardown. A `teardown_with_pending()` convenience should additionally return any prepared, unpushed expansion suffix.
+
+Recoverability does not imply resumability after arbitrary I/O failure: PostgreSQL framing may already be partially visible to the client.
+
+## Dependencies and adapters
+
+- `Pipeline` depends on generated grammar and lightweight operation records, not batching storage.
+- `IntermediaryConnection` coordinates middleware, pipeline, and transports but does not choose storage.
+- `StateRowBatcher` adapts fields of caller state to the existing `IntermediaryMiddleware` seam.
+- Existing identity and one-to-one middleware retain their current `Forward` behaviour.
+- Existing suppression middleware retains its current project-without-send behaviour.
+- An identity `BackendPressure` adapter reports empty pressure and drains nothing.
+
+The deletion test supports this seam placement: deleting `Pipeline` would spread ordering, phase legality, and exact-once projection across every caller; deleting `StateRowBatcher` would remove only an optional storage policy. The former is a deep module earning locality and leverage, while the latter is correctly an adapter.
+
+## Tests
+
+Tests should cross the public connection/middleware interface rather than inspect private prepared state.
+
+1. Retain three rows, flush on `CommandComplete`, and observe exactly `row1, row2, row3, command`.
+2. Assert empty expansion neither emits nor projects; the later batch projects every retained row exactly once.
+3. Verify ordinary `Suppress` advances once and cannot be replayed by the stock adapter.
+4. Pipeline two operations and prove later responses cannot overtake the earlier retained batch.
+5. Interleave notices and notifications; verify the adapter flushes earlier rows before them.
+6. Cover `PortalSuspended`, errors, `ReadyForQuery`, COPY IN/OUT/BOTH, and extended-query error drain.
+7. Make the final expansion element illegal; verify atomic rejection, unchanged ledger, and recovery of all messages.
+8. Fail state insertion and verify the input is in the error while earlier rows remain in state.
+9. Hit count and byte limits independently; verify the upstream reader is not polled while full.
+10. Cover oversize pass-through and reject modes.
+11. Inject failures before encoding, after encoding, during partial write, and during flush; account for every payload owner.
+12. Cancel at each await point, then teardown and account for retained and pending messages.
+13. Property-test legal backend streams: stable order, capacity never exceeded, every emitted/suppressed event projected exactly once, and payload ownership conserved.
+14. Verify compatibility: identity middleware still produces `Forwarded`, non-empty expansion still produces ordered fan-out, and suppression behaviour is unchanged.
+
+## Migration
+
+1. Document empty `Expand` as retained-without-projection and add `BackendForwarding::Retained`.
+2. Remove `ForwardError::EmptyExpansion` and the unconditional source clone.
+3. Add atomic sequence preparation inside `Pipeline`; treat one-message forwarding as a degenerate sequence.
+4. Add pending-suffix recovery around downstream encoding and flush.
+5. Add optional pressure/drain support and the stock `StateRowBatcher` adapter.
+6. Applications add buffer fields to their connection state and configure explicit count/byte limits.
+7. Existing middleware requires no behavioural migration unless it returned empty expansion expecting an error.
+
+## Advantages
+
+- No crate-owned `Hold` payload or backend queue.
+- Caller chooses storage layout, accounting, encryption, and spill strategy.
+- Buffered rows are naturally recovered through existing state-returning teardown.
+- Reuses the v0.8.0 async/fallible, zero-or-many middleware interface.
+- Exact-once projection and ordering remain concentrated in a deep crate module.
+- No payload clone is required when the expanded outcome stops echoing its source.
+- Existing forward, expansion, and suppression adapters remain compatible.
+
+## Disadvantages and risks
+
+- Empty `Expand` is less explicit than a named `Hold` decision and is easier to misuse.
+- The crate cannot prove arbitrary custom middleware actually retained an input; only the stock adapter provides that structural guarantee.
+- Caller state becomes coupled to batching policy and must be memory-budgeted.
+- Atomic sequence validation adds a pass over the batch and a clone of lightweight ledger metadata.
+- Pressure is enforceable only for middleware participating in the optional pressure interface; arbitrary state allocation remains invisible.
+- Changing expanded observability to omit `source` is a breaking interface change, though it removes the v0.8.0 payload clone.
+- Spill stores that require async draining do not fit the simple stock adapter and need a custom handler.
+- Recovery after partial I/O is for cleanup, not safe replay.
+
+## Recommendation
+
+Adopt this approach when state ownership flexibility and teardown recovery outweigh the clarity of an explicit `Hold` variant. Keep buffering as an optional adapter at the middleware seam, keep protocol projection and ordered sending inside the deep pipeline/connection module, and ship the bounded in-state adapter so the safest implementation is also the easiest one.

--- a/docs/design/backend-batching-crate-hold.md
+++ b/docs/design/backend-batching-crate-hold.md
@@ -1,0 +1,368 @@
+# Crate-owned backend holds
+
+## Status and intent
+
+This is a design proposal, not an implementation commitment. It adds a crate-owned
+holding module at the intermediary backend-forwarding seam. The module enables an
+async, fallible middleware adapter to retain a bounded group of PostgreSQL backend
+messages and later replace that group with zero, one, or many messages. It is aimed
+at policies such as decrypting or filtering rows in batches.
+
+The design deliberately keeps `Pipeline` payload-free. `Pipeline` remains the
+protocol-obligation ledger; the new module owns deferred payloads. This preserves
+the separation in ADR 0002 between wire receipt, policy, and session advancement.
+
+## v0.8.0 baseline
+
+This proposal targets tag `pg-proto-v0.8.0`. At that tag the forwarding-boundary
+`IntermediaryMiddleware` is already async and fallible. Its backend result supports
+`Forward`, non-empty ordered `Expand`, and `Suppress`. `process_backend` applies
+client-role interception before this hook and server-role interception afterward.
+It projects each forwarded/expanded output, projects a suppressed source without
+writing it, then flushes queued local responses. `Pipeline` remains payload-free
+and can return an owned `BackendAction::Deferred`. The missing capability is to
+retain several source messages across calls before choosing the existing forward,
+fan-out, or suppression outcome.
+
+## Seam and interface
+
+The seam belongs in the existing `IntermediaryMiddleware::backend` position: after
+the PostgreSQL-facing role has decoded and intercepted a backend wire message and
+before server-role middleware, projection, and encoding. A single per-connection
+`BackendHold` module sits there. The existing middleware interface gains one result
+variant and one optional hook; the connection gains one explicit flush entry point:
+
+```rust
+pub enum BackendMiddlewareOutput {
+    Forward(BackendMessage),
+    Expand(Vec<BackendMessage>),
+    Suppress(BackendMessage),
+    /// Defer this source in the connection-owned, bounded hold.
+    Hold(BackendMessage),
+}
+
+pub trait IntermediaryMiddleware<State, ServerContext, ClientContext> {
+    // Existing frontend(...) and backend(...) remain.
+    fn flush_backend<'a>(
+        &'a mut self,
+        server: &'a ServerContext,
+        client: &'a ClientContext,
+        state: &'a mut State,
+        held: HeldBackendMessages,
+        reason: BackendFlushReason,
+    ) -> Pin<Box<dyn Future<
+        Output = Result<BackendFlushOutput, Self::Error>
+    > + 'a>>;
+}
+
+impl<...> IntermediaryConnection<...> {
+    pub async fn flush_backend_hold(
+        &mut self,
+    ) -> Result<BackendForwarding, ForwardError<...>>;
+}
+```
+
+`forward_backend` keeps its v0.8.0 entry point and result type. On `Hold`, it moves
+the returned source into the connection-owned queue and reports a new
+`BackendForwarding::Held` outcome. `Forward`, `Expand`, and `Suppress` retain their
+v0.8.0 one-source meanings. Before processing a barrier or admitting a message
+that would exceed capacity, the driver first releases the held prefix through
+`flush_backend`; it never silently combines a later one-source decision with that
+prefix. `flush_backend_hold` performs the same operation explicitly without
+reading upstream. The identity implementation returns the messages unchanged.
+Thus the middleware interface has two backend hooks and the driver has two relevant
+calls (`forward_backend`, `flush_backend_hold`).
+
+`HeldBackendMessages` is an opaque, ordered, non-empty owned collection. Middleware
+can iterate it and consume it with `into_messages`; only the crate constructs it.
+`BackendFlushOutput` is `Release(Vec<BackendMessage>)` or `Hold(HeldBackendMessages)`.
+An empty release suppresses the held span; unlike v0.8.0 `Expand`, it is legal here
+because its source span is explicit.
+
+The context exposes immutable role contexts plus a reason:
+
+```rust
+pub enum BackendFlushReason {
+    Capacity,
+    ProtocolBarrier,
+    ExplicitFlush,
+    Teardown,
+}
+```
+
+The flush context also exposes `held_messages`, `held_bytes`, and configured limits.
+It does not expose `Pipeline`, operation IDs, transports, or projection methods.
+Middleware can therefore await storage or a batch cryptography engine and fail,
+but cannot partially advance protocol state.
+
+An empty flush release is suppression. A one-element release is the ordinary
+interception case. Multiple elements are ordered fan-out. `Hold` is a
+crate type and the held messages remain fields of `IntermediaryConnection`; the
+adapter never has to put payloads in user-defined connection state.
+
+The default `flush_backend` returns `Release(held.into_messages())`, so existing
+middleware remains source-compatible unless it exhaustively matches
+`BackendMiddlewareOutput`. A builder method enables non-zero hold limits:
+
+```rust
+intermediary
+    .backend_batching(RowDecryptor::new(keys), BackendHoldLimits {
+        max_messages: 256,
+        max_bytes: 4 * 1024 * 1024,
+    })
+```
+
+The exact spelling may change, but the interface facts and ownership must not.
+
+## Protocol projection invariants
+
+1. **Every received input is accounted for exactly once.** It is in exactly one
+   of: the unread transport, the crate-owned hold, an in-flight middleware call,
+   a committed release, or the terminal error payload. It is never both projected
+   and held.
+2. **A release is atomic with respect to projection.** The implementation first
+   simulates the whole replacement sequence against a cloned/snapshot projection
+   ledger. It commits the snapshot only if every output is reconstructable, legal,
+   and attributable in order. No prefix is projected on failure.
+3. **Input obligations are consumed exactly once.** The simulation carries both
+   the original held input sequence and its replacement sequence. It verifies that
+   the replacement is a legal projection of the same operation span. Suppression
+   consumes the input span without writing; fan-out may contain extra non-advancing
+   messages, but may not consume an operation outside that span.
+4. **Every released output is projected exactly once before encoding.** There is
+   no encode path which bypasses the committed projection. A write failure does
+   not roll projection back; it is terminal because bytes may already have escaped.
+5. **Order is stable.** Inputs retain wire order. Outputs retain adapter order.
+   A later operation cannot be released before an earlier held operation. PostgreSQL
+   asynchronous messages may be emitted early only when doing so does not cross a
+   held relative-order requirement; the conservative initial implementation holds
+   them with the batch.
+6. **Each newly received message crosses `backend` once.** On `Hold`, its returned
+   value is moved into the queue without cloning. Held values cross only
+   `flush_backend`, when the crate transfers the whole queue. A cancelled flush
+   restores that same owned queue with an internal guard.
+7. **No frontend read may increase outstanding work while the backend hold is at
+   capacity.** `forward_next` disables the downstream-read branch and forces a
+   capacity release attempt.
+
+The span check in invariant 3 is essential. Merely applying each replacement to
+the current `Pipeline` would permit a middleware bug to suppress `ReadyForQuery`,
+invent a second completion, or accidentally consume the next operation.
+
+## Capacity and backpressure
+
+Both a message count and estimated decoded payload-byte count are mandatory,
+non-zero configuration. Before reading upstream, the driver reserves one maximum
+frame slot using the connection's configured maximum frame length. Once a newly
+decoded message reaches either limit, middleware is called with `Capacity` and
+must return `Release`; `Hold` becomes `BackendHoldError::Capacity` carrying the
+intact hold. The driver stops reading both upstream and frontend traffic after
+that error. There is no unbounded retry loop.
+
+Known protocol barriers also force a release rather than allowing a batch to cross
+an observable command boundary. The initial conservative barrier catalogue is
+`ErrorResponse`, `ReadyForQuery`, COPY mode changes/completions, and connection
+termination. `CommandComplete` can be batched with preceding row data but ends the
+batch. Catalogue decisions live next to backend grammar projection, not in each
+adapter. Explicit `flush_backend_hold` handles latency timers owned by an
+application driver.
+
+Transport output buffering remains separate: a successful release projects the
+entire output, pushes its frames in order, then flushes according to the existing
+transport policy. The hold limit therefore controls decoded policy payloads, not
+encoded transport bytes.
+
+## Errors and teardown
+
+```rust
+pub enum BackendHoldError<E> {
+    Io(io::Error),
+    Middleware { error: E, held: HeldBackendMessages },
+    Capacity { held: HeldBackendMessages },
+    Projection { error: BackendProjectionError, held: HeldBackendMessages,
+                 output: Vec<BackendMessage> },
+}
+```
+
+All errors before projection return ownership of the intact input and, where
+useful, proposed output. The connection becomes poisoned after middleware,
+capacity, or projection failure: callers may inspect or tear it down, but may not
+resume forwarding accidentally. This avoids specifying whether fallible middleware
+is safe to replay.
+
+Deliberate teardown performs one `Teardown` release attempt. A successful release
+is written and flushed before transports are recovered. A failed or refused
+release returns `IntermediaryTeardownError` containing the connection parts and
+held messages; it must never silently drop a non-empty hold. An explicit
+`abort_backend_hold(self)` escape hatch may recover parts while reporting the
+dropped messages, but should be visibly destructive and separate from `teardown`.
+`Drop` cannot await and therefore only closes transports; debug builds should
+assert/log when a live hold is dropped.
+
+After projection commit, any encoding or write failure is terminal and teardown
+does not retry the release. This module owns that policy because only it knows
+whether projection committed and whether a frame prefix may have been written.
+
+## Hidden implementation
+
+The implementation should be local to a new private `backend_hold` module plus a
+small field and delegation in `IntermediaryConnection`:
+
+```rust
+struct BackendHold {
+    input: VecDeque<HeldBackend>,
+    bytes: usize,
+    generation: u64,
+    status: HoldStatus,
+}
+
+struct HeldBackend {
+    message: BackendMessage,
+    // Private attribution captured without advancing the live ledger.
+    span: ResponseSpan,
+}
+```
+
+`Pipeline` gains private prepare/simulate/commit support, not a public payload
+queue. A projection transaction clones only its lightweight operation ledger,
+projects the original sequence to determine its operation span, projects proposed
+outputs within that span, and swaps the ledger on success. If cloning the ledger
+is undesirable, an undo-free prepared transition log provides the same atomicity.
+
+Barrier classification, byte accounting, poisoning, release transactions, and
+teardown bookkeeping stay hidden. This gives the module depth: two middleware hooks
+and two driver calls hide ownership, ordering, capacity, exact-once projection,
+transport sequencing, and recovery. The seam gives callers leverage and keeps
+protocol failure fixes local.
+
+## Dependencies and adapters
+
+- `backend_hold` depends on decoded `BackendMessage`, private pipeline projection,
+  the configured maximum frame length, and the intermediary's existing transport.
+- `Pipeline` does not depend on middleware or transport and remains payload-free.
+- The identity adapter preserves today's behavior.
+- The existing role middleware ordering is preserved: client-role interception
+  occurs before holding; server-role interception occurs on each released output.
+- A test adapter releases scripted batches and failures. It crosses the same seam
+  as production adapters; no test-only projection bypass is added.
+
+The batching seam is real only when identity, legacy single-message, and batching
+adapters exist. Internal seams (span simulation and barrier catalogue) remain
+private because applications do not vary them safely.
+
+## Example
+
+```rust
+fn backend<'a>(
+    &mut self,
+    _server: &'a ServerCx,
+    _client: &'a ClientCx,
+    _state: &'a mut State,
+    message: BackendMessage,
+) -> Pin<Box<dyn Future<Output = Result<BackendMiddlewareOutput, Error>> + 'a>> {
+    Box::pin(async move {
+        Ok(match message {
+            message @ BackendMessage::DataRow(_) => BackendMiddlewareOutput::Hold(message),
+            barrier => BackendMiddlewareOutput::Forward(barrier),
+        })
+    })
+}
+
+fn flush_backend<'a>(
+    &mut self,
+    _server: &'a ServerCx,
+    _client: &'a ClientCx,
+    state: &'a mut State,
+    input: HeldBackendMessages,
+    _reason: BackendFlushReason,
+) -> Pin<Box<dyn Future<Output = Result<BackendFlushOutput, Error>> + 'a>> {
+  Box::pin(async move {
+    let mut output = Vec::new();
+    for message in input.into_messages() {
+        match message {
+            BackendMessage::DataRow(row) if !state.row_visible(&row).await? => {}
+            BackendMessage::DataRow(row) => {
+                output.extend(state.decrypt_and_split(row).await?);
+            }
+            other => output.push(other),
+        }
+    }
+    Ok(BackendFlushOutput::Release(output))
+  })
+}
+```
+
+This shows suppression and ordered fan-out without storing messages in `State`.
+The actual legality of suppressing or splitting a particular message is determined
+by the atomic span validator, not trusted to the adapter.
+
+## Tests
+
+Tests should exercise the interface rather than reach through it:
+
+- identity parity with current one-message forwarding;
+- hold across several `DataRow` messages, then release at `CommandComplete`;
+- ordered fan-out and suppression within one operation span;
+- rejection of output that consumes too few or too many operation transitions;
+- no live-ledger mutation when element 2 of a proposed output fails projection;
+- exactly one projection per input span and per emitted output, using a recording
+  projection adapter or observable ledger state;
+- asynchronous messages conservatively preserve wire order while a hold exists;
+- count, byte, and maximum-frame capacity behavior, including frontend read gating;
+- async middleware suspension while neither payload ownership nor state is exposed
+  to another forwarding call (the connection's `&mut self` enforces this);
+- middleware error returns the intact ordered hold and poisons forwarding;
+- cancellation of `forward_backend` before and during middleware does not
+  lose the decoded input; use an internal guard to restore in-flight input on drop;
+- write failure after projection is terminal and never replays output;
+- teardown flush success, teardown refusal/error recovery, and explicit abort;
+- COPY, extended-error drain, pipelined operations, and protocol barrier catalogue;
+- property tests comparing atomic simulation with sequential projection for all
+  legal sequences and proving failed proposals leave the live ledger unchanged.
+
+## Migration
+
+1. Introduce the private hold module and projection transaction tests without
+   changing the identity forwarding path.
+2. Add `Held` to `BackendForwarding`/`ForwardedMessage` and route existing
+   `forward_backend` through the hold module while proving identity parity.
+3. Preserve and test the v0.8.0 client-role/boundary/server-role ordering.
+4. Add builder configuration and limits, then integrate hold-aware `forward_next`.
+5. Replace `ForwardError::Deferred(BackendMessage)` with internal crate-owned
+   queuing. During a deprecation window, map impossible legacy deferred cases to a
+   terminal compatibility error rather than returning payload ownership.
+6. Make teardown fallible only for configurations that can hold, or introduce a
+   new fallible teardown first and deprecate the infallible method once downstream
+   callers can migrate.
+
+## Advantages
+
+- Strong locality: payload lifetime, projection atomicity, capacity, and teardown
+  ownership are implemented once rather than reconstructed by every caller.
+- A deep module: a two-hook middleware interface provides batching, suppression,
+  fan-out, async work, ordering, and backpressure.
+- User state remains domain state rather than a protocol recovery queue.
+- The crate can enforce exact-once projection and reject invalid replacement spans.
+- `Pipeline` retains its useful payload-free design and bounded operation ledger.
+- Cancellation and errors can return or recover one authoritative owned batch.
+
+## Costs and risks
+
+- The crate takes on substantial implementation complexity: atomic span validation,
+  cancellation guards, memory accounting, poisoning, and fallible teardown.
+- `BackendMessage` payload size is only an estimate unless every variant exposes
+  exact retained allocation size; limits must document that characteristic.
+- The two-hook interface requires batching adapters to split per-message admission
+  from whole-batch transformation.
+- Conservative asynchronous-message ordering and barriers can add latency.
+- Fan-out/suppression legality is subtle and couples private hold code to generated
+  backend grammar semantics.
+- Existing `forward_backend -> BackendForwarding` needs a `Held` outcome, while
+  infallible teardown cannot represent a refused flush, so migration adds surface.
+- Applications with specialized scheduling may find crate-owned policy less
+  flexible than retaining messages in their own connection state.
+
+The deletion test favors this module: deleting it would redistribute payload
+ownership, exact-once projection, ordering, capacity, cancellation, and teardown
+logic into every batching caller. That is enough leverage to justify the seam,
+provided the external interface remains limited to two hooks and two driver calls.

--- a/docs/design/backend-batching-implementation-handoff.md
+++ b/docs/design/backend-batching-implementation-handoff.md
@@ -1,0 +1,347 @@
+# Implementation handoff: ordered backend batch holding
+
+## Objective
+
+Widen pg-proto's builder-only intermediary interface so CipherStash can retain
+multiple PostgreSQL `DataRow` messages, transform them asynchronously as a batch,
+then forward the same number of replacement rows in original order. Each source
+and replacement must affect protocol state exactly once.
+
+This is a one-to-one delayed replacement capability. Preserve the independent
+meaning of `BackendMiddlewareOutput::Expand`: immediate replacement of one
+received message with multiple outgoing messages.
+
+## Start here
+
+Read these sources before editing:
+
+- [`backend-batching-prototype-report.md`](backend-batching-prototype-report.md)
+  contains the validated decision and rejected alternatives.
+- [`backend-batching-crate-hold.md`](backend-batching-crate-hold.md) contains the
+  fuller crate-owned design, including limits, barriers, errors, and tests.
+- [`backend-batching-comparison.md`](backend-batching-comparison.md) compares the
+  ownership seams.
+- [`backend-batching-prototype.html`](backend-batching-prototype.html) is a
+  throwaway state-machine primary source, not production code.
+- `CONTEXT.md` defines project terminology.
+- `docs/adr/0002-proxy-interception-boundary.md` requires wire receipt, policy,
+  and session advancement to remain separate.
+
+The repository is currently at pg-proto 0.8.0. The design documents are untracked
+in the working tree at the time of this handoff; preserve them when creating the
+implementation branch.
+
+## Existing 0.8.0 behaviour
+
+The relevant implementation is in `src/intermediary_component.rs`:
+
+- `BackendMiddlewareOutput` supports `Forward`, `Expand`, and `Suppress`.
+- `process_backend` receives and source-role-intercepts one message, invokes
+  async boundary middleware, then destination-role-intercepts output.
+- `Suppress(message)` calls `advance_backend(message)` immediately.
+- `Expand(messages)` calls `emit_backend` for every output immediately and
+  rejects an empty vector.
+- `emit_backend` calls `Pipeline::accept_backend` before writing downstream.
+- `forward_next` selects between frontend and backend transports.
+- `teardown` currently assumes no retained backend payloads.
+
+The ordering ledger is in `src/pipeline.rs`. It intentionally retains operation
+metadata rather than message payloads. Keep it payload-free.
+
+The defect is observable when middleware stores rows elsewhere and returns
+`Suppress`: every source is projected immediately, then each later re-emitted row
+is projected again. `Expand` cannot represent delayed forwarding because it has
+one current source and immediate output semantics.
+
+## Chosen ownership model
+
+The intermediary connection owns authoritative uncommitted backend messages.
+Caller-defined connection state may own derived application data such as crypto
+workspaces, decrypted values, tenant facts, and spill handles. It is not the
+authoritative owner of received protocol messages.
+
+Use these ownership states:
+
+```text
+transport
+  → pending source
+  → crate-owned hold
+  → borrowed by async batch policy
+  → atomically prepared replacements
+  → projected and written in order
+```
+
+At every await point, each source must remain reachable through exactly one
+connection-owned location. Cancellation restores control without replaying
+source-role or boundary middleware.
+
+## Target interface shape
+
+Treat names as provisional, but preserve the semantics:
+
+```rust
+pub enum BackendMiddlewareOutput {
+    Forward(BackendMessage),
+    Expand(Vec<BackendMessage>),
+    Suppress(BackendMessage),
+
+    /// Retain the unchanged current source without projection or output.
+    Hold,
+}
+
+pub enum BackendBatchOutput {
+    /// Keep the authoritative input span uncommitted.
+    KeepHolding,
+
+    /// Atomically replace every held input with one output in the same position.
+    ReplaceOneToOne(Vec<BackendMessage>),
+}
+
+pub enum BackendFlushReason {
+    Capacity,
+    ProtocolBarrier,
+    Explicit,
+    Teardown,
+}
+```
+
+Add an async/fallible batch hook to `IntermediaryMiddleware`. The held span is
+borrowed so cancellation cannot drop it:
+
+```rust
+fn flush_backend<'a>(
+    &'a mut self,
+    server: &'a ServerContext,
+    client: &'a ClientContext,
+    state: &'a mut State,
+    held: &'a HeldBackendMessages,
+    reason: BackendFlushReason,
+) -> Pin<Box<
+    dyn Future<Output = Result<BackendBatchOutput, Self::Error>> + 'a,
+>>;
+```
+
+`HeldBackendMessages` is an opaque ordered view. Expose iteration and safe message
+inspection, not mutation, transport access, pipeline access, or projection
+methods. The default hook returns one-to-one clones of the held messages so
+identity middleware remains usable. `BackendMessage` already has cheap cloning
+for byte payloads; measure before pursuing a more elaborate lending result.
+
+`Hold` is deliberately a unit variant. Before awaiting boundary middleware, the
+connection retains the post-client-role-interception source in a private pending
+slot and passes a clone to the existing owned-message hook. If the hook returns
+`Hold`, move the authoritative pending source into the hold. If the future is
+cancelled, the source remains in the connection. Do not require middleware to
+return the authoritative message it is asking pg-proto to retain.
+
+Add explicit builder configuration for non-zero message and byte limits. No
+implicit unbounded hold is acceptable. Existing configurations that never return
+`Hold` should preserve their current behaviour without allocating a hold queue.
+
+## Required semantics
+
+### One-to-one release
+
+The first production slice supports equal input and output cardinality only. A
+held span of length `n` accepts exactly `n` replacements. Preserve order by index.
+This is the CipherStash requirement and keeps general fan-out out of the delayed
+batch state machine.
+
+The current barrier is not part of the held row span unless middleware explicitly
+returns `Hold` for it. On a known barrier with pending rows:
+
+1. invoke `flush_backend` with `ProtocolBarrier`;
+2. atomically project and emit the replacements;
+3. process the barrier through its normal one-message decision; and
+4. emit the barrier after the released rows.
+
+Conservatively classify `CommandComplete`, `PortalSuspended`,
+`EmptyQueryResponse`, `ErrorResponse`, `ReadyForQuery`, COPY phase transitions,
+and asynchronous messages as barriers in the first implementation. Co-locate the
+catalogue with backend projection rules and prove each entry with a tracer test.
+
+### Atomic projection
+
+Add private prepare/commit support to `Pipeline` for a complete backend sequence.
+Dry-run replacements against a clone or prepared transition log of the lightweight
+ledger. Commit the live ledger only if every replacement is reconstructable,
+legal, attributable to the same held response span, and ordered.
+
+Do not project original held messages and then project replacements. The original
+sequence is used only to validate the response span and cardinality. The committed
+downstream projection consists of the replacements exactly once.
+
+No socket write occurs until the entire sequence validates. Once writes begin, an
+I/O failure is terminal because a frame prefix may be visible; do not roll back or
+replay projection.
+
+### Pressure and driving
+
+Track both held message count and estimated retained bytes. When either limit is
+reached:
+
+1. stop polling the upstream backend transport;
+2. invoke the batch hook with `Capacity`;
+3. accept only a successful release; and
+4. return a structured capacity error carrying the intact connection/hold if
+   middleware elects to keep holding.
+
+Update `forward_next` so frontend polling cannot create more outstanding work
+while a full backend hold blocks progress. Preserve existing pipeline admission
+and local-response ordering.
+
+Provide an explicit `flush_backend_hold()` operation for latency timers and
+application-controlled batch boundaries. It reads no new upstream frame.
+
+### Errors and teardown
+
+Preserve ownership in every pre-write error:
+
+- middleware failure leaves the hold intact;
+- cancellation leaves the hold intact;
+- cardinality/projection failure returns proposed outputs and leaves the live
+  ledger and hold unchanged;
+- capacity refusal leaves the hold intact; and
+- encoding failure before any write returns the unsent values.
+
+A normal teardown cannot silently discard a hold. Make the hold-aware teardown
+fallible or add a distinct fallible teardown operation before changing the
+existing method. It should attempt a `Teardown` flush and return all connection
+parts plus held inputs on refusal/failure. Provide a visibly destructive abort
+only if callers genuinely need to discard retained messages.
+
+## Implementation sequence
+
+Follow tracer bullets; keep each slice green before widening the next seam.
+
+### 1. Red ownership tests
+
+Add facade-level in-memory tests demonstrating the current failure and desired
+state transitions. Completion criterion: tests fail because 0.8.0 lacks `Hold`,
+not because fixtures bypass the builder interface.
+
+Cover:
+
+- three held rows released one-to-one before `CommandComplete`;
+- no downstream bytes and no live-ledger advancement while held;
+- each replacement projected once;
+- stable row order; and
+- `Expand` retains its immediate one-to-many behaviour in a separate regression.
+
+### 2. Private hold module
+
+Implement a private payload owner with pending, held, flushing, and poisoned
+states. Add message/byte accounting and cancellation-safe restoration. Completion
+criterion: unit tests account for every source across each state transition and
+the public interface is unchanged.
+
+### 3. Atomic pipeline preparation
+
+Add private backend-sequence dry-run and commit operations. Completion criterion:
+an illegal element at every batch index leaves the authoritative ledger unchanged,
+while a legal sequence commits the same final state as sequential one-message
+projection.
+
+### 4. Middleware and builder seam
+
+Add `Hold`, the borrowed batch hook, opaque held view, limits, forwarding outcomes,
+and explicit flush. Completion criterion: identity, ordinary forward, suppress,
+and immediate expand regressions remain green; a batching adapter can be written
+using only root-facade types.
+
+### 5. Driver, barriers, and pressure
+
+Integrate automatic barrier/capacity flush into `forward_backend` and
+`forward_next`. Completion criterion: the transport-poll tracer proves no extra
+backend read at capacity, and asynchronous/COPY/extended-error cases preserve
+wire order.
+
+### 6. Recovery and teardown
+
+Make all pre-write failures ownership-preserving and define fallible teardown.
+Completion criterion: cancellation at every await point and injected failures at
+every preparation/write boundary account for every input and unsent output.
+
+### 7. CipherStash-shaped acceptance test
+
+Build a facade-only adapter whose connection state contains derived batch data
+but no authoritative raw-message queue. Buffer encrypted rows, perform one async
+batch transformation, release equal-cardinality decrypted rows, and forward the
+terminator. Completion criterion: the peer observes exact order and cardinality,
+projection counters are one, and teardown has an empty hold.
+
+### 8. Documentation and compatibility
+
+Update README/rustdoc/MIGRATION and the public-surface manifest. Document
+`Forward`, immediate `Expand`, committed `Suppress`, and deferred `Hold` as four
+distinct concepts. Completion criterion: every public snippet compiles and audits,
+doctests, examples, compile-fail tests, MSRV, Clippy, rustdoc, and the workspace
+suite pass.
+
+## Test matrix
+
+At minimum, cover:
+
+- simple-query `DataRow` batches of zero, one, limit, and limit-plus-one rows;
+- extended query with `PortalSuspended` and `CommandComplete`;
+- `ErrorResponse` followed by extended error drain and `ReadyForQuery`;
+- asynchronous `NoticeResponse`, `NotificationResponse`, and `ParameterStatus`;
+- COPY IN, OUT, and BOTH transitions;
+- pipelined operations, proving a later response cannot overtake a held span;
+- middleware error, cancellation, invalid cardinality, illegal replacement,
+  encoding failure, write failure, and teardown refusal;
+- count and byte limits independently, including one oversized row policy;
+- role middleware order: client role once per source, boundary batch policy once,
+  server role once per replacement; and
+- property tests for ownership conservation, stable order, and failed atomic
+  preparation leaving the live ledger unchanged.
+
+Use deterministic in-memory transports for primary coverage. PostgreSQL container
+compatibility is supplementary.
+
+## Guardrails and traps
+
+- Keep `Expand` immediate and one-source-to-many-output. It is orthogonal to this
+  feature.
+- Keep `Suppress` committed. A suppressed source cannot later be replayed.
+- Keep authoritative raw messages out of caller-defined connection state.
+- Keep `Pipeline` payload-free; the private hold owns payloads.
+- Keep held inputs borrowed across async batch policy so cancellation cannot drop
+  them.
+- Keep destination-role middleware on replacements at release time, exactly once.
+- Preserve source-role middleware timing before a source enters the hold.
+- Make capacity affect transport polling, not merely vector insertion.
+- Validate the entire replacement span before changing the live ledger or writing.
+- Treat partial writes as terminal; recovery means accounting, not replay.
+- Avoid a public projection token or operation-ledger escape hatch.
+- Avoid empty `Expand` as an implicit retention signal.
+- Avoid expanding the first slice into a general streaming response scheduler.
+
+## Verification commands
+
+Use the repository's current CI-equivalent commands rather than relying only on
+focused tests. At handoff time the expected checks include:
+
+```sh
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps
+cargo test --workspace
+cargo test --workspace --doc
+cargo check --workspace --examples
+cargo bench --workspace --no-run
+git diff --check
+```
+
+Also run the deterministic public-surface and documentation audits already present
+in the repository, plus Rust 1.88 all-target checking. If sandbox restrictions
+block loopback tests, rerun those tests outside the sandbox and report that fact.
+
+## Definition of done
+
+The feature is complete when a facade-only CipherStash-shaped adapter can retain
+and asynchronously transform ordered DataRows in batches without `Suppress` or
+`Expand`, every source and replacement is accounted for exactly once, capacity
+stops upstream reads, cancellation and pre-write failures preserve ownership,
+teardown cannot silently discard held inputs, all existing forwarding modes retain
+their semantics, and the full repository verification matrix passes.

--- a/docs/design/backend-batching-prototype-report.md
+++ b/docs/design/backend-batching-prototype-report.md
@@ -1,0 +1,160 @@
+# Backend batching prototype report
+
+## Question
+
+Which design best supports CipherStash's ordered, one-to-one transformation of a
+batch of `DataRow` messages without projecting a source twice or losing ownership
+while asynchronous transformation is pending?
+
+The throwaway [backend batching state-machine lab](backend-batching-prototype.html)
+models the three options from the comparison report. It exposes every received
+message's current owner, pending and in-flight batches, emitted order, input and
+output projection counts, connection closure, and an event log.
+
+## Scenarios exercised
+
+Each option was driven through the same state transitions:
+
+1. receive three `DataRow` messages without projection;
+2. receive `CommandComplete`, atomically transform and flush the ordered batch;
+3. reach a three-row capacity limit and refuse another transport read;
+4. cancel while a flush owns the batch and restore every uncommitted message;
+5. tear down with a non-empty batch; and
+6. attempt to claim retention without actually storing the received row.
+
+The model deliberately uses a one-to-one transformation:
+
+```text
+DataRow(1), DataRow(2), DataRow(3), CommandComplete
+    ↓ async batch transformation
+DataRow'(1), DataRow'(2), DataRow'(3), CommandComplete
+```
+
+`Expand` is not needed for this operation. The relevant capability is delayed,
+atomic replacement of an ordered input span.
+
+## Prototype results
+
+### Crate-owned hold
+
+The happy path is direct: every row moves from transport ownership into the
+connection hold without projection. At the barrier, the whole span moves into an
+in-flight transaction, is validated, and is committed once. Cancellation restores
+the same values to the hold. Capacity is visible to the connection before it
+polls the transport again.
+
+The prototype could not express “reported retained but lost the value”: the
+decision transfers the owned message into a crate-controlled collection. This is
+the strongest result of the experiment. The public `Hold` spelling is less
+important than the ownership transfer it represents.
+
+The cost predicted by the paper design remains. Teardown becomes fallible or must
+return the hold explicitly, and pg-proto must implement limits, atomic projection,
+cancellation guards, and barrier handling.
+
+### Caller-defined connection-state buffering
+
+The correct implementation follows the same successful state graph. Middleware
+moves each row into the caller-defined connection state, returns a non-projecting
+decision, then drains that state at the barrier. It naturally supports
+application-specific row representations and teardown already recovers the state.
+
+The contract-violation scenario exposed its weakness. Middleware can report that
+an input was retained without inserting it into state. From pg-proto's side the
+decision is indistinguishable from a correct retention, yet the ownership
+invariant fails immediately. The reverse error—storing a row while returning
+`Suppress`—would recreate the double-projection problem when the stored row is
+later emitted.
+
+The prototype also confirmed that bounding a `VecDeque` is not enough. The driver
+needs a mandatory pressure/drain interface before it can know not to poll another
+backend frame. At that point the supposedly small design has gained a second
+coordination protocol whose invariants remain split across crate and caller.
+
+### Ordered response collector
+
+The collector also makes the invalid ownership transition unrepresentable and
+provides the cleanest driver: received messages enter a private transaction and
+the driver drains legal output in order. Cancellation, backpressure, and retry are
+local to one module.
+
+For CipherStash's case, however, its extra scheduling machinery produced no
+additional useful state transition. There is one upstream response stream, one
+downstream response stream, and an order-preserving one-to-one transformation.
+Local response producers, fairness between producers, and operation scheduling
+would increase implementation and teardown complexity without solving a further
+requirement demonstrated by the tracer.
+
+## Comparative findings
+
+| Finding | Crate-owned hold | Connection state | Response collector |
+| --- | --- | --- | --- |
+| Ordered 1:1 batch | Natural | Natural when correctly implemented | Natural |
+| Lost-retention state representable | No | Yes | No |
+| Double projection preventable locally | Yes | Depends on caller contract | Yes |
+| Driver can enforce pressure | Yes | Only through another mandatory interface | Yes |
+| Specialised application storage | Requires an adapter or derived state | Native | Requires an adapter/producer |
+| Added machinery for this use case | Moderate | Low initially, moderate when made safe | High |
+| Interface depth | High | Low: correctness spans the seam | High, but broader than required |
+
+## Final recommendation
+
+Implement the **crate-owned hold**, narrowed to ordered one-to-one batch
+replacement rather than general fan-out.
+
+The prototype changes the emphasis of the earlier paper recommendation. The
+important primitive is not `Hold` plus `Expand`; it is an owned, uncommitted input
+span with one atomic release:
+
+```rust
+enum BackendMiddlewareOutput {
+    Forward(BackendMessage),
+    Suppress(BackendMessage),
+    Hold(BackendMessage),
+}
+
+enum BackendBatchOutput {
+    ReplaceOneToOne(Vec<BackendMessage>),
+    KeepHolding,
+}
+```
+
+The exact names need refinement, and `ReplaceOneToOne` should ideally carry a
+crate-issued opaque batch token or consume `HeldBackendMessages` so the output
+cardinality can be checked against the authoritative input span. A release must:
+
+1. consume the held span as a single owned value;
+2. require the same number of ordered replacement messages for CipherStash's
+   initial use case;
+3. dry-run the complete span against separate lightweight input and output
+   projections;
+4. commit only when every replacement is legal;
+5. restore the original span if the async policy future is cancelled before
+   commit; and
+6. stop upstream reads at explicit message and byte limits.
+
+Keep application-derived batch data—cryptographic workspaces, decrypted values,
+tenant facts, and spill handles—in caller-defined connection state. Keep the
+authoritative uncommitted `BackendMessage` values in pg-proto. This hybrid assigns
+each owner the facts it can enforce.
+
+Do not use empty `Expand` as retention, and do not require `Expand` for the
+CipherStash migration. General one-to-many replacement can remain an independent
+capability with immediate semantics. The ordered response collector should be
+revisited only if local streaming responses or multiple competing response
+producers become concrete requirements.
+
+## Implementation tracer bullets
+
+Before widening the production interface, implement these four tests against a
+minimal private hold module:
+
+- three `DataRow` inputs become three replacements followed by the unchanged
+  terminator, with each input and output projection counted once;
+- cancellation at every await point returns all held messages in original order;
+- reaching either hold limit prevents another backend transport poll; and
+- cardinality mismatch or an illegal replacement leaves the live projection and
+  authoritative hold unchanged.
+
+These tests answer the ownership and state questions without committing to the
+final public naming.

--- a/docs/design/backend-batching-prototype.html
+++ b/docs/design/backend-batching-prototype.html
@@ -1,0 +1,235 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>PROTOTYPE — pg-proto backend batching</title>
+  <style>
+    :root { color-scheme: light dark; font-family: ui-monospace, monospace; }
+    body { max-width: 1050px; margin: 2rem auto; padding: 0 1rem; }
+    h1 { margin-bottom: .25rem; }
+    .warning { color: #c55; font-weight: bold; }
+    .tabs, .actions { display: flex; flex-wrap: wrap; gap: .5rem; margin: 1rem 0; }
+    button { padding: .55rem .8rem; cursor: pointer; }
+    button.active { outline: 3px solid #4b9; }
+    .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(270px, 1fr)); gap: 1rem; }
+    section { border: 1px solid #8888; border-radius: .5rem; padding: 1rem; }
+    pre { white-space: pre-wrap; overflow-wrap: anywhere; min-height: 8rem; }
+    table { width: 100%; border-collapse: collapse; }
+    th, td { border-bottom: 1px solid #8885; padding: .4rem; text-align: left; }
+    .ok { color: #297; }
+    .bad { color: #d55; }
+  </style>
+</head>
+<body>
+  <h1>Backend batching state-machine lab</h1>
+  <p class="warning">PROTOTYPE — throwaway model, not pg-proto production code.</p>
+  <p>
+    Question: which ownership model best supports an ordered 1:1 transformation
+    of buffered <code>DataRow</code> messages without double projection?
+  </p>
+
+  <nav class="tabs" aria-label="Design">
+    <button data-design="hold">Crate-owned hold</button>
+    <button data-design="state">Connection state</button>
+    <button data-design="collector">Response collector</button>
+  </nav>
+
+  <div class="actions">
+    <button data-action="row">Receive DataRow</button>
+    <button data-action="terminator">Receive CommandComplete</button>
+    <button data-action="flush">Explicit flush</button>
+    <button data-action="cancel">Cancel during flush</button>
+    <button data-action="violate">Attempt lost retention</button>
+    <button data-action="teardown">Teardown</button>
+    <button data-action="reset">Reset</button>
+  </div>
+
+  <div class="grid">
+    <section>
+      <h2>Full state</h2>
+      <pre id="state"></pre>
+    </section>
+    <section>
+      <h2>Event log</h2>
+      <pre id="log"></pre>
+    </section>
+  </div>
+
+  <section>
+    <h2>Live invariant check</h2>
+    <table>
+      <tbody>
+        <tr><th>Every received message owned</th><td id="owned"></td></tr>
+        <tr><th>No input projected twice</th><td id="once"></td></tr>
+        <tr><th>Output order preserved</th><td id="order"></td></tr>
+        <tr><th>Capacity bounded (3 rows)</th><td id="capacity"></td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <script>
+    const models = {
+      hold: {
+        title: "crate-owned hold",
+        owner: "connection.hold",
+        cancellation: "connection restores the in-flight hold",
+        teardown: "fallible: returns the authoritative hold",
+      },
+      state: {
+        title: "caller-defined connection state",
+        owner: "state.rows",
+        cancellation: "future must have moved every row back into state",
+        teardown: "state is recovered, but correctness is a middleware contract",
+      },
+      collector: {
+        title: "ordered response collector",
+        owner: "connection.collector",
+        cancellation: "scheduler retains the in-flight transaction",
+        teardown: "fallible: returns collector queue and producer",
+      },
+    };
+
+    let design = "hold";
+    let s;
+
+    function reset() {
+      s = {
+        nextId: 1,
+        received: [],
+        pending: [],
+        inFlight: [],
+        emitted: [],
+        inputProjection: {},
+        outputProjection: {},
+        closed: false,
+        log: [`selected ${models[design].title}`],
+      };
+      render();
+    }
+
+    function receiveRow() {
+      if (s.closed) return note("connection is closed");
+      if (s.pending.length >= 3) return note("BACKPRESSURE: row not read; capacity is full");
+      const message = { id: s.nextId++, kind: "DataRow" };
+      s.received.push(message);
+      s.pending.push(message);
+      note(`${message.kind}#${message.id} moved to ${models[design].owner}; no projection`);
+      if (design === "collector") note("collector associates row with the response-head transaction");
+    }
+
+    function receiveTerminator() {
+      if (s.closed) return note("connection is closed");
+      const message = { id: s.nextId++, kind: "CommandComplete" };
+      s.received.push(message);
+      s.pending.push(message);
+      note(`barrier #${message.id} appended after held rows; flush required before next read`);
+      flush();
+    }
+
+    function flush() {
+      if (s.closed) return note("connection is closed");
+      if (!s.pending.length) return note("nothing to flush");
+      s.inFlight = s.pending.splice(0);
+      const proposed = s.inFlight.map(message => ({
+        source: message.id,
+        kind: message.kind,
+        value: message.kind === "DataRow" ? `decrypted(${message.id})` : message.kind,
+      }));
+      note(`atomic validation of ${proposed.length} ordered 1:1 replacements`);
+      for (const output of proposed) {
+        s.inputProjection[output.source] = (s.inputProjection[output.source] || 0) + 1;
+        s.outputProjection[output.source] = (s.outputProjection[output.source] || 0) + 1;
+        s.emitted.push(output);
+      }
+      s.inFlight = [];
+      note(`committed and emitted: ${proposed.map(x => x.value).join(", ")}`);
+    }
+
+    function cancelFlush() {
+      if (s.closed) return note("connection is closed");
+      if (!s.pending.length) return note("nothing pending; receive rows first");
+      s.inFlight = s.pending.splice(0);
+      note(`flush future cancelled; ${models[design].cancellation}`);
+      s.pending.unshift(...s.inFlight);
+      s.inFlight = [];
+      note("all messages restored; projection remains unchanged");
+    }
+
+    function violateRetention() {
+      if (s.closed) return note("connection is closed");
+      if (design !== "state") {
+        return note("unrepresentable: the crate owns every deferred input");
+      }
+      const message = { id: s.nextId++, kind: "DataRow" };
+      s.received.push(message);
+      note("BUG: middleware reported retained but failed to insert the row into state");
+    }
+
+    function teardown() {
+      if (s.closed) return note("already torn down");
+      s.closed = true;
+      note(`teardown with ${s.pending.length} pending: ${models[design].teardown}`);
+    }
+
+    function note(message) {
+      s.log.push(message);
+      render();
+    }
+
+    function check() {
+      const locations = new Map();
+      for (const m of s.pending) locations.set(m.id, (locations.get(m.id) || 0) + 1);
+      for (const m of s.inFlight) locations.set(m.id, (locations.get(m.id) || 0) + 1);
+      for (const m of s.emitted) locations.set(m.source, (locations.get(m.source) || 0) + 1);
+      const owned = s.received.every(m => locations.get(m.id) === 1);
+      const once = Object.values(s.inputProjection).every(n => n === 1)
+        && Object.values(s.outputProjection).every(n => n === 1);
+      const order = s.emitted.every((m, i, all) => i === 0 || all[i - 1].source < m.source);
+      return { owned, once, order, capacity: s.pending.filter(m => m.kind === "DataRow").length <= 3 };
+    }
+
+    function mark(id, ok) {
+      const el = document.getElementById(id);
+      el.className = ok ? "ok" : "bad";
+      el.textContent = ok ? "PASS" : "FAIL";
+    }
+
+    function render() {
+      document.querySelectorAll("[data-design]").forEach(button => {
+        button.classList.toggle("active", button.dataset.design === design);
+      });
+      document.getElementById("state").textContent = JSON.stringify({
+        design: models[design].title,
+        authoritativeOwner: models[design].owner,
+        received: s.received,
+        pending: s.pending,
+        inFlight: s.inFlight,
+        emitted: s.emitted,
+        inputProjection: s.inputProjection,
+        outputProjection: s.outputProjection,
+        closed: s.closed,
+      }, null, 2);
+      document.getElementById("log").textContent = s.log.map((x, i) => `${i + 1}. ${x}`).join("\n");
+      const result = check();
+      Object.entries(result).forEach(([name, ok]) => mark(name, ok));
+    }
+
+    document.querySelectorAll("[data-design]").forEach(button => {
+      button.addEventListener("click", () => { design = button.dataset.design; reset(); });
+    });
+    document.querySelectorAll("[data-action]").forEach(button => {
+      button.addEventListener("click", () => ({
+        row: receiveRow,
+        terminator: receiveTerminator,
+        flush,
+        cancel: cancelFlush,
+        violate: violateRetention,
+        teardown,
+        reset,
+      })[button.dataset.action]());
+    });
+    reset();
+  </script>
+</body>
+</html>

--- a/docs/public-api.txt
+++ b/docs/public-api.txt
@@ -16,10 +16,12 @@ pub use codec::{
 pub use demux::CancelKey;
 pub use intermediary_component::{
     AllowAuthenticatedRoute, AuthenticatedRouteContext, AuthenticatedRoutePolicy,
-    BackendForwarding, BackendMiddlewareOutput, CancellationPolicy, CancellationRoute,
-    EstablishmentFailurePolicy, ForwardError, ForwardedMessage, FrontendForwarding,
-    FrontendMiddlewareOutput, IdentityIntermediaryMiddleware, InitialServerContext, Intermediary,
-    IntermediaryAccept, IntermediaryAcceptError, IntermediaryBuildError, IntermediaryBuilder,
+    BackendBatchForwarding, BackendBatchOutput, BackendBatchProjectionError, BackendFlushReason,
+    BackendForwarding, BackendHoldConfigError, BackendHoldLimits, BackendMiddlewareOutput,
+    CancellationPolicy, CancellationRoute, EstablishmentFailurePolicy, ForwardError,
+    ForwardedMessage, FrontendForwarding, FrontendMiddlewareOutput, HeldBackendMessages,
+    IdentityIntermediaryMiddleware, InitialServerContext, Intermediary, IntermediaryAccept,
+    IntermediaryAcceptError, IntermediaryBuildError, IntermediaryBuilder,
     IntermediaryCancellationRegistry, IntermediaryConnection, IntermediaryContexts,
     IntermediaryMiddleware, IntermediaryMiddlewareFactory, RejectCancellation,
     StartupResolutionError, StartupRouteResolver,

--- a/src/backend_hold.rs
+++ b/src/backend_hold.rs
@@ -1,0 +1,89 @@
+use crate::codec::BackendMessage;
+
+#[derive(Debug, Default)]
+pub(crate) struct BackendHold {
+    pending: Option<(BackendMessage, usize)>,
+    held: Vec<BackendMessage>,
+    held_bytes: usize,
+}
+
+impl BackendHold {
+    pub(crate) fn set_pending(&mut self, message: BackendMessage) {
+        assert!(
+            self.pending.is_none(),
+            "only one backend source may be pending"
+        );
+        let bytes = retained_bytes(&message);
+        self.pending = Some((message, bytes));
+    }
+
+    pub(crate) fn pending(&self) -> Option<&BackendMessage> {
+        self.pending.as_ref().map(|(message, _)| message)
+    }
+
+    pub(crate) fn take_pending(&mut self) -> Option<BackendMessage> {
+        self.pending.take().map(|(message, _)| message)
+    }
+
+    pub(crate) fn hold_pending(&mut self) {
+        let (message, bytes) = self.pending.take().expect("a backend source is pending");
+        self.held.push(message);
+        self.held_bytes = self.held_bytes.saturating_add(bytes);
+    }
+
+    pub(crate) fn messages(&self) -> &[BackendMessage] {
+        &self.held
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.held.len()
+    }
+
+    pub(crate) fn bytes(&self) -> usize {
+        self.held_bytes
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.held.is_empty()
+    }
+
+    pub(crate) fn clear(&mut self) -> Vec<BackendMessage> {
+        self.held_bytes = 0;
+        std::mem::take(&mut self.held)
+    }
+}
+
+fn retained_bytes(message: &BackendMessage) -> usize {
+    message
+        .to_frame()
+        .map_or(0, |frame| frame.body.len().saturating_add(5))
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+
+    use super::*;
+    use crate::DataRow;
+
+    fn row(value: &'static [u8]) -> BackendMessage {
+        BackendMessage::DataRow(DataRow {
+            columns: vec![Some(Bytes::from_static(value))],
+        })
+    }
+
+    #[test]
+    fn pending_moves_into_ordered_accounted_hold() {
+        let mut hold = BackendHold::default();
+        hold.set_pending(row(b"one"));
+        assert_eq!(hold.pending(), Some(&row(b"one")));
+        hold.hold_pending();
+        hold.set_pending(row(b"two"));
+        hold.hold_pending();
+        assert_eq!(hold.len(), 2);
+        assert!(hold.bytes() > 0);
+        assert_eq!(hold.clear(), vec![row(b"one"), row(b"two")]);
+        assert!(hold.is_empty());
+        assert_eq!(hold.bytes(), 0);
+    }
+}

--- a/src/intermediary_component.rs
+++ b/src/intermediary_component.rs
@@ -9,6 +9,26 @@ use crate::{
     pipeline::{BackendAction, FrontendAction, FrontendHandling, Pipeline, PipelinePolicy},
 };
 
+fn is_backend_batch_barrier(message: &crate::codec::BackendMessage) -> bool {
+    use crate::codec::BackendMessage as B;
+    matches!(
+        message,
+        B::CommandComplete(_)
+            | B::PortalSuspended
+            | B::EmptyQueryResponse
+            | B::ErrorResponse(_)
+            | B::ReadyForQuery(_)
+            | B::CopyInResponse(_)
+            | B::CopyOutResponse(_)
+            | B::CopyBothResponse(_)
+            | B::CopyDone
+            | B::NoticeResponse(_)
+            | B::NotificationResponse { .. }
+            | B::ParameterStatus { .. }
+            | B::BackendKeyData { .. }
+    )
+}
+
 /// Required posture for out-of-band cancellation connections.
 ///
 /// Forwarding cancellation is implemented by issue #36. Until then the only
@@ -244,6 +264,108 @@ pub enum BackendMiddlewareOutput {
     Expand(Vec<crate::codec::BackendMessage>),
     /// Consume the response after advancing protocol and pipeline state.
     Suppress(crate::codec::BackendMessage),
+    /// Retain the unchanged current source without projection or output.
+    Hold,
+}
+
+/// Ordered result of applying batch policy to retained backend messages.
+#[derive(Debug, Eq, PartialEq)]
+pub enum BackendBatchOutput {
+    /// Leave the authoritative input span retained by the connection.
+    KeepHolding,
+    /// Replace every held input with one output at the same ordered position.
+    ReplaceOneToOne(Vec<crate::codec::BackendMessage>),
+}
+
+/// Reason retained backend messages are offered to batch policy.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BackendFlushReason {
+    /// A configured message or byte limit was reached.
+    Capacity,
+    /// A protocol boundary must follow the held span.
+    ProtocolBarrier,
+    /// The application requested a latency or batch boundary.
+    Explicit,
+    /// The connection is being deliberately torn down.
+    Teardown,
+}
+
+/// Non-zero bounds for connection-owned backend messages.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct BackendHoldLimits {
+    max_messages: usize,
+    max_bytes: usize,
+}
+
+impl BackendHoldLimits {
+    /// Creates message-count and retained-byte bounds.
+    ///
+    /// # Errors
+    /// Returns an error when either bound is zero.
+    pub const fn new(
+        max_messages: usize,
+        max_bytes: usize,
+    ) -> Result<Self, BackendHoldConfigError> {
+        if max_messages == 0 || max_bytes == 0 {
+            Err(BackendHoldConfigError)
+        } else {
+            Ok(Self {
+                max_messages,
+                max_bytes,
+            })
+        }
+    }
+    /// Maximum retained message count.
+    #[must_use]
+    pub const fn max_messages(self) -> usize {
+        self.max_messages
+    }
+    /// Maximum estimated retained wire bytes.
+    #[must_use]
+    pub const fn max_bytes(self) -> usize {
+        self.max_bytes
+    }
+}
+
+/// A zero backend hold bound is invalid.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct BackendHoldConfigError;
+
+impl fmt::Display for BackendHoldConfigError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("backend hold limits must be non-zero")
+    }
+}
+impl std::error::Error for BackendHoldConfigError {}
+
+/// Opaque ordered view of connection-owned backend messages.
+#[derive(Clone, Copy, Debug)]
+pub struct HeldBackendMessages<'a> {
+    messages: &'a [crate::codec::BackendMessage],
+    bytes: usize,
+}
+
+impl<'a> HeldBackendMessages<'a> {
+    /// Number of held messages.
+    #[must_use]
+    pub const fn len(self) -> usize {
+        self.messages.len()
+    }
+    /// Whether the view is empty.
+    #[must_use]
+    pub const fn is_empty(self) -> bool {
+        self.messages.is_empty()
+    }
+    /// Estimated retained wire bytes.
+    #[must_use]
+    pub const fn bytes(self) -> usize {
+        self.bytes
+    }
+    /// Iterates over messages in receipt order.
+    #[must_use]
+    pub fn iter(self) -> impl ExactSizeIterator<Item = &'a crate::codec::BackendMessage> {
+        self.messages.iter()
+    }
 }
 
 /// Asynchronous, fallible middleware at the forwarding boundary.
@@ -273,6 +395,22 @@ pub trait IntermediaryMiddleware<State, ServerContext, ClientContext> {
         message: crate::codec::BackendMessage,
     ) -> Pin<Box<dyn Future<Output = Result<BackendMiddlewareOutput, Self::Error>> + 'a>> {
         Box::pin(async move { Ok(BackendMiddlewareOutput::Forward(message)) })
+    }
+
+    /// Applies policy to an ordered borrowed span of retained backend messages.
+    fn flush_backend<'a>(
+        &'a mut self,
+        _server: &'a ServerContext,
+        _client: &'a ClientContext,
+        _state: &'a mut State,
+        held: HeldBackendMessages<'a>,
+        _reason: BackendFlushReason,
+    ) -> Pin<Box<dyn Future<Output = Result<BackendBatchOutput, Self::Error>> + 'a>> {
+        Box::pin(async move {
+            Ok(BackendBatchOutput::ReplaceOneToOne(
+                held.iter().cloned().collect(),
+            ))
+        })
     }
 }
 
@@ -333,6 +471,7 @@ pub struct Intermediary<
     pub(crate) cancellation: CancellationPolicy,
     pub(crate) cancellation_registry: Cancellation,
     pub(crate) failure_policy: EstablishmentFailurePolicy,
+    pub(crate) backend_hold_limits: Option<BackendHoldLimits>,
 }
 
 impl Intermediary<()> {
@@ -375,6 +514,7 @@ pub struct IntermediaryBuilder<
     cancellation: Option<CancellationPolicy>,
     cancellation_registry: Cancellation,
     failure_policy: EstablishmentFailurePolicy,
+    backend_hold_limits: Option<BackendHoldLimits>,
 }
 
 impl Default for IntermediaryBuilder {
@@ -389,6 +529,7 @@ impl Default for IntermediaryBuilder {
             cancellation: None,
             cancellation_registry: RejectCancellation,
             failure_policy: EstablishmentFailurePolicy::Close,
+            backend_hold_limits: None,
         }
     }
 }
@@ -407,6 +548,7 @@ impl<S, C, R, A, P, B, K> IntermediaryBuilder<S, C, R, A, P, B, K> {
             cancellation: self.cancellation,
             cancellation_registry: self.cancellation_registry,
             failure_policy: self.failure_policy,
+            backend_hold_limits: self.backend_hold_limits,
         }
     }
 
@@ -423,6 +565,7 @@ impl<S, C, R, A, P, B, K> IntermediaryBuilder<S, C, R, A, P, B, K> {
             cancellation: self.cancellation,
             cancellation_registry: self.cancellation_registry,
             failure_policy: self.failure_policy,
+            backend_hold_limits: self.backend_hold_limits,
         }
     }
 
@@ -442,6 +585,7 @@ impl<S, C, R, A, P, B, K> IntermediaryBuilder<S, C, R, A, P, B, K> {
             cancellation: self.cancellation,
             cancellation_registry: self.cancellation_registry,
             failure_policy: self.failure_policy,
+            backend_hold_limits: self.backend_hold_limits,
         }
     }
 
@@ -461,6 +605,7 @@ impl<S, C, R, A, P, B, K> IntermediaryBuilder<S, C, R, A, P, B, K> {
             cancellation: self.cancellation,
             cancellation_registry: self.cancellation_registry,
             failure_policy: self.failure_policy,
+            backend_hold_limits: self.backend_hold_limits,
         }
     }
 
@@ -480,6 +625,7 @@ impl<S, C, R, A, P, B, K> IntermediaryBuilder<S, C, R, A, P, B, K> {
             cancellation: self.cancellation,
             cancellation_registry: self.cancellation_registry,
             failure_policy: self.failure_policy,
+            backend_hold_limits: self.backend_hold_limits,
         }
     }
 
@@ -496,6 +642,7 @@ impl<S, C, R, A, P, B, K> IntermediaryBuilder<S, C, R, A, P, B, K> {
             cancellation: self.cancellation,
             cancellation_registry: self.cancellation_registry,
             failure_policy: self.failure_policy,
+            backend_hold_limits: self.backend_hold_limits,
         }
     }
 
@@ -516,6 +663,13 @@ impl<S, C, R, A, P, B, K> IntermediaryBuilder<S, C, R, A, P, B, K> {
         self
     }
 
+    /// Enables bounded connection-owned backend message holding.
+    #[must_use]
+    pub fn backend_batching(mut self, limits: BackendHoldLimits) -> Self {
+        self.backend_hold_limits = Some(limits);
+        self
+    }
+
     /// Enables forwarding through an application-owned concurrent registry.
     #[must_use]
     pub fn cancellation_registry<Next>(
@@ -532,6 +686,7 @@ impl<S, C, R, A, P, B, K> IntermediaryBuilder<S, C, R, A, P, B, K> {
             cancellation: Some(CancellationPolicy::Forward),
             cancellation_registry: registry,
             failure_policy: self.failure_policy,
+            backend_hold_limits: self.backend_hold_limits,
         }
     }
 
@@ -556,6 +711,7 @@ impl<S, C, R, A, P, B, K> IntermediaryBuilder<S, C, R, A, P, B, K> {
                 .ok_or(IntermediaryBuildError::MissingCancellationPolicy)?,
             cancellation_registry: self.cancellation_registry,
             failure_policy: self.failure_policy,
+            backend_hold_limits: self.backend_hold_limits,
         })
     }
 }
@@ -772,6 +928,8 @@ pub struct IntermediaryConnection<
     pipeline: Pipeline<Policy>,
     target: ConnectTarget,
     pending_frontend: Option<crate::codec::FrontendMessage>,
+    backend_hold: crate::backend_hold::BackendHold,
+    backend_hold_limits: Option<BackendHoldLimits>,
     pending_local: VecDeque<PendingLocalResponses>,
     cancellation_registry: Cancellation,
     client_cancel_key: Option<crate::demux::CancelKey>,
@@ -825,6 +983,8 @@ pub enum ForwardedMessage {
     FrontendLocallyHandled(crate::codec::FrontendMessage),
     /// A PostgreSQL-originated response advanced protocol state but was suppressed.
     BackendSuppressed(crate::codec::BackendMessage),
+    /// A PostgreSQL response entered the connection-owned backend hold.
+    BackendHeld,
 }
 
 /// Observable result of processing one client-originated message.
@@ -864,15 +1024,64 @@ pub enum BackendForwarding {
     },
     /// The response advanced protocol state but was not sent.
     Suppressed(crate::codec::BackendMessage),
+    /// The response entered the connection-owned hold without projection.
+    Held,
 }
 
 impl BackendForwarding {
     /// Returns the owned PostgreSQL response represented by this outcome.
+    ///
+    /// # Panics
+    /// Panics for [`BackendForwarding::Held`] because the connection still owns
+    /// that response.
     #[must_use]
     pub fn into_message(self) -> crate::codec::BackendMessage {
         match self {
             Self::Forwarded(message) | Self::Suppressed(message) => message,
             Self::Expanded { source, .. } => source,
+            Self::Held => panic!("a held response remains owned by the connection"),
+        }
+    }
+}
+
+/// Observable result of explicitly applying backend batch policy.
+#[derive(Debug, Eq, PartialEq)]
+pub enum BackendBatchForwarding {
+    /// The held span was atomically projected and emitted in order.
+    Released(Vec<crate::codec::BackendMessage>),
+    /// Batch policy elected to retain the unchanged span.
+    Kept,
+    /// No backend messages were held.
+    Empty,
+}
+
+/// Validation failure for an ordered one-to-one backend replacement span.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BackendBatchProjectionError {
+    /// Replacement cardinality differed from the held span.
+    Cardinality {
+        /// Number of authoritative held inputs.
+        expected: usize,
+        /// Number of proposed replacements.
+        actual: usize,
+    },
+    /// A held source was not attributable at this pipeline position.
+    IllegalSource,
+    /// A proposed replacement was illegal or not reconstructable.
+    IllegalReplacement,
+    /// Replacements would consume a different protocol span than the sources.
+    DifferentSpan,
+}
+
+impl From<crate::pipeline::BackendSequenceError> for BackendBatchProjectionError {
+    fn from(error: crate::pipeline::BackendSequenceError) -> Self {
+        match error {
+            crate::pipeline::BackendSequenceError::Cardinality { expected, actual } => {
+                Self::Cardinality { expected, actual }
+            }
+            crate::pipeline::BackendSequenceError::Source(_) => Self::IllegalSource,
+            crate::pipeline::BackendSequenceError::Replacement(_) => Self::IllegalReplacement,
+            crate::pipeline::BackendSequenceError::DifferentSpan => Self::DifferentSpan,
         }
     }
 }
@@ -896,6 +1105,15 @@ where
     #[must_use]
     pub const fn cancellation_key(&self) -> Option<&crate::demux::CancelKey> {
         self.client_cancel_key.as_ref()
+    }
+
+    /// Returns an ordered borrowed view of retained backend messages.
+    #[must_use]
+    pub fn held_backend_messages(&self) -> HeldBackendMessages<'_> {
+        HeldBackendMessages {
+            messages: self.backend_hold.messages(),
+            bytes: self.backend_hold.bytes(),
+        }
     }
 
     /// Detaches this session's cancellation mapping explicitly.
@@ -1046,6 +1264,18 @@ where
     pub async fn forward_backend(
         &mut self,
     ) -> Result<BackendForwarding, ForwardError<Boundary::Error>> {
+        if self.backend_hold.pending().is_some() {
+            return self.process_pending_backend().await;
+        }
+        if self.backend_hold_is_full() {
+            match self
+                .flush_backend_hold_for(BackendFlushReason::Capacity)
+                .await?
+            {
+                BackendBatchForwarding::Released(_) | BackendBatchForwarding::Empty => {}
+                BackendBatchForwarding::Kept => return Err(ForwardError::BackendHoldCapacity),
+            }
+        }
         let message = self.upstream.receive_wire_raw().await?;
         self.process_backend(message).await
     }
@@ -1055,24 +1285,51 @@ where
         message: crate::codec::BackendMessage,
     ) -> Result<BackendForwarding, ForwardError<Boundary::Error>> {
         let message = self.upstream.intercept_backend(&mut self.state, message);
-        let source = message.clone();
+        self.backend_hold.set_pending(message);
+        if self
+            .backend_hold
+            .pending()
+            .is_some_and(is_backend_batch_barrier)
+            && !self.backend_hold.is_empty()
+        {
+            match self
+                .flush_backend_hold_for(BackendFlushReason::ProtocolBarrier)
+                .await?
+            {
+                BackendBatchForwarding::Released(_) | BackendBatchForwarding::Empty => {}
+                BackendBatchForwarding::Kept => return Err(ForwardError::BackendHoldRefused),
+            }
+        }
+        self.process_pending_backend().await
+    }
+
+    async fn process_pending_backend(
+        &mut self,
+    ) -> Result<BackendForwarding, ForwardError<Boundary::Error>> {
+        let source = self
+            .backend_hold
+            .pending()
+            .expect("pending backend processing requires a source")
+            .clone();
         let decision = self
             .boundary
             .backend(
                 self.downstream.context(),
                 self.upstream.context(),
                 &mut self.state,
-                message,
+                source.clone(),
             )
             .await
             .map_err(ForwardError::Middleware)?;
         let outcome = match decision {
             BackendMiddlewareOutput::Forward(message) => {
+                let _ = self.backend_hold.take_pending();
                 let message = self.downstream.intercept_backend(&mut self.state, message);
                 let message = self.emit_backend(message).await?;
                 BackendForwarding::Forwarded(message)
             }
             BackendMiddlewareOutput::Suppress(message) => {
+                let _ = self.backend_hold.take_pending();
                 let message = self.advance_backend(message)?;
                 BackendForwarding::Suppressed(message)
             }
@@ -1080,6 +1337,7 @@ where
                 if messages.is_empty() {
                     return Err(ForwardError::EmptyExpansion(source));
                 }
+                let _ = self.backend_hold.take_pending();
                 let mut emitted = Vec::with_capacity(messages.len());
                 for message in messages {
                     let message = self.downstream.intercept_backend(&mut self.state, message);
@@ -1090,9 +1348,100 @@ where
                     messages: emitted,
                 }
             }
+            BackendMiddlewareOutput::Hold => {
+                if self.backend_hold_limits.is_none() {
+                    return Err(ForwardError::BackendHoldingDisabled(source));
+                }
+                self.backend_hold.hold_pending();
+                BackendForwarding::Held
+            }
         };
         self.flush_local_responses().await?;
         Ok(outcome)
+    }
+
+    fn backend_hold_is_full(&self) -> bool {
+        self.backend_hold_limits.is_some_and(|limits| {
+            self.backend_hold.len() >= limits.max_messages()
+                || self.backend_hold.bytes() >= limits.max_bytes()
+        })
+    }
+
+    /// Applies batch policy to held messages without reading another upstream frame.
+    ///
+    /// # Errors
+    /// Returns middleware, encoding, projection, or transport failures while
+    /// preserving the hold until projection commits.
+    pub async fn flush_backend_hold(
+        &mut self,
+    ) -> Result<BackendBatchForwarding, ForwardError<Boundary::Error>> {
+        self.flush_backend_hold_for(BackendFlushReason::Explicit)
+            .await
+    }
+
+    /// Flushes retained messages for deliberate teardown without reading upstream.
+    ///
+    /// # Errors
+    /// Returns an error when middleware fails, refuses release, proposes an
+    /// invalid span, or output cannot be encoded or written.
+    pub async fn prepare_backend_teardown(
+        &mut self,
+    ) -> Result<BackendBatchForwarding, ForwardError<Boundary::Error>> {
+        let outcome = self
+            .flush_backend_hold_for(BackendFlushReason::Teardown)
+            .await?;
+        if matches!(outcome, BackendBatchForwarding::Kept) {
+            return Err(ForwardError::BackendHoldRefused);
+        }
+        Ok(outcome)
+    }
+
+    async fn flush_backend_hold_for(
+        &mut self,
+        reason: BackendFlushReason,
+    ) -> Result<BackendBatchForwarding, ForwardError<Boundary::Error>> {
+        if self.backend_hold.is_empty() {
+            return Ok(BackendBatchForwarding::Empty);
+        }
+        let held = HeldBackendMessages {
+            messages: self.backend_hold.messages(),
+            bytes: self.backend_hold.bytes(),
+        };
+        let decision = self
+            .boundary
+            .flush_backend(
+                self.downstream.context(),
+                self.upstream.context(),
+                &mut self.state,
+                held,
+                reason,
+            )
+            .await
+            .map_err(ForwardError::Middleware)?;
+        let BackendBatchOutput::ReplaceOneToOne(messages) = decision else {
+            return Ok(BackendBatchForwarding::Kept);
+        };
+        let messages: Vec<_> = messages
+            .into_iter()
+            .map(|message| self.downstream.intercept_backend(&mut self.state, message))
+            .collect();
+        for message in &messages {
+            message.to_frame().map_err(ForwardError::Io)?;
+        }
+        let prepared = self
+            .pipeline
+            .prepare_backend_replacements(self.backend_hold.messages(), &messages)
+            .map_err(|error| ForwardError::BackendBatch {
+                error: error.into(),
+                proposed: messages.clone(),
+            })?;
+        self.pipeline = prepared;
+        let _sources = self.backend_hold.clear();
+        for message in &messages {
+            self.downstream.send_wire_raw(message.clone()).await?;
+        }
+        self.flush_local_responses().await?;
+        Ok(BackendBatchForwarding::Released(messages))
     }
 
     fn advance_backend(
@@ -1153,6 +1502,30 @@ where
     pub async fn forward_next(
         &mut self,
     ) -> Result<ForwardedMessage, ForwardError<Boundary::Error>> {
+        if self.backend_hold.pending().is_some() {
+            return self
+                .process_pending_backend()
+                .await
+                .map(|outcome| match outcome {
+                    BackendForwarding::Forwarded(message) => ForwardedMessage::Backend(message),
+                    BackendForwarding::Expanded { source, messages } => {
+                        ForwardedMessage::BackendExpanded { source, messages }
+                    }
+                    BackendForwarding::Suppressed(message) => {
+                        ForwardedMessage::BackendSuppressed(message)
+                    }
+                    BackendForwarding::Held => ForwardedMessage::BackendHeld,
+                });
+        }
+        if self.backend_hold_is_full() {
+            match self
+                .flush_backend_hold_for(BackendFlushReason::Capacity)
+                .await?
+            {
+                BackendBatchForwarding::Released(_) | BackendBatchForwarding::Empty => {}
+                BackendBatchForwarding::Kept => return Err(ForwardError::BackendHoldCapacity),
+            }
+        }
         if self.pending_frontend.is_some() {
             let message = self.upstream.receive_wire_raw().await?;
             return self
@@ -1166,6 +1539,7 @@ where
                     BackendForwarding::Suppressed(message) => {
                         ForwardedMessage::BackendSuppressed(message)
                     }
+                    BackendForwarding::Held => ForwardedMessage::BackendHeld,
                 });
         }
         tokio::select! {
@@ -1185,6 +1559,7 @@ where
                         ForwardedMessage::BackendExpanded { source, messages }
                     }
                     BackendForwarding::Suppressed(message) => ForwardedMessage::BackendSuppressed(message),
+                    BackendForwarding::Held => ForwardedMessage::BackendHeld,
                 })
             }
         }
@@ -1192,6 +1567,10 @@ where
 
     /// Deliberately tears down both roles and recovers transports, handlers,
     /// contexts, boundary middleware, and the sole connection state.
+    ///
+    /// # Panics
+    /// Panics when a backend source is pending or held. Call
+    /// [`Self::prepare_backend_teardown`] first when batching is enabled.
     #[allow(clippy::type_complexity)]
     pub fn teardown(
         mut self,
@@ -1206,6 +1585,10 @@ where
             crate::ClientConnectionContext<ClientEvidence>,
         >,
     ) {
+        assert!(
+            self.backend_hold.is_empty() && self.backend_hold.pending().is_none(),
+            "backend messages remain held; call prepare_backend_teardown before teardown"
+        );
         let _ = self.detach_cancellation();
         let (downstream, server_handler, server_context) = self.downstream.into_parts();
         let (upstream, client_handler, client_context) = self.upstream.into_parts();
@@ -1236,6 +1619,19 @@ pub enum ForwardError<MiddlewareError = std::convert::Infallible> {
     Deferred(crate::codec::BackendMessage),
     /// Backend fan-out did not contain a replacement response.
     EmptyExpansion(crate::codec::BackendMessage),
+    /// Middleware requested holding without configured finite limits.
+    BackendHoldingDisabled(crate::codec::BackendMessage),
+    /// Batch policy kept a full hold, so no transport may be polled.
+    BackendHoldCapacity,
+    /// Batch policy refused a required protocol-boundary release.
+    BackendHoldRefused,
+    /// A proposed batch failed atomic protocol-span validation.
+    BackendBatch {
+        /// Validation failure.
+        error: BackendBatchProjectionError,
+        /// Unsent proposed replacements in order.
+        proposed: Vec<crate::codec::BackendMessage>,
+    },
     /// Forwarding-boundary middleware rejected a message.
     Middleware(MiddlewareError),
 }
@@ -1252,6 +1648,17 @@ impl<E> fmt::Display for ForwardError<E> {
             Self::EmptyExpansion(_) => {
                 formatter.write_str("backend expansion must contain at least one response")
             }
+            Self::BackendHoldingDisabled(_) => {
+                formatter.write_str("backend holding is not configured")
+            }
+            Self::BackendHoldCapacity => {
+                formatter.write_str("backend hold is full and batch policy kept holding")
+            }
+            Self::BackendHoldRefused => {
+                formatter.write_str("backend batch policy refused a required release")
+            }
+            Self::BackendBatch { .. } => formatter
+                .write_str("backend batch replacement is not a legal one-to-one protocol span"),
             Self::Middleware(_) => formatter.write_str("forwarding middleware rejected a message"),
         }
     }
@@ -1265,9 +1672,14 @@ where
         match self {
             Self::Io(error) => Some(error),
             Self::Middleware(error) => Some(error),
-            Self::Frontend(_) | Self::Backend(_) | Self::Deferred(_) | Self::EmptyExpansion(_) => {
-                None
-            }
+            Self::Frontend(_)
+            | Self::Backend(_)
+            | Self::Deferred(_)
+            | Self::EmptyExpansion(_)
+            | Self::BackendHoldingDisabled(_)
+            | Self::BackendHoldCapacity
+            | Self::BackendHoldRefused
+            | Self::BackendBatch { .. } => None,
         }
     }
 }
@@ -1560,6 +1972,8 @@ where
             pipeline: Pipeline::new(self.pipeline),
             target: selected,
             pending_frontend: None,
+            backend_hold: crate::backend_hold::BackendHold::default(),
+            backend_hold_limits: self.backend_hold_limits,
             pending_local: VecDeque::new(),
             cancellation_registry: self.cancellation_registry.clone(),
             client_cancel_key,
@@ -1577,7 +1991,11 @@ where
                 .await;
             let message = match message {
                 Ok(BackendMiddlewareOutput::Forward(message)) => message,
-                Ok(BackendMiddlewareOutput::Suppress(_) | BackendMiddlewareOutput::Expand(_)) => {
+                Ok(
+                    BackendMiddlewareOutput::Suppress(_)
+                    | BackendMiddlewareOutput::Expand(_)
+                    | BackendMiddlewareOutput::Hold,
+                ) => {
                     let _ = connection.detach_cancellation();
                     let _ = connection.teardown();
                     return Err(IntermediaryAcceptError::ServerOutput(io::Error::new(

--- a/src/internal_tests/intermediary_pipeline.rs
+++ b/src/internal_tests/intermediary_pipeline.rs
@@ -636,6 +636,50 @@ fn simple_query_stream_stays_at_head_until_ready() {
 }
 
 #[test]
+fn backend_batch_preparation_is_atomic_and_span_preserving() {
+    let mut pipeline = bounded(2);
+    pipeline
+        .accept_frontend(
+            FrontendMessage::Query(Bytes::from_static(b"select 1")),
+            FrontendHandling::Forward,
+        )
+        .unwrap();
+    let sources = vec![
+        BackendMessage::DataRow(DataRow {
+            columns: vec![Some(Bytes::from_static(b"encrypted"))],
+        }),
+        BackendMessage::CommandComplete(Bytes::from_static(b"SELECT 1")),
+    ];
+    let replacements = vec![
+        BackendMessage::DataRow(DataRow {
+            columns: vec![Some(Bytes::from_static(b"clear"))],
+        }),
+        BackendMessage::CommandComplete(Bytes::from_static(b"SELECT 1")),
+    ];
+    let prepared = pipeline
+        .prepare_backend_replacements(&sources, &replacements)
+        .unwrap();
+    assert_eq!(
+        pipeline.len(),
+        1,
+        "preparation must not mutate the live ledger"
+    );
+    pipeline = prepared;
+    assert_eq!(pipeline.len(), 1, "command completion awaits ReadyForQuery");
+
+    let before = pipeline.len();
+    assert!(
+        pipeline
+            .prepare_backend_replacements(
+                &[BackendMessage::ReadyForQuery(TransactionStatus::Idle)],
+                &[BackendMessage::DataRow(DataRow { columns: vec![] })],
+            )
+            .is_err()
+    );
+    assert_eq!(pipeline.len(), before, "failed preparation is atomic");
+}
+
+#[test]
 fn complete_extended_pipeline_is_ordered() {
     let mut pipeline = bounded(8);
     for message in [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 
 #[allow(dead_code)]
 mod auth;
+mod backend_hold;
 #[allow(dead_code)]
 mod cancel;
 #[allow(dead_code)]
@@ -75,10 +76,12 @@ pub use codec::{
 pub use demux::CancelKey;
 pub use intermediary_component::{
     AllowAuthenticatedRoute, AuthenticatedRouteContext, AuthenticatedRoutePolicy,
-    BackendForwarding, BackendMiddlewareOutput, CancellationPolicy, CancellationRoute,
-    EstablishmentFailurePolicy, ForwardError, ForwardedMessage, FrontendForwarding,
-    FrontendMiddlewareOutput, IdentityIntermediaryMiddleware, InitialServerContext, Intermediary,
-    IntermediaryAccept, IntermediaryAcceptError, IntermediaryBuildError, IntermediaryBuilder,
+    BackendBatchForwarding, BackendBatchOutput, BackendBatchProjectionError, BackendFlushReason,
+    BackendForwarding, BackendHoldConfigError, BackendHoldLimits, BackendMiddlewareOutput,
+    CancellationPolicy, CancellationRoute, EstablishmentFailurePolicy, ForwardError,
+    ForwardedMessage, FrontendForwarding, FrontendMiddlewareOutput, HeldBackendMessages,
+    IdentityIntermediaryMiddleware, InitialServerContext, Intermediary, IntermediaryAccept,
+    IntermediaryAcceptError, IntermediaryBuildError, IntermediaryBuilder,
     IntermediaryCancellationRegistry, IntermediaryConnection, IntermediaryContexts,
     IntermediaryMiddleware, IntermediaryMiddlewareFactory, RejectCancellation,
     StartupResolutionError, StartupRouteResolver,

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -171,6 +171,14 @@ pub struct BackendProjectionError {
     pub message: BackendMessage,
 }
 
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) enum BackendSequenceError {
+    Cardinality { expected: usize, actual: usize },
+    Source(BackendMessage),
+    Replacement(BackendMessage),
+    DifferentSpan,
+}
+
 /// Public summary of the pipeline's projected frontend state.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum PipelineState {
@@ -533,6 +541,59 @@ impl Default for Pipeline<NoPipeline> {
 }
 
 impl<P: PipelinePolicy> Pipeline<P> {
+    fn snapshot(&self) -> Self {
+        Self {
+            policy: self.policy,
+            operations: self.operations.clone(),
+            request_state: self.request_state,
+            response_state: self.response_state,
+            next_id: self.next_id,
+            changed: Arc::clone(&self.changed),
+        }
+    }
+
+    pub(crate) fn prepare_backend_replacements(
+        &self,
+        sources: &[BackendMessage],
+        replacements: &[BackendMessage],
+    ) -> Result<Self, BackendSequenceError> {
+        if sources.len() != replacements.len() {
+            return Err(BackendSequenceError::Cardinality {
+                expected: sources.len(),
+                actual: replacements.len(),
+            });
+        }
+        let mut source_projection = self.snapshot();
+        for message in sources.iter().cloned() {
+            match source_projection.accept_backend(message) {
+                Ok(BackendAction::Emit(_)) => {}
+                Ok(BackendAction::Deferred(message))
+                | Err(BackendProjectionError { message, .. }) => {
+                    return Err(BackendSequenceError::Source(message));
+                }
+            }
+        }
+        let mut replacement_projection = self.snapshot();
+        for message in replacements.iter().cloned() {
+            if !message.is_reconstructable() {
+                return Err(BackendSequenceError::Replacement(message));
+            }
+            match replacement_projection.accept_backend(message) {
+                Ok(BackendAction::Emit(_)) => {}
+                Ok(BackendAction::Deferred(message))
+                | Err(BackendProjectionError { message, .. }) => {
+                    return Err(BackendSequenceError::Replacement(message));
+                }
+            }
+        }
+        if source_projection.operations != replacement_projection.operations
+            || source_projection.request_state != replacement_projection.request_state
+            || source_projection.response_state != replacement_projection.response_state
+        {
+            return Err(BackendSequenceError::DifferentSpan);
+        }
+        Ok(replacement_projection)
+    }
     /// Creates an empty pipeline using `policy`.
     #[must_use]
     pub(crate) fn new(policy: P) -> Self {

--- a/tests/intermediary_builder.rs
+++ b/tests/intermediary_builder.rs
@@ -818,3 +818,197 @@ async fn async_middleware_supports_suppression_local_responses_and_backend_fanou
     downstream.await.unwrap();
     upstream.await.unwrap();
 }
+
+#[derive(Default)]
+struct OrderedBatch;
+
+impl
+    IntermediaryMiddleware<
+        usize,
+        ServerConnectionContext<String, TrustIdentity>,
+        ClientConnectionContext<()>,
+    > for OrderedBatch
+{
+    type Error = Infallible;
+
+    fn backend<'a>(
+        &'a mut self,
+        _: &'a ServerConnectionContext<String, TrustIdentity>,
+        _: &'a ClientConnectionContext<()>,
+        _: &'a mut usize,
+        message: BackendMessage,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<Output = Result<pg_proto::BackendMiddlewareOutput, Self::Error>>
+                + 'a,
+        >,
+    > {
+        Box::pin(async move {
+            if matches!(message, BackendMessage::DataRow(_)) {
+                Ok(pg_proto::BackendMiddlewareOutput::Hold)
+            } else {
+                Ok(pg_proto::BackendMiddlewareOutput::Forward(message))
+            }
+        })
+    }
+
+    fn flush_backend<'a>(
+        &'a mut self,
+        _: &'a ServerConnectionContext<String, TrustIdentity>,
+        _: &'a ClientConnectionContext<()>,
+        flushes: &'a mut usize,
+        held: pg_proto::HeldBackendMessages<'a>,
+        reason: pg_proto::BackendFlushReason,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<Output = Result<pg_proto::BackendBatchOutput, Self::Error>>
+                + 'a,
+        >,
+    > {
+        Box::pin(async move {
+            assert_eq!(reason, pg_proto::BackendFlushReason::ProtocolBarrier);
+            *flushes += 1;
+            let replacements = held
+                .iter()
+                .map(|message| {
+                    let BackendMessage::DataRow(row) = message else {
+                        panic!("batch contains a non-row")
+                    };
+                    let value = row.columns[0].as_ref().unwrap();
+                    let mut clear = b"clear-".to_vec();
+                    clear.extend_from_slice(value);
+                    BackendMessage::DataRow(pg_proto::DataRow {
+                        columns: vec![Some(Bytes::from(clear))],
+                    })
+                })
+                .collect();
+            Ok(pg_proto::BackendBatchOutput::ReplaceOneToOne(replacements))
+        })
+    }
+}
+
+#[tokio::test]
+#[allow(clippy::too_many_lines)]
+async fn held_rows_are_released_once_in_order_before_the_protocol_barrier() {
+    let (downstream_transport, mut downstream_peer) = tokio::io::duplex(16 * 1024);
+    let (upstream_transport, mut upstream_peer) = tokio::io::duplex(16 * 1024);
+    let upstream_transport = std::sync::Mutex::new(Some(upstream_transport));
+    let server = Server::builder()
+        .tls(ServerTlsPolicy::Disabled)
+        .authentication(TrustServerAuthentication)
+        .build()
+        .unwrap();
+    let client = Client::builder()
+        .connector(move |_| {
+            let transport = upstream_transport.lock().unwrap().take().unwrap();
+            async move { Ok::<_, Infallible>(transport) }
+        })
+        .tls(ClientTlsPolicy::Disabled)
+        .authentication(TrustClientAuthentication)
+        .build()
+        .unwrap();
+    let intermediary = Intermediary::builder()
+        .server(server)
+        .client(client)
+        .startup_resolver(CandidateResolver)
+        .authenticated_route(RefineRoute)
+        .cancellation(CancellationPolicy::Reject)
+        .pipeline(BoundedPipeline::new(1).unwrap())
+        .middleware(
+            |_: &ServerConnectionContext<String, TrustIdentity>,
+             _: &ClientConnectionContext<()>| OrderedBatch,
+        )
+        .backend_batching(pg_proto::BackendHoldLimits::new(8, 4096).unwrap())
+        .build()
+        .unwrap();
+
+    let downstream = tokio::spawn(async move {
+        let startup = pg_proto::StartupMessage {
+            version: pg_proto::ProtocolVersion::V3_0,
+            parameters: std::iter::once((
+                Bytes::from_static(b"user"),
+                Bytes::from_static(b"alice"),
+            ))
+            .collect(),
+        };
+        downstream_peer
+            .write_all(&startup.encode().unwrap())
+            .await
+            .unwrap();
+        let mut authentication_and_ready = [0; 15];
+        downstream_peer
+            .read_exact(&mut authentication_and_ready)
+            .await
+            .unwrap();
+        downstream_peer
+            .write_all(&frontend_bytes(&FrontendMessage::Query(
+                Bytes::from_static(b"SELECT"),
+            )))
+            .await
+            .unwrap();
+        for expected in [b"clear-one".as_slice(), b"clear-two", b"clear-three"] {
+            let (tag, body) = read_tagged(&mut downstream_peer).await;
+            assert_eq!(tag, b'D');
+            assert_eq!(&body[6..], expected);
+        }
+        assert_eq!(read_tagged(&mut downstream_peer).await.0, b'C');
+        assert_eq!(read_tagged(&mut downstream_peer).await.0, b'Z');
+    });
+    let upstream = tokio::spawn(async move {
+        let length = upstream_peer.read_u32().await.unwrap();
+        let mut startup = vec![0; usize::try_from(length).unwrap() - 4];
+        upstream_peer.read_exact(&mut startup).await.unwrap();
+        upstream_peer
+            .write_all(&[b'R', 0, 0, 0, 8, 0, 0, 0, 0, b'Z', 0, 0, 0, 5, b'I'])
+            .await
+            .unwrap();
+        assert_eq!(read_tagged(&mut upstream_peer).await.0, b'Q');
+        for encrypted in [b"one".as_slice(), b"two", b"three"] {
+            upstream_peer
+                .write_all(&backend_bytes(&BackendMessage::DataRow(
+                    pg_proto::DataRow {
+                        columns: vec![Some(Bytes::copy_from_slice(encrypted))],
+                    },
+                )))
+                .await
+                .unwrap();
+        }
+        upstream_peer
+            .write_all(&backend_bytes(&BackendMessage::CommandComplete(
+                Bytes::from_static(b"SELECT 3"),
+            )))
+            .await
+            .unwrap();
+        upstream_peer
+            .write_all(&backend_bytes(&BackendMessage::ReadyForQuery(
+                pg_proto::TransactionStatus::Idle,
+            )))
+            .await
+            .unwrap();
+    });
+
+    let mut session =
+        Box::pin(intermediary.accept(downstream_transport, "downstream-peer".to_owned(), 0_usize))
+            .await
+            .unwrap()
+            .into_session();
+    session.forward_frontend().await.unwrap();
+    for expected_len in 1..=3 {
+        assert_eq!(
+            session.forward_backend().await.unwrap(),
+            pg_proto::BackendForwarding::Held
+        );
+        assert_eq!(session.held_backend_messages().len(), expected_len);
+    }
+    assert_eq!(*session.state(), 0);
+    assert!(matches!(
+        session.forward_backend().await.unwrap(),
+        pg_proto::BackendForwarding::Forwarded(BackendMessage::CommandComplete(_))
+    ));
+    assert_eq!(*session.state(), 1);
+    assert!(session.held_backend_messages().is_empty());
+    session.forward_backend().await.unwrap();
+    let _ = session.teardown();
+    downstream.await.unwrap();
+    upstream.await.unwrap();
+}


### PR DESCRIPTION
## Summary

- add bounded, connection-owned holding for ordered backend messages
- add cancellation-safe async one-to-one batch replacement with atomic pipeline projection
- flush holds at protocol barriers, capacity, explicit boundaries, and teardown
- preserve immediate `Expand` and committed `Suppress` semantics
- add CipherStash-shaped facade coverage and implementation design documentation

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo test --workspace` (loopback test run with local-network permission)
- `cargo test --workspace --doc`
- `cargo test --test compile_fail --test public_surface --test documentation_audit --test intermediary_builder`
- `cargo check --workspace --examples`
- `cargo +1.88.0 check --workspace --all-targets`
- `cargo bench --workspace --no-run`
- `git diff --check`