### PR TITLE
refactor: use native async policy traits

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ authenticated routing, cancellation storage, middleware, and failure disclosure
 remain explicit application policies.
 
 ```rust,no_run
-use std::{convert::Infallible, future::Future, pin::Pin};
+use std::convert::Infallible;
 use pg_proto::{
     CancellationPolicy, Client, ClientTlsPolicy, ConnectTarget, InitialServerContext,
     Intermediary, Server, ServerTlsPolicy, StartupParameters, StartupRouteResolver,
@@ -224,12 +224,12 @@ use pg_proto::{
 struct Route;
 impl<Peer> StartupRouteResolver<Peer> for Route {
     type Error = Infallible;
-    fn resolve<'a>(
-        &'a self,
+    async fn resolve(
+        &self,
         _: StartupParameters,
-        _: InitialServerContext<'a, Peer>,
-    ) -> Pin<Box<dyn Future<Output = Result<ConnectTarget, Self::Error>> + 'a>> {
-        Box::pin(async { Ok(ConnectTarget::new("127.0.0.1:5432")) })
+        _: InitialServerContext<'_, Peer>,
+    ) -> Result<ConnectTarget, Self::Error> {
+        Ok(ConnectTarget::new("127.0.0.1:5432"))
     }
 }
 

--- a/docs/design/backend-batching-crate-hold.md
+++ b/docs/design/backend-batching-crate-hold.md
@@ -43,16 +43,14 @@ pub enum BackendMiddlewareOutput {
 
 pub trait IntermediaryMiddleware<State, ServerContext, ClientContext> {
     // Existing frontend(...) and backend(...) remain.
-    fn flush_backend<'a>(
-        &'a mut self,
-        server: &'a ServerContext,
-        client: &'a ClientContext,
-        state: &'a mut State,
+    async fn flush_backend(
+        &mut self,
+        server: &ServerContext,
+        client: &ClientContext,
+        state: &mut State,
         held: HeldBackendMessages,
         reason: BackendFlushReason,
-    ) -> Pin<Box<dyn Future<
-        Output = Result<BackendFlushOutput, Self::Error>
-    > + 'a>>;
+    ) -> Result<BackendFlushOutput, Self::Error>;
 }
 
 impl<...> IntermediaryConnection<...> {
@@ -253,30 +251,27 @@ private because applications do not vary them safely.
 ## Example
 
 ```rust
-fn backend<'a>(
+async fn backend(
     &mut self,
-    _server: &'a ServerCx,
-    _client: &'a ClientCx,
-    _state: &'a mut State,
+    _server: &ServerCx,
+    _client: &ClientCx,
+    _state: &mut State,
     message: BackendMessage,
-) -> Pin<Box<dyn Future<Output = Result<BackendMiddlewareOutput, Error>> + 'a>> {
-    Box::pin(async move {
-        Ok(match message {
-            message @ BackendMessage::DataRow(_) => BackendMiddlewareOutput::Hold(message),
-            barrier => BackendMiddlewareOutput::Forward(barrier),
-        })
+) -> Result<BackendMiddlewareOutput, Error> {
+    Ok(match message {
+        message @ BackendMessage::DataRow(_) => BackendMiddlewareOutput::Hold(message),
+        barrier => BackendMiddlewareOutput::Forward(barrier),
     })
 }
 
-fn flush_backend<'a>(
+async fn flush_backend(
     &mut self,
-    _server: &'a ServerCx,
-    _client: &'a ClientCx,
-    state: &'a mut State,
+    _server: &ServerCx,
+    _client: &ClientCx,
+    state: &mut State,
     input: HeldBackendMessages,
     _reason: BackendFlushReason,
-) -> Pin<Box<dyn Future<Output = Result<BackendFlushOutput, Error>> + 'a>> {
-  Box::pin(async move {
+) -> Result<BackendFlushOutput, Error> {
     let mut output = Vec::new();
     for message in input.into_messages() {
         match message {
@@ -288,7 +283,6 @@ fn flush_backend<'a>(
         }
     }
     Ok(BackendFlushOutput::Release(output))
-  })
 }
 ```
 

--- a/docs/public-api.txt
+++ b/docs/public-api.txt
@@ -1,12 +1,11 @@
 pub use client_component::{
     BuildError, CancelError, Client, ClientAuthentication, ClientAuthenticationChallenge,
-    ClientAuthenticationError, ClientAuthenticationFuture, ClientAuthenticationResponse,
-    ClientAuthenticationSession, ClientBuilder, ClientConnection, ClientConnectionContext,
-    ClientInitialContext, ClientTlsConfig, ClientTlsConfiguration, ClientTlsError, ClientTlsPolicy,
-    ClientTlsProvider, ClientTlsStatus, ClientTransport, ConnectError, ConnectTarget,
-    ConnectionChanged, ConnectionClean, IdentityHandler, ProtocolLimitError, ProtocolLimits,
-    QueryError, ReloadableClientTls, StartupParameterError, StartupParameters,
-    TrustClientAuthentication,
+    ClientAuthenticationError, ClientAuthenticationResponse, ClientAuthenticationSession,
+    ClientBuilder, ClientConnection, ClientConnectionContext, ClientInitialContext,
+    ClientTlsConfig, ClientTlsConfiguration, ClientTlsError, ClientTlsPolicy, ClientTlsProvider,
+    ClientTlsStatus, ClientTransport, ConnectError, ConnectTarget, ConnectionChanged,
+    ConnectionClean, IdentityHandler, ProtocolLimitError, ProtocolLimits, QueryError,
+    ReloadableClientTls, StartupParameterError, StartupParameters, TrustClientAuthentication,
 };
 pub use codec::{
     Authentication, BackendMessage, Bind, Close, CopyResponse, DataRow, Describe, DescribeTarget,
@@ -38,10 +37,10 @@ pub use server_component::{
     AcceptError, AcceptedServerTransport, BuildServerError, CancellationRequest, DisabledServerTls,
     IdentityServerHandler, NegotiatedServerTls, NoServerIdentity, NoServerIdentityProvider,
     OptionalServerTls, RequiredServerTls, Server, ServerAccept, ServerAcceptFuture,
-    ServerAuthentication, ServerAuthenticationAction, ServerAuthenticationFuture,
-    ServerAuthenticationProvider, ServerAuthenticationRequest, ServerAuthenticationResponse,
-    ServerBuilder, ServerCancellation, ServerConnection, ServerConnectionContext, ServerIdentity,
-    ServerIdentityProvider, ServerProtocolLimits, ServerTlsConfiguration, ServerTlsPolicy,
-    TrustIdentity, TrustServerAuthentication,
+    ServerAuthentication, ServerAuthenticationAction, ServerAuthenticationProvider,
+    ServerAuthenticationRequest, ServerAuthenticationResponse, ServerBuilder, ServerCancellation,
+    ServerConnection, ServerConnectionContext, ServerIdentity, ServerIdentityProvider,
+    ServerProtocolLimits, ServerTlsConfiguration, ServerTlsPolicy, TrustIdentity,
+    TrustServerAuthentication,
 };
 pub use startup::{ProtocolVersion, StartupMessage};

--- a/examples/intermediary_pipeline.rs
+++ b/examples/intermediary_pipeline.rs
@@ -10,13 +10,12 @@ use std::convert::Infallible;
 struct Route;
 impl<Peer> StartupRouteResolver<Peer> for Route {
     type Error = Infallible;
-    fn resolve<'a>(
-        &'a self,
+    async fn resolve(
+        &self,
         _: StartupParameters,
-        _: InitialServerContext<'a, Peer>,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<ConnectTarget, Self::Error>> + 'a>>
-    {
-        Box::pin(async { Ok(ConnectTarget::new("postgres")) })
+        _: InitialServerContext<'_, Peer>,
+    ) -> Result<ConnectTarget, Self::Error> {
+        Ok(ConnectTarget::new("postgres"))
     }
 }
 

--- a/examples/protocol_logging_proxy/main.rs
+++ b/examples/protocol_logging_proxy/main.rs
@@ -36,41 +36,26 @@ impl
 {
     type Error = std::convert::Infallible;
 
-    fn frontend<'a>(
-        &'a mut self,
-        _: &'a ServerConnectionContext<SocketAddr, TrustIdentity>,
-        _: &'a ClientConnectionContext<()>,
-        state: &'a mut ProtocolState,
+    async fn frontend(
+        &mut self,
+        _: &ServerConnectionContext<SocketAddr, TrustIdentity>,
+        _: &ClientConnectionContext<()>,
+        state: &mut ProtocolState,
         message: FrontendMessage,
-    ) -> std::pin::Pin<
-        Box<
-            dyn std::future::Future<
-                    Output = Result<pg_proto::FrontendMiddlewareOutput, Self::Error>,
-                > + 'a,
-        >,
-    > {
-        Box::pin(async move {
-            println!("[{}] client -> server: {message:?}", state.connection);
-            Ok(pg_proto::FrontendMiddlewareOutput::Forward(message))
-        })
+    ) -> Result<pg_proto::FrontendMiddlewareOutput, Self::Error> {
+        println!("[{}] client -> server: {message:?}", state.connection);
+        Ok(pg_proto::FrontendMiddlewareOutput::Forward(message))
     }
 
-    fn backend<'a>(
-        &'a mut self,
-        _: &'a ServerConnectionContext<SocketAddr, TrustIdentity>,
-        _: &'a ClientConnectionContext<()>,
-        state: &'a mut ProtocolState,
+    async fn backend(
+        &mut self,
+        _: &ServerConnectionContext<SocketAddr, TrustIdentity>,
+        _: &ClientConnectionContext<()>,
+        state: &mut ProtocolState,
         message: BackendMessage,
-    ) -> std::pin::Pin<
-        Box<
-            dyn std::future::Future<Output = Result<pg_proto::BackendMiddlewareOutput, Self::Error>>
-                + 'a,
-        >,
-    > {
-        Box::pin(async move {
-            println!("[{}] server -> client: {message:?}", state.connection);
-            Ok(pg_proto::BackendMiddlewareOutput::Forward(message))
-        })
+    ) -> Result<pg_proto::BackendMiddlewareOutput, Self::Error> {
+        println!("[{}] server -> client: {message:?}", state.connection);
+        Ok(pg_proto::BackendMiddlewareOutput::Forward(message))
     }
 }
 
@@ -156,13 +141,12 @@ struct Route(SocketAddr);
 impl StartupRouteResolver<SocketAddr> for Route {
     type Error = Infallible;
 
-    fn resolve<'a>(
-        &'a self,
+    async fn resolve(
+        &self,
         _: StartupParameters,
-        _: InitialServerContext<'a, SocketAddr>,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<ConnectTarget, Self::Error>> + 'a>>
-    {
-        Box::pin(async move { Ok(ConnectTarget::new(self.0.to_string())) })
+        _: InitialServerContext<'_, SocketAddr>,
+    ) -> Result<ConnectTarget, Self::Error> {
+        Ok(ConnectTarget::new(self.0.to_string()))
     }
 }
 

--- a/examples/proxy_skeleton.rs
+++ b/examples/proxy_skeleton.rs
@@ -13,13 +13,12 @@ struct Route;
 impl<Peer> StartupRouteResolver<Peer> for Route {
     type Error = Infallible;
 
-    fn resolve<'a>(
-        &'a self,
+    async fn resolve(
+        &self,
         _startup: StartupParameters,
-        _context: InitialServerContext<'a, Peer>,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<ConnectTarget, Self::Error>> + 'a>>
-    {
-        Box::pin(async { Ok(ConnectTarget::new("postgres")) })
+        _context: InitialServerContext<'_, Peer>,
+    ) -> Result<ConnectTarget, Self::Error> {
+        Ok(ConnectTarget::new("postgres"))
     }
 }
 

--- a/examples/rewriting_intermediary.rs
+++ b/examples/rewriting_intermediary.rs
@@ -13,13 +13,12 @@ use pg_proto::{
 struct Route;
 impl<Peer> StartupRouteResolver<Peer> for Route {
     type Error = Infallible;
-    fn resolve<'a>(
-        &'a self,
+    async fn resolve(
+        &self,
         _: StartupParameters,
-        _: InitialServerContext<'a, Peer>,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<ConnectTarget, Self::Error>> + 'a>>
-    {
-        Box::pin(async { Ok(ConnectTarget::new("postgres")) })
+        _: InitialServerContext<'_, Peer>,
+    ) -> Result<ConnectTarget, Self::Error> {
+        Ok(ConnectTarget::new("postgres"))
     }
 }
 
@@ -34,54 +33,38 @@ impl
 {
     type Error = std::convert::Infallible;
 
-    fn frontend<'a>(
-        &'a mut self,
-        _: &'a ServerConnectionContext<(), TrustIdentity>,
-        _: &'a ClientConnectionContext<()>,
-        (): &'a mut (),
+    async fn frontend(
+        &mut self,
+        _: &ServerConnectionContext<(), TrustIdentity>,
+        _: &ClientConnectionContext<()>,
+        (): &mut (),
         message: FrontendMessage,
-    ) -> std::pin::Pin<
-        Box<
-            dyn std::future::Future<
-                    Output = Result<pg_proto::FrontendMiddlewareOutput, Self::Error>,
-                > + 'a,
-        >,
-    > {
-        Box::pin(async move {
-            Ok(pg_proto::FrontendMiddlewareOutput::Forward(match message {
-                FrontendMessage::Query(_) => FrontendMessage::Query(Bytes::from_static(
-                    b"select amount from ledger where visible = true",
-                )),
-                FrontendMessage::Parse(mut parse) => {
-                    parse.query =
-                        Bytes::from_static(b"select amount from ledger where visible = true");
-                    FrontendMessage::Parse(parse)
-                }
-                other => other,
-            }))
-        })
+    ) -> Result<pg_proto::FrontendMiddlewareOutput, Self::Error> {
+        Ok(pg_proto::FrontendMiddlewareOutput::Forward(match message {
+            FrontendMessage::Query(_) => FrontendMessage::Query(Bytes::from_static(
+                b"select amount from ledger where visible = true",
+            )),
+            FrontendMessage::Parse(mut parse) => {
+                parse.query = Bytes::from_static(b"select amount from ledger where visible = true");
+                FrontendMessage::Parse(parse)
+            }
+            other => other,
+        }))
     }
-    fn backend<'a>(
-        &'a mut self,
-        _: &'a ServerConnectionContext<(), TrustIdentity>,
-        _: &'a ClientConnectionContext<()>,
-        (): &'a mut (),
+    async fn backend(
+        &mut self,
+        _: &ServerConnectionContext<(), TrustIdentity>,
+        _: &ClientConnectionContext<()>,
+        (): &mut (),
         message: BackendMessage,
-    ) -> std::pin::Pin<
-        Box<
-            dyn std::future::Future<Output = Result<pg_proto::BackendMiddlewareOutput, Self::Error>>
-                + 'a,
-        >,
-    > {
-        Box::pin(async move {
-            Ok(pg_proto::BackendMiddlewareOutput::Forward(match message {
-                BackendMessage::RowDescription(mut rows) if !rows.fields.is_empty() => {
-                    rows.fields[0].name = Bytes::from_static(b"visible_amount");
-                    BackendMessage::RowDescription(rows)
-                }
-                other => other,
-            }))
-        })
+    ) -> Result<pg_proto::BackendMiddlewareOutput, Self::Error> {
+        Ok(pg_proto::BackendMiddlewareOutput::Forward(match message {
+            BackendMessage::RowDescription(mut rows) if !rows.fields.is_empty() => {
+                rows.fields[0].name = Bytes::from_static(b"visible_amount");
+                BackendMessage::RowDescription(rows)
+            }
+            other => other,
+        }))
     }
 }
 

--- a/examples/sql_logging_proxy/main.rs
+++ b/examples/sql_logging_proxy/main.rs
@@ -58,60 +58,45 @@ impl
 {
     type Error = std::convert::Infallible;
 
-    fn frontend<'a>(
-        &'a mut self,
-        _: &'a ServerConnectionContext<SocketAddr, TrustIdentity>,
-        _: &'a ClientConnectionContext<()>,
-        state: &'a mut SqlState,
+    async fn frontend(
+        &mut self,
+        _: &ServerConnectionContext<SocketAddr, TrustIdentity>,
+        _: &ClientConnectionContext<()>,
+        state: &mut SqlState,
         message: FrontendMessage,
-    ) -> std::pin::Pin<
-        Box<
-            dyn std::future::Future<
-                    Output = Result<pg_proto::FrontendMiddlewareOutput, Self::Error>,
-                > + 'a,
-        >,
-    > {
-        Box::pin(async move {
-            if let FrontendMessage::Query(sql)
-            | FrontendMessage::Parse(pg_proto::Parse { query: sql, .. }) = &message
-            {
-                (state.reporter)(Observation::Sql {
-                    connection: state.connection,
-                    statement: String::from_utf8_lossy(sql).into_owned(),
-                });
-            }
-            Ok(pg_proto::FrontendMiddlewareOutput::Forward(message))
-        })
+    ) -> Result<pg_proto::FrontendMiddlewareOutput, Self::Error> {
+        if let FrontendMessage::Query(sql)
+        | FrontendMessage::Parse(pg_proto::Parse { query: sql, .. }) = &message
+        {
+            (state.reporter)(Observation::Sql {
+                connection: state.connection,
+                statement: String::from_utf8_lossy(sql).into_owned(),
+            });
+        }
+        Ok(pg_proto::FrontendMiddlewareOutput::Forward(message))
     }
 
-    fn backend<'a>(
-        &'a mut self,
-        _: &'a ServerConnectionContext<SocketAddr, TrustIdentity>,
-        _: &'a ClientConnectionContext<()>,
-        state: &'a mut SqlState,
+    async fn backend(
+        &mut self,
+        _: &ServerConnectionContext<SocketAddr, TrustIdentity>,
+        _: &ClientConnectionContext<()>,
+        state: &mut SqlState,
         message: BackendMessage,
-    ) -> std::pin::Pin<
-        Box<
-            dyn std::future::Future<Output = Result<pg_proto::BackendMiddlewareOutput, Self::Error>>
-                + 'a,
-        >,
-    > {
-        Box::pin(async move {
-            match &message {
-                BackendMessage::DataRow(_) => state.rows = state.rows.saturating_add(1),
-                BackendMessage::CommandComplete(tag) => {
-                    (state.reporter)(Observation::RowCount {
-                        connection: state.connection,
-                        rows: state.rows,
-                        command: String::from_utf8_lossy(tag).into_owned(),
-                    });
-                    state.rows = 0;
-                }
-                BackendMessage::ErrorResponse(_) => state.rows = 0,
-                _ => {}
+    ) -> Result<pg_proto::BackendMiddlewareOutput, Self::Error> {
+        match &message {
+            BackendMessage::DataRow(_) => state.rows = state.rows.saturating_add(1),
+            BackendMessage::CommandComplete(tag) => {
+                (state.reporter)(Observation::RowCount {
+                    connection: state.connection,
+                    rows: state.rows,
+                    command: String::from_utf8_lossy(tag).into_owned(),
+                });
+                state.rows = 0;
             }
-            Ok(pg_proto::BackendMiddlewareOutput::Forward(message))
-        })
+            BackendMessage::ErrorResponse(_) => state.rows = 0,
+            _ => {}
+        }
+        Ok(pg_proto::BackendMiddlewareOutput::Forward(message))
     }
 }
 
@@ -210,13 +195,12 @@ struct Route(SocketAddr);
 impl StartupRouteResolver<SocketAddr> for Route {
     type Error = Infallible;
 
-    fn resolve<'a>(
-        &'a self,
+    async fn resolve(
+        &self,
         _: StartupParameters,
-        _: InitialServerContext<'a, SocketAddr>,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<ConnectTarget, Self::Error>> + 'a>>
-    {
-        Box::pin(async move { Ok(ConnectTarget::new(self.0.to_string())) })
+        _: InitialServerContext<'_, SocketAddr>,
+    ) -> Result<ConnectTarget, Self::Error> {
+        Ok(ConnectTarget::new(self.0.to_string()))
     }
 }
 

--- a/fuzz/fuzz_targets/scram.rs
+++ b/fuzz/fuzz_targets/scram.rs
@@ -3,8 +3,7 @@
 use libfuzzer_sys::fuzz_target;
 use pg_proto::{
     DisabledServerTls, Server, ServerAuthentication, ServerAuthenticationAction,
-    ServerAuthenticationFuture, ServerAuthenticationProvider, ServerAuthenticationRequest,
-    ServerAuthenticationResponse,
+    ServerAuthenticationProvider, ServerAuthenticationRequest, ServerAuthenticationResponse,
 };
 use tokio::io::{AsyncWriteExt as _, duplex};
 
@@ -13,35 +12,35 @@ struct SaslPolicy;
 
 impl ServerAuthenticationProvider for SaslPolicy {
     type Authentication = Self;
-    fn create(&self) -> Self { *self }
+    fn create(&self) -> Self {
+        *self
+    }
 }
 
 impl ServerAuthentication<()> for SaslPolicy {
     type Identity = ();
     type Error = std::convert::Infallible;
 
-    fn start<'a>(&'a mut self, _: ServerAuthenticationRequest<'a, ()>)
-        -> ServerAuthenticationFuture<'a, ServerAuthenticationAction<()>, Self::Error>
-    {
-        Box::pin(async {
-            Ok(ServerAuthenticationAction::Sasl {
-                mechanisms: vec![bytes::Bytes::from_static(b"SCRAM-SHA-256")],
-            })
+    async fn start(
+        &mut self,
+        _: ServerAuthenticationRequest<'_, ()>,
+    ) -> Result<ServerAuthenticationAction<()>, Self::Error> {
+        Ok(ServerAuthenticationAction::Sasl {
+            mechanisms: vec![bytes::Bytes::from_static(b"SCRAM-SHA-256")],
         })
     }
 
-    fn respond<'a>(
-        &'a mut self,
-        _: ServerAuthenticationRequest<'a, ()>,
+    async fn respond(
+        &mut self,
+        _: ServerAuthenticationRequest<'_, ()>,
         response: ServerAuthenticationResponse,
-    ) -> ServerAuthenticationFuture<'a, ServerAuthenticationAction<()>, Self::Error> {
-        Box::pin(async move {
-            Ok(match response {
-                ServerAuthenticationResponse::SaslInitial { .. } =>
-                    ServerAuthenticationAction::SaslContinue(bytes::Bytes::from_static(b"r=fuzz")),
-                ServerAuthenticationResponse::Sasl(_) => ServerAuthenticationAction::Accept(()),
-                _ => ServerAuthenticationAction::Accept(()),
-            })
+    ) -> Result<ServerAuthenticationAction<()>, Self::Error> {
+        Ok(match response {
+            ServerAuthenticationResponse::SaslInitial { .. } => {
+                ServerAuthenticationAction::SaslContinue(bytes::Bytes::from_static(b"r=fuzz"))
+            }
+            ServerAuthenticationResponse::Sasl(_) => ServerAuthenticationAction::Accept(()),
+            _ => ServerAuthenticationAction::Accept(()),
         })
     }
 }
@@ -49,17 +48,20 @@ impl ServerAuthentication<()> for SaslPolicy {
 fuzz_target!(|data: &[u8]| {
     let mut input = vec![0, 0, 0, 13, 0, 3, 0, 0, b'u', 0, b'f', 0, 0];
     input.extend_from_slice(data);
-    tokio::runtime::Builder::new_current_thread().build().unwrap().block_on(async move {
-        let (server_io, mut peer) = duplex(input.len().saturating_add(4096));
-        tokio::spawn(async move {
-            let _ = peer.write_all(&input).await;
-            let _ = peer.shutdown().await;
+    tokio::runtime::Builder::new_current_thread()
+        .build()
+        .unwrap()
+        .block_on(async move {
+            let (server_io, mut peer) = duplex(input.len().saturating_add(4096));
+            tokio::spawn(async move {
+                let _ = peer.write_all(&input).await;
+                let _ = peer.shutdown().await;
+            });
+            let server = Server::builder()
+                .tls(DisabledServerTls)
+                .authentication(SaslPolicy)
+                .build()
+                .unwrap();
+            let _ = server.accept(server_io, (), ()).await;
         });
-        let server = Server::builder()
-            .tls(DisabledServerTls)
-            .authentication(SaslPolicy)
-            .build()
-            .unwrap();
-        let _ = server.accept(server_io, (), ()).await;
-    });
 });

--- a/src/client_component.rs
+++ b/src/client_component.rs
@@ -139,15 +139,15 @@ impl fmt::Debug for ClientTlsConfig {
 }
 
 /// Application-owned source of reloadable client TLS material.
+///
+/// Resolution futures are not required to be [`Send`].
+#[allow(async_fn_in_trait)]
 pub trait ClientTlsProvider {
     /// Provider resolution failure.
     type Error;
 
     /// Resolves material for one connection attempt.
-    fn resolve<'a>(
-        &'a self,
-        target: &'a ConnectTarget,
-    ) -> Pin<Box<dyn Future<Output = Result<ClientTlsConfig, Self::Error>> + 'a>>;
+    async fn resolve(&self, target: &ConnectTarget) -> Result<ClientTlsConfig, Self::Error>;
 }
 
 /// Failure while resolving or establishing client TLS.
@@ -182,11 +182,8 @@ impl<ProviderError: std::error::Error + 'static> std::error::Error
 impl ClientTlsProvider for () {
     type Error = Infallible;
 
-    fn resolve<'a>(
-        &'a self,
-        _target: &'a ConnectTarget,
-    ) -> Pin<Box<dyn Future<Output = Result<ClientTlsConfig, Self::Error>> + 'a>> {
-        Box::pin(async { unreachable!("disabled TLS never resolves a provider") })
+    async fn resolve(&self, _target: &ConnectTarget) -> Result<ClientTlsConfig, Self::Error> {
+        unreachable!("disabled TLS never resolves a provider")
     }
 }
 
@@ -359,6 +356,9 @@ pub enum ClientAuthenticationResponse {
 }
 
 /// Factory for asynchronous, fallible per-connection authentication sessions.
+///
+/// Authentication futures are not required to be [`Send`].
+#[allow(async_fn_in_trait)]
 pub trait ClientAuthentication {
     /// Typed identity evidence produced after server confirmation.
     type Evidence;
@@ -368,17 +368,13 @@ pub trait ClientAuthentication {
     type Error;
 
     /// Creates fresh authentication state using the selected route.
-    fn begin<'a>(
-        &'a self,
-        target: &'a ConnectTarget,
-    ) -> ClientAuthenticationFuture<'a, Self::Session, Self::Error>;
+    async fn begin(&self, target: &ConnectTarget) -> Result<Self::Session, Self::Error>;
 }
 
-/// Boxed future used by application-defined authentication policies.
-pub type ClientAuthenticationFuture<'a, Output, Error> =
-    Pin<Box<dyn Future<Output = Result<Output, Error>> + 'a>>;
-
 /// Mutable authentication policy state owned by one connection attempt.
+///
+/// Authentication futures are not required to be [`Send`].
+#[allow(async_fn_in_trait)]
 pub trait ClientAuthenticationSession {
     /// Typed identity evidence produced after server confirmation.
     type Evidence;
@@ -386,13 +382,13 @@ pub trait ClientAuthenticationSession {
     type Error;
 
     /// Answers one server authentication challenge.
-    fn respond(
+    async fn respond(
         &mut self,
         challenge: ClientAuthenticationChallenge,
-    ) -> ClientAuthenticationFuture<'_, ClientAuthenticationResponse, Self::Error>;
+    ) -> Result<ClientAuthenticationResponse, Self::Error>;
 
     /// Produces identity evidence after `AuthenticationOk` was received.
-    fn authenticated(self) -> ClientAuthenticationFuture<'static, Self::Evidence, Self::Error>;
+    async fn authenticated(self) -> Result<Self::Evidence, Self::Error>;
 }
 
 /// Failure while running an application authentication policy.
@@ -441,11 +437,8 @@ impl ClientAuthentication for TrustClientAuthentication {
     type Session = Self;
     type Error = Infallible;
 
-    fn begin<'a>(
-        &'a self,
-        _target: &'a ConnectTarget,
-    ) -> Pin<Box<dyn Future<Output = Result<Self::Session, Self::Error>> + 'a>> {
-        Box::pin(async { Ok(Self) })
+    async fn begin(&self, _target: &ConnectTarget) -> Result<Self::Session, Self::Error> {
+        Ok(Self)
     }
 }
 
@@ -453,15 +446,15 @@ impl ClientAuthenticationSession for TrustClientAuthentication {
     type Evidence = ();
     type Error = Infallible;
 
-    fn respond(
+    async fn respond(
         &mut self,
         _challenge: ClientAuthenticationChallenge,
-    ) -> ClientAuthenticationFuture<'_, ClientAuthenticationResponse, Self::Error> {
-        Box::pin(async { Ok(ClientAuthenticationResponse::Verified) })
+    ) -> Result<ClientAuthenticationResponse, Self::Error> {
+        Ok(ClientAuthenticationResponse::Verified)
     }
 
-    fn authenticated(self) -> Pin<Box<dyn Future<Output = Result<Self::Evidence, Self::Error>>>> {
-        Box::pin(async { Ok(()) })
+    async fn authenticated(self) -> Result<Self::Evidence, Self::Error> {
+        Ok(())
     }
 }
 

--- a/src/intermediary_component.rs
+++ b/src/intermediary_component.rs
@@ -179,28 +179,34 @@ impl<'a, Peer> InitialServerContext<'a, Peer> {
 }
 
 /// Required asynchronous startup routing policy.
+///
+/// Resolution futures are not required to be [`Send`].
+#[allow(async_fn_in_trait)]
 pub trait StartupRouteResolver<Peer> {
     /// Application resolver failure.
     type Error;
 
     /// Selects a destination before client-facing authentication begins.
-    fn resolve<'a>(
-        &'a self,
+    async fn resolve(
+        &self,
         startup: StartupParameters,
-        context: InitialServerContext<'a, Peer>,
-    ) -> Pin<Box<dyn Future<Output = Result<ConnectTarget, Self::Error>> + 'a>>;
+        context: InitialServerContext<'_, Peer>,
+    ) -> Result<ConnectTarget, Self::Error>;
 }
 
 /// Optional policy that validates or refines a destination after authentication.
+///
+/// Routing futures are not required to be [`Send`].
+#[allow(async_fn_in_trait)]
 pub trait AuthenticatedRoutePolicy<Peer, Identity> {
     /// Application policy failure.
     type Error;
     /// Validates or refines the startup-selected target using typed identity evidence.
-    fn route<'a>(
-        &'a self,
+    async fn route(
+        &self,
         target: ConnectTarget,
-        context: AuthenticatedRouteContext<'a, Peer, Identity>,
-    ) -> Pin<Box<dyn Future<Output = Result<ConnectTarget, Self::Error>> + 'a>>;
+        context: AuthenticatedRouteContext<'_, Peer, Identity>,
+    ) -> Result<ConnectTarget, Self::Error>;
 }
 
 /// Borrowed facts passed to authenticated route policy.
@@ -230,12 +236,12 @@ pub struct AllowAuthenticatedRoute;
 
 impl<Peer, Identity> AuthenticatedRoutePolicy<Peer, Identity> for AllowAuthenticatedRoute {
     type Error = std::convert::Infallible;
-    fn route<'a>(
-        &'a self,
+    async fn route(
+        &self,
         target: ConnectTarget,
-        _context: AuthenticatedRouteContext<'a, Peer, Identity>,
-    ) -> Pin<Box<dyn Future<Output = Result<ConnectTarget, Self::Error>> + 'a>> {
-        Box::pin(async move { Ok(target) })
+        _context: AuthenticatedRouteContext<'_, Peer, Identity>,
+    ) -> Result<ConnectTarget, Self::Error> {
+        Ok(target)
     }
 }
 
@@ -369,48 +375,49 @@ impl<'a> HeldBackendMessages<'a> {
 }
 
 /// Asynchronous, fallible middleware at the forwarding boundary.
+///
+/// Middleware futures are not required to be [`Send`].
+#[allow(async_fn_in_trait)]
 pub trait IntermediaryMiddleware<State, ServerContext, ClientContext> {
     /// Application-defined interception failure.
     type Error;
 
     /// Intercepts a client-originated message after server-role middleware and
     /// before client-role middleware.
-    fn frontend<'a>(
-        &'a mut self,
-        _server: &'a ServerContext,
-        _client: &'a ClientContext,
-        _state: &'a mut State,
+    async fn frontend(
+        &mut self,
+        _server: &ServerContext,
+        _client: &ClientContext,
+        _state: &mut State,
         message: crate::codec::FrontendMessage,
-    ) -> Pin<Box<dyn Future<Output = Result<FrontendMiddlewareOutput, Self::Error>> + 'a>> {
-        Box::pin(async move { Ok(FrontendMiddlewareOutput::Forward(message)) })
+    ) -> Result<FrontendMiddlewareOutput, Self::Error> {
+        Ok(FrontendMiddlewareOutput::Forward(message))
     }
 
     /// Intercepts a PostgreSQL-originated message after client-role middleware
     /// and before server-role middleware.
-    fn backend<'a>(
-        &'a mut self,
-        _server: &'a ServerContext,
-        _client: &'a ClientContext,
-        _state: &'a mut State,
+    async fn backend(
+        &mut self,
+        _server: &ServerContext,
+        _client: &ClientContext,
+        _state: &mut State,
         message: crate::codec::BackendMessage,
-    ) -> Pin<Box<dyn Future<Output = Result<BackendMiddlewareOutput, Self::Error>> + 'a>> {
-        Box::pin(async move { Ok(BackendMiddlewareOutput::Forward(message)) })
+    ) -> Result<BackendMiddlewareOutput, Self::Error> {
+        Ok(BackendMiddlewareOutput::Forward(message))
     }
 
     /// Applies policy to an ordered borrowed span of retained backend messages.
-    fn flush_backend<'a>(
-        &'a mut self,
-        _server: &'a ServerContext,
-        _client: &'a ClientContext,
-        _state: &'a mut State,
-        held: HeldBackendMessages<'a>,
+    async fn flush_backend(
+        &mut self,
+        _server: &ServerContext,
+        _client: &ClientContext,
+        _state: &mut State,
+        held: HeldBackendMessages<'_>,
         _reason: BackendFlushReason,
-    ) -> Pin<Box<dyn Future<Output = Result<BackendBatchOutput, Self::Error>> + 'a>> {
-        Box::pin(async move {
-            Ok(BackendBatchOutput::ReplaceOneToOne(
-                held.iter().cloned().collect(),
-            ))
-        })
+    ) -> Result<BackendBatchOutput, Self::Error> {
+        Ok(BackendBatchOutput::ReplaceOneToOne(
+            held.iter().cloned().collect(),
+        ))
     }
 }
 

--- a/src/internal_tests/server_role.rs
+++ b/src/internal_tests/server_role.rs
@@ -3,8 +3,8 @@
 use bytes::Bytes;
 use pg_proto::{
     Conn, Server, ServerAccept, ServerAuthentication, ServerAuthenticationAction,
-    ServerAuthenticationFuture, ServerAuthenticationProvider, ServerAuthenticationRequest,
-    ServerAuthenticationResponse, ServerTlsPolicy,
+    ServerAuthenticationProvider, ServerAuthenticationRequest, ServerAuthenticationResponse,
+    ServerTlsPolicy,
     codec::{BackendMessage, DataRow, FieldDescription, RowDescription, TransactionStatus},
     credentials::{verify_cleartext, verify_md5_response},
     pre_startup::PreStartupOffer,
@@ -43,44 +43,38 @@ impl ServerAuthentication<()> for ScramAuthentication {
     type Identity = &'static str;
     type Error = std::io::Error;
 
-    fn start<'a>(
-        &'a mut self,
-        _request: ServerAuthenticationRequest<'a, ()>,
-    ) -> ServerAuthenticationFuture<'a, ServerAuthenticationAction<Self::Identity>, Self::Error>
-    {
-        Box::pin(async {
-            Ok(ServerAuthenticationAction::Sasl {
-                mechanisms: vec![Bytes::from_static(SCRAM_SHA_256)],
-            })
+    async fn start(
+        &mut self,
+        _request: ServerAuthenticationRequest<'_, ()>,
+    ) -> Result<ServerAuthenticationAction<Self::Identity>, Self::Error> {
+        Ok(ServerAuthenticationAction::Sasl {
+            mechanisms: vec![Bytes::from_static(SCRAM_SHA_256)],
         })
     }
 
-    fn respond<'a>(
-        &'a mut self,
-        _request: ServerAuthenticationRequest<'a, ()>,
+    async fn respond(
+        &mut self,
+        _request: ServerAuthenticationRequest<'_, ()>,
         response: ServerAuthenticationResponse,
-    ) -> ServerAuthenticationFuture<'a, ServerAuthenticationAction<Self::Identity>, Self::Error>
-    {
-        Box::pin(async move {
-            match response {
-                ServerAuthenticationResponse::SaslInitial {
-                    mechanism,
-                    response: Some(initial),
-                } => {
-                    let (exchange, challenge) = self.server.start(&mechanism, &initial)?;
-                    self.exchange = Some(exchange);
-                    Ok(ServerAuthenticationAction::SaslContinue(challenge))
-                }
-                ServerAuthenticationResponse::Sasl(final_response) => {
-                    let final_data = self.exchange.take().unwrap().finish(&final_response)?;
-                    Ok(ServerAuthenticationAction::SaslFinal {
-                        server_final: final_data,
-                        identity: "proxy_test",
-                    })
-                }
-                _ => Err(std::io::Error::other("unexpected SCRAM response")),
+    ) -> Result<ServerAuthenticationAction<Self::Identity>, Self::Error> {
+        match response {
+            ServerAuthenticationResponse::SaslInitial {
+                mechanism,
+                response: Some(initial),
+            } => {
+                let (exchange, challenge) = self.server.start(&mechanism, &initial)?;
+                self.exchange = Some(exchange);
+                Ok(ServerAuthenticationAction::SaslContinue(challenge))
             }
-        })
+            ServerAuthenticationResponse::Sasl(final_response) => {
+                let final_data = self.exchange.take().unwrap().finish(&final_response)?;
+                Ok(ServerAuthenticationAction::SaslFinal {
+                    server_final: final_data,
+                    identity: "proxy_test",
+                })
+            }
+            _ => Err(std::io::Error::other("unexpected SCRAM response")),
+        }
     }
 }
 
@@ -96,28 +90,24 @@ impl ServerAuthentication<()> for CompatibilityAuthentication {
     type Identity = ();
     type Error = ();
 
-    fn start<'a>(
-        &'a mut self,
-        _request: ServerAuthenticationRequest<'a, ()>,
-    ) -> ServerAuthenticationFuture<'a, ServerAuthenticationAction<Self::Identity>, Self::Error>
-    {
-        Box::pin(async { Ok(ServerAuthenticationAction::CleartextPassword) })
+    async fn start(
+        &mut self,
+        _request: ServerAuthenticationRequest<'_, ()>,
+    ) -> Result<ServerAuthenticationAction<Self::Identity>, Self::Error> {
+        Ok(ServerAuthenticationAction::CleartextPassword)
     }
 
-    fn respond<'a>(
-        &'a mut self,
-        _request: ServerAuthenticationRequest<'a, ()>,
+    async fn respond(
+        &mut self,
+        _request: ServerAuthenticationRequest<'_, ()>,
         response: ServerAuthenticationResponse,
-    ) -> ServerAuthenticationFuture<'a, ServerAuthenticationAction<Self::Identity>, Self::Error>
-    {
-        Box::pin(async move {
-            let ServerAuthenticationResponse::Password(body) = response else {
-                return Err(());
-            };
-            (body == b"secret".as_slice())
-                .then_some(ServerAuthenticationAction::Accept(()))
-                .ok_or(())
-        })
+    ) -> Result<ServerAuthenticationAction<Self::Identity>, Self::Error> {
+        let ServerAuthenticationResponse::Password(body) = response else {
+            return Err(());
+        };
+        (body == b"secret".as_slice())
+            .then_some(ServerAuthenticationAction::Accept(()))
+            .ok_or(())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,13 +60,12 @@ mod transport;
 
 pub use client_component::{
     BuildError, CancelError, Client, ClientAuthentication, ClientAuthenticationChallenge,
-    ClientAuthenticationError, ClientAuthenticationFuture, ClientAuthenticationResponse,
-    ClientAuthenticationSession, ClientBuilder, ClientConnection, ClientConnectionContext,
-    ClientInitialContext, ClientTlsConfig, ClientTlsConfiguration, ClientTlsError, ClientTlsPolicy,
-    ClientTlsProvider, ClientTlsStatus, ClientTransport, ConnectError, ConnectTarget,
-    ConnectionChanged, ConnectionClean, IdentityHandler, ProtocolLimitError, ProtocolLimits,
-    QueryError, ReloadableClientTls, StartupParameterError, StartupParameters,
-    TrustClientAuthentication,
+    ClientAuthenticationError, ClientAuthenticationResponse, ClientAuthenticationSession,
+    ClientBuilder, ClientConnection, ClientConnectionContext, ClientInitialContext,
+    ClientTlsConfig, ClientTlsConfiguration, ClientTlsError, ClientTlsPolicy, ClientTlsProvider,
+    ClientTlsStatus, ClientTransport, ConnectError, ConnectTarget, ConnectionChanged,
+    ConnectionClean, IdentityHandler, ProtocolLimitError, ProtocolLimits, QueryError,
+    ReloadableClientTls, StartupParameterError, StartupParameters, TrustClientAuthentication,
 };
 pub use codec::{
     Authentication, BackendMessage, Bind, Close, CopyResponse, DataRow, Describe, DescribeTarget,
@@ -98,11 +97,11 @@ pub use server_component::{
     AcceptError, AcceptedServerTransport, BuildServerError, CancellationRequest, DisabledServerTls,
     IdentityServerHandler, NegotiatedServerTls, NoServerIdentity, NoServerIdentityProvider,
     OptionalServerTls, RequiredServerTls, Server, ServerAccept, ServerAcceptFuture,
-    ServerAuthentication, ServerAuthenticationAction, ServerAuthenticationFuture,
-    ServerAuthenticationProvider, ServerAuthenticationRequest, ServerAuthenticationResponse,
-    ServerBuilder, ServerCancellation, ServerConnection, ServerConnectionContext, ServerIdentity,
-    ServerIdentityProvider, ServerProtocolLimits, ServerTlsConfiguration, ServerTlsPolicy,
-    TrustIdentity, TrustServerAuthentication,
+    ServerAuthentication, ServerAuthenticationAction, ServerAuthenticationProvider,
+    ServerAuthenticationRequest, ServerAuthenticationResponse, ServerBuilder, ServerCancellation,
+    ServerConnection, ServerConnectionContext, ServerIdentity, ServerIdentityProvider,
+    ServerProtocolLimits, ServerTlsConfiguration, ServerTlsPolicy, TrustIdentity,
+    TrustServerAuthentication,
 };
 pub use startup::{ProtocolVersion, StartupMessage};
 

--- a/src/server_component.rs
+++ b/src/server_component.rs
@@ -20,10 +20,6 @@ use crate::{
     transport::Buffered,
 };
 
-/// A non-`Send` future returned by application-defined server authentication.
-pub type ServerAuthenticationFuture<'a, Identity, Error> =
-    Pin<Box<dyn Future<Output = Result<Identity, Error>> + 'a>>;
-
 /// Async startup routing hook used by the intermediary facade.
 #[allow(clippy::type_complexity)]
 pub(crate) trait StartupResolver<State, Peer, Identity> {
@@ -217,6 +213,9 @@ pub enum ServerAuthenticationResponse {
 }
 
 /// Per-connection asynchronous authentication policy.
+///
+/// Authentication futures are not required to be [`Send`].
+#[allow(async_fn_in_trait)]
 pub trait ServerAuthentication<Peer> {
     /// Typed evidence produced by successful authentication.
     type Identity;
@@ -224,17 +223,17 @@ pub trait ServerAuthentication<Peer> {
     type Error;
 
     /// Starts the application-driven authentication conversation.
-    fn start<'a>(
-        &'a mut self,
-        request: ServerAuthenticationRequest<'a, Peer>,
-    ) -> ServerAuthenticationFuture<'a, ServerAuthenticationAction<Self::Identity>, Self::Error>;
+    async fn start(
+        &mut self,
+        request: ServerAuthenticationRequest<'_, Peer>,
+    ) -> Result<ServerAuthenticationAction<Self::Identity>, Self::Error>;
 
     /// Advances the conversation after one protocol response.
-    fn respond<'a>(
-        &'a mut self,
-        request: ServerAuthenticationRequest<'a, Peer>,
+    async fn respond(
+        &mut self,
+        request: ServerAuthenticationRequest<'_, Peer>,
         response: ServerAuthenticationResponse,
-    ) -> ServerAuthenticationFuture<'a, ServerAuthenticationAction<Self::Identity>, Self::Error>;
+    ) -> Result<ServerAuthenticationAction<Self::Identity>, Self::Error>;
 }
 
 /// Factory creating one isolated authentication policy per connection.
@@ -470,20 +469,18 @@ impl<Peer> ServerAuthentication<Peer> for TrustServerAuthentication {
     type Identity = TrustIdentity;
     type Error = std::convert::Infallible;
 
-    fn start<'a>(
-        &'a mut self,
-        _request: ServerAuthenticationRequest<'a, Peer>,
-    ) -> ServerAuthenticationFuture<'a, ServerAuthenticationAction<Self::Identity>, Self::Error>
-    {
-        Box::pin(async { Ok(ServerAuthenticationAction::Accept(TrustIdentity)) })
+    async fn start(
+        &mut self,
+        _request: ServerAuthenticationRequest<'_, Peer>,
+    ) -> Result<ServerAuthenticationAction<Self::Identity>, Self::Error> {
+        Ok(ServerAuthenticationAction::Accept(TrustIdentity))
     }
 
-    fn respond<'a>(
-        &'a mut self,
-        _request: ServerAuthenticationRequest<'a, Peer>,
+    async fn respond(
+        &mut self,
+        _request: ServerAuthenticationRequest<'_, Peer>,
         _response: ServerAuthenticationResponse,
-    ) -> ServerAuthenticationFuture<'a, ServerAuthenticationAction<Self::Identity>, Self::Error>
-    {
+    ) -> Result<ServerAuthenticationAction<Self::Identity>, Self::Error> {
         unreachable!("trust authentication accepts before a response")
     }
 }

--- a/tests/client_runtime_middleware.rs
+++ b/tests/client_runtime_middleware.rs
@@ -9,10 +9,9 @@ use std::{
 use bytes::Bytes;
 use pg_proto::{
     BackendMessage, Client, ClientAuthentication, ClientAuthenticationChallenge,
-    ClientAuthenticationFuture, ClientAuthenticationResponse, ClientAuthenticationSession,
-    ClientConnectionContext, ClientInitialContext, ClientMiddleware, ClientTlsPolicy,
-    ClientTlsStatus, ConnectTarget, FrontendMessage, MiddlewareFactory, StartupParameters,
-    TrustClientAuthentication,
+    ClientAuthenticationResponse, ClientAuthenticationSession, ClientConnectionContext,
+    ClientInitialContext, ClientMiddleware, ClientTlsPolicy, ClientTlsStatus, ConnectTarget,
+    FrontendMessage, MiddlewareFactory, StartupParameters, TrustClientAuthentication,
 };
 use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _, DuplexStream};
 
@@ -31,11 +30,8 @@ impl ClientAuthentication for PasswordAuthentication {
     type Session = Self;
     type Error = std::convert::Infallible;
 
-    fn begin<'a>(
-        &'a self,
-        _target: &'a ConnectTarget,
-    ) -> ClientAuthenticationFuture<'a, Self::Session, Self::Error> {
-        Box::pin(async { Ok(*self) })
+    async fn begin(&self, _target: &ConnectTarget) -> Result<Self::Session, Self::Error> {
+        Ok(*self)
     }
 }
 
@@ -43,20 +39,18 @@ impl ClientAuthenticationSession for PasswordAuthentication {
     type Evidence = &'static str;
     type Error = std::convert::Infallible;
 
-    fn respond(
+    async fn respond(
         &mut self,
         challenge: ClientAuthenticationChallenge,
-    ) -> ClientAuthenticationFuture<'_, ClientAuthenticationResponse, Self::Error> {
+    ) -> Result<ClientAuthenticationResponse, Self::Error> {
         assert_eq!(challenge, ClientAuthenticationChallenge::CleartextPassword);
-        Box::pin(async {
-            Ok(ClientAuthenticationResponse::Password(Bytes::from_static(
-                b"policy-secret",
-            )))
-        })
+        Ok(ClientAuthenticationResponse::Password(Bytes::from_static(
+            b"policy-secret",
+        )))
     }
 
-    fn authenticated(self) -> ClientAuthenticationFuture<'static, Self::Evidence, Self::Error> {
-        Box::pin(async { Ok("authenticated") })
+    async fn authenticated(self) -> Result<Self::Evidence, Self::Error> {
+        Ok("authenticated")
     }
 }
 

--- a/tests/client_tls_auth.rs
+++ b/tests/client_tls_auth.rs
@@ -2,8 +2,6 @@
 
 use std::{
     convert::Infallible,
-    future::Future,
-    pin::Pin,
     sync::{
         Arc,
         atomic::{AtomicUsize, Ordering},
@@ -39,12 +37,9 @@ impl ClientAuthentication for PasswordPolicy {
     type Evidence = String;
     type Session = PasswordSession;
 
-    fn begin<'a>(
-        &'a self,
-        target: &'a ConnectTarget,
-    ) -> Pin<Box<dyn Future<Output = Result<Self::Session, Self::Error>> + 'a>> {
+    async fn begin(&self, target: &ConnectTarget) -> Result<Self::Session, Self::Error> {
         let identity = target.metadata().get("tenant").unwrap().to_owned();
-        Box::pin(async move { Ok(PasswordSession { identity }) })
+        Ok(PasswordSession { identity })
     }
 }
 
@@ -52,20 +47,18 @@ impl ClientAuthenticationSession for PasswordSession {
     type Error = Infallible;
     type Evidence = String;
 
-    fn respond<'a>(
-        &'a mut self,
+    async fn respond(
+        &mut self,
         challenge: ClientAuthenticationChallenge,
-    ) -> Pin<Box<dyn Future<Output = Result<ClientAuthenticationResponse, Self::Error>> + 'a>> {
-        Box::pin(async move {
-            assert_eq!(challenge, ClientAuthenticationChallenge::CleartextPassword);
-            Ok(ClientAuthenticationResponse::Password(Bytes::from_static(
-                b"secret",
-            )))
-        })
+    ) -> Result<ClientAuthenticationResponse, Self::Error> {
+        assert_eq!(challenge, ClientAuthenticationChallenge::CleartextPassword);
+        Ok(ClientAuthenticationResponse::Password(Bytes::from_static(
+            b"secret",
+        )))
     }
 
-    fn authenticated(self) -> Pin<Box<dyn Future<Output = Result<Self::Evidence, Self::Error>>>> {
-        Box::pin(async move { Ok(self.identity) })
+    async fn authenticated(self) -> Result<Self::Evidence, Self::Error> {
+        Ok(self.identity)
     }
 }
 
@@ -123,18 +116,13 @@ struct ReloadingTls {
 impl ClientTlsProvider for ReloadingTls {
     type Error = Infallible;
 
-    fn resolve<'a>(
-        &'a self,
-        _target: &'a ConnectTarget,
-    ) -> Pin<Box<dyn Future<Output = Result<ClientTlsConfig, Self::Error>> + 'a>> {
+    async fn resolve(&self, _target: &ConnectTarget) -> Result<ClientTlsConfig, Self::Error> {
         self.resolutions.fetch_add(1, Ordering::SeqCst);
         let roots = self.roots.clone();
-        Box::pin(async move {
-            Ok(ClientTlsConfig::new(
-                ServerName::try_from("localhost").unwrap(),
-                roots,
-            ))
-        })
+        Ok(ClientTlsConfig::new(
+            ServerName::try_from("localhost").unwrap(),
+            roots,
+        ))
     }
 }
 
@@ -329,11 +317,8 @@ impl ClientAuthentication for DenyingPolicy {
     type Evidence = ();
     type Session = Self;
 
-    fn begin<'a>(
-        &'a self,
-        _target: &'a ConnectTarget,
-    ) -> Pin<Box<dyn Future<Output = Result<Self::Session, Self::Error>> + 'a>> {
-        Box::pin(async { Err(Denied) })
+    async fn begin(&self, _target: &ConnectTarget) -> Result<Self::Session, Self::Error> {
+        Err(Denied)
     }
 }
 
@@ -341,15 +326,15 @@ impl ClientAuthenticationSession for DenyingPolicy {
     type Error = Denied;
     type Evidence = ();
 
-    fn respond(
+    async fn respond(
         &mut self,
         _challenge: ClientAuthenticationChallenge,
-    ) -> Pin<Box<dyn Future<Output = Result<ClientAuthenticationResponse, Self::Error>> + '_>> {
-        Box::pin(async { Err(Denied) })
+    ) -> Result<ClientAuthenticationResponse, Self::Error> {
+        Err(Denied)
     }
 
-    fn authenticated(self) -> Pin<Box<dyn Future<Output = Result<(), Self::Error>>>> {
-        Box::pin(async { Err(Denied) })
+    async fn authenticated(self) -> Result<(), Self::Error> {
+        Err(Denied)
     }
 }
 

--- a/tests/intermediary_builder.rs
+++ b/tests/intermediary_builder.rs
@@ -16,35 +16,29 @@ use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 struct CandidateResolver;
 impl StartupRouteResolver<String> for CandidateResolver {
     type Error = Infallible;
-    fn resolve<'a>(
-        &'a self,
+    async fn resolve(
+        &self,
         startup: StartupParameters,
-        initial: InitialServerContext<'a, String>,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<ConnectTarget, Self::Error>> + 'a>>
-    {
-        Box::pin(async move {
-            assert_eq!(initial.peer(), "downstream-peer");
-            assert_eq!(startup.user(), Some("alice"));
-            Ok(ConnectTarget::new("candidate"))
-        })
+        initial: InitialServerContext<'_, String>,
+    ) -> Result<ConnectTarget, Self::Error> {
+        assert_eq!(initial.peer(), "downstream-peer");
+        assert_eq!(startup.user(), Some("alice"));
+        Ok(ConnectTarget::new("candidate"))
     }
 }
 
 struct RefineRoute;
 impl AuthenticatedRoutePolicy<String, TrustIdentity> for RefineRoute {
     type Error = Infallible;
-    fn route<'a>(
-        &'a self,
+    async fn route(
+        &self,
         target: ConnectTarget,
-        context: AuthenticatedRouteContext<'a, String, TrustIdentity>,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<ConnectTarget, Self::Error>> + 'a>>
-    {
-        Box::pin(async move {
-            assert_eq!(target.name(), "candidate");
-            assert_eq!(context.peer(), "downstream-peer");
-            assert_eq!(context.identity(), &TrustIdentity);
-            Ok(ConnectTarget::new("tenant-a"))
-        })
+        context: AuthenticatedRouteContext<'_, String, TrustIdentity>,
+    ) -> Result<ConnectTarget, Self::Error> {
+        assert_eq!(target.name(), "candidate");
+        assert_eq!(context.peer(), "downstream-peer");
+        assert_eq!(context.identity(), &TrustIdentity);
+        Ok(ConnectTarget::new("tenant-a"))
     }
 }
 
@@ -226,43 +220,28 @@ impl
 {
     type Error = Infallible;
 
-    fn frontend<'a>(
-        &'a mut self,
-        _: &'a ServerConnectionContext<String, TrustIdentity>,
-        _: &'a ClientConnectionContext<()>,
-        state: &'a mut Vec<&'static str>,
+    async fn frontend(
+        &mut self,
+        _: &ServerConnectionContext<String, TrustIdentity>,
+        _: &ClientConnectionContext<()>,
+        state: &mut Vec<&'static str>,
         message: FrontendMessage,
-    ) -> std::pin::Pin<
-        Box<
-            dyn std::future::Future<
-                    Output = Result<pg_proto::FrontendMiddlewareOutput, Self::Error>,
-                > + 'a,
-        >,
-    > {
-        Box::pin(async move {
-            tokio::task::yield_now().await;
-            state.push("boundary-frontend");
-            Ok(pg_proto::FrontendMiddlewareOutput::Forward(message))
-        })
+    ) -> Result<pg_proto::FrontendMiddlewareOutput, Self::Error> {
+        tokio::task::yield_now().await;
+        state.push("boundary-frontend");
+        Ok(pg_proto::FrontendMiddlewareOutput::Forward(message))
     }
 
-    fn backend<'a>(
-        &'a mut self,
-        _: &'a ServerConnectionContext<String, TrustIdentity>,
-        _: &'a ClientConnectionContext<()>,
-        state: &'a mut Vec<&'static str>,
+    async fn backend(
+        &mut self,
+        _: &ServerConnectionContext<String, TrustIdentity>,
+        _: &ClientConnectionContext<()>,
+        state: &mut Vec<&'static str>,
         message: BackendMessage,
-    ) -> std::pin::Pin<
-        Box<
-            dyn std::future::Future<Output = Result<pg_proto::BackendMiddlewareOutput, Self::Error>>
-                + 'a,
-        >,
-    > {
-        Box::pin(async move {
-            tokio::task::yield_now().await;
-            state.push("boundary-backend");
-            Ok(pg_proto::BackendMiddlewareOutput::Forward(message))
-        })
+    ) -> Result<pg_proto::BackendMiddlewareOutput, Self::Error> {
+        tokio::task::yield_now().await;
+        state.push("boundary-backend");
+        Ok(pg_proto::BackendMiddlewareOutput::Forward(message))
     }
 }
 
@@ -614,66 +593,51 @@ impl
 {
     type Error = BoundaryFailure;
 
-    fn frontend<'a>(
-        &'a mut self,
-        _: &'a ServerConnectionContext<String, TrustIdentity>,
-        _: &'a ClientConnectionContext<()>,
-        (): &'a mut (),
+    async fn frontend(
+        &mut self,
+        _: &ServerConnectionContext<String, TrustIdentity>,
+        _: &ClientConnectionContext<()>,
+        (): &mut (),
         message: FrontendMessage,
-    ) -> std::pin::Pin<
-        Box<
-            dyn std::future::Future<
-                    Output = Result<pg_proto::FrontendMiddlewareOutput, Self::Error>,
-                > + 'a,
-        >,
-    > {
-        Box::pin(async move {
-            tokio::task::yield_now().await;
-            match &message {
-                FrontendMessage::Query(query) if query == "LOCAL" => {
-                    Ok(pg_proto::FrontendMiddlewareOutput::Respond {
-                        request: message,
-                        responses: vec![
-                            BackendMessage::CommandComplete(Bytes::from_static(b"LOCAL")),
-                            BackendMessage::ReadyForQuery(pg_proto::TransactionStatus::Idle),
-                        ],
-                    })
-                }
-                FrontendMessage::Query(query) if query == "DROP" => {
-                    Ok(pg_proto::FrontendMiddlewareOutput::Suppress(message))
-                }
-                FrontendMessage::Query(query) if query == "FAIL" => Err(BoundaryFailure),
-                _ => Ok(pg_proto::FrontendMiddlewareOutput::Forward(message)),
+    ) -> Result<pg_proto::FrontendMiddlewareOutput, Self::Error> {
+        tokio::task::yield_now().await;
+        match &message {
+            FrontendMessage::Query(query) if query == "LOCAL" => {
+                Ok(pg_proto::FrontendMiddlewareOutput::Respond {
+                    request: message,
+                    responses: vec![
+                        BackendMessage::CommandComplete(Bytes::from_static(b"LOCAL")),
+                        BackendMessage::ReadyForQuery(pg_proto::TransactionStatus::Idle),
+                    ],
+                })
             }
-        })
+            FrontendMessage::Query(query) if query == "DROP" => {
+                Ok(pg_proto::FrontendMiddlewareOutput::Suppress(message))
+            }
+            FrontendMessage::Query(query) if query == "FAIL" => Err(BoundaryFailure),
+            _ => Ok(pg_proto::FrontendMiddlewareOutput::Forward(message)),
+        }
     }
 
-    fn backend<'a>(
-        &'a mut self,
-        _: &'a ServerConnectionContext<String, TrustIdentity>,
-        _: &'a ClientConnectionContext<()>,
-        (): &'a mut (),
+    async fn backend(
+        &mut self,
+        _: &ServerConnectionContext<String, TrustIdentity>,
+        _: &ClientConnectionContext<()>,
+        (): &mut (),
         message: BackendMessage,
-    ) -> std::pin::Pin<
-        Box<
-            dyn std::future::Future<Output = Result<pg_proto::BackendMiddlewareOutput, Self::Error>>
-                + 'a,
-        >,
-    > {
-        Box::pin(async move {
-            tokio::task::yield_now().await;
-            match message {
-                BackendMessage::DataRow(_) => Ok(pg_proto::BackendMiddlewareOutput::Expand(vec![
-                    BackendMessage::DataRow(pg_proto::DataRow {
-                        columns: vec![Some(Bytes::from_static(b"clear-one"))],
-                    }),
-                    BackendMessage::DataRow(pg_proto::DataRow {
-                        columns: vec![Some(Bytes::from_static(b"clear-two"))],
-                    }),
-                ])),
-                other => Ok(pg_proto::BackendMiddlewareOutput::Forward(other)),
-            }
-        })
+    ) -> Result<pg_proto::BackendMiddlewareOutput, Self::Error> {
+        tokio::task::yield_now().await;
+        match message {
+            BackendMessage::DataRow(_) => Ok(pg_proto::BackendMiddlewareOutput::Expand(vec![
+                BackendMessage::DataRow(pg_proto::DataRow {
+                    columns: vec![Some(Bytes::from_static(b"clear-one"))],
+                }),
+                BackendMessage::DataRow(pg_proto::DataRow {
+                    columns: vec![Some(Bytes::from_static(b"clear-two"))],
+                }),
+            ])),
+            other => Ok(pg_proto::BackendMiddlewareOutput::Forward(other)),
+        }
     }
 }
 
@@ -831,59 +795,45 @@ impl
 {
     type Error = Infallible;
 
-    fn backend<'a>(
-        &'a mut self,
-        _: &'a ServerConnectionContext<String, TrustIdentity>,
-        _: &'a ClientConnectionContext<()>,
-        _: &'a mut usize,
+    async fn backend(
+        &mut self,
+        _: &ServerConnectionContext<String, TrustIdentity>,
+        _: &ClientConnectionContext<()>,
+        _: &mut usize,
         message: BackendMessage,
-    ) -> std::pin::Pin<
-        Box<
-            dyn std::future::Future<Output = Result<pg_proto::BackendMiddlewareOutput, Self::Error>>
-                + 'a,
-        >,
-    > {
-        Box::pin(async move {
-            if matches!(message, BackendMessage::DataRow(_)) {
-                Ok(pg_proto::BackendMiddlewareOutput::Hold)
-            } else {
-                Ok(pg_proto::BackendMiddlewareOutput::Forward(message))
-            }
-        })
+    ) -> Result<pg_proto::BackendMiddlewareOutput, Self::Error> {
+        if matches!(message, BackendMessage::DataRow(_)) {
+            Ok(pg_proto::BackendMiddlewareOutput::Hold)
+        } else {
+            Ok(pg_proto::BackendMiddlewareOutput::Forward(message))
+        }
     }
 
-    fn flush_backend<'a>(
-        &'a mut self,
-        _: &'a ServerConnectionContext<String, TrustIdentity>,
-        _: &'a ClientConnectionContext<()>,
-        flushes: &'a mut usize,
-        held: pg_proto::HeldBackendMessages<'a>,
+    async fn flush_backend(
+        &mut self,
+        _: &ServerConnectionContext<String, TrustIdentity>,
+        _: &ClientConnectionContext<()>,
+        flushes: &mut usize,
+        held: pg_proto::HeldBackendMessages<'_>,
         reason: pg_proto::BackendFlushReason,
-    ) -> std::pin::Pin<
-        Box<
-            dyn std::future::Future<Output = Result<pg_proto::BackendBatchOutput, Self::Error>>
-                + 'a,
-        >,
-    > {
-        Box::pin(async move {
-            assert_eq!(reason, pg_proto::BackendFlushReason::ProtocolBarrier);
-            *flushes += 1;
-            let replacements = held
-                .iter()
-                .map(|message| {
-                    let BackendMessage::DataRow(row) = message else {
-                        panic!("batch contains a non-row")
-                    };
-                    let value = row.columns[0].as_ref().unwrap();
-                    let mut clear = b"clear-".to_vec();
-                    clear.extend_from_slice(value);
-                    BackendMessage::DataRow(pg_proto::DataRow {
-                        columns: vec![Some(Bytes::from(clear))],
-                    })
+    ) -> Result<pg_proto::BackendBatchOutput, Self::Error> {
+        assert_eq!(reason, pg_proto::BackendFlushReason::ProtocolBarrier);
+        *flushes += 1;
+        let replacements = held
+            .iter()
+            .map(|message| {
+                let BackendMessage::DataRow(row) = message else {
+                    panic!("batch contains a non-row")
+                };
+                let value = row.columns[0].as_ref().unwrap();
+                let mut clear = b"clear-".to_vec();
+                clear.extend_from_slice(value);
+                BackendMessage::DataRow(pg_proto::DataRow {
+                    columns: vec![Some(Bytes::from(clear))],
                 })
-                .collect();
-            Ok(pg_proto::BackendBatchOutput::ReplaceOneToOne(replacements))
-        })
+            })
+            .collect();
+        Ok(pg_proto::BackendBatchOutput::ReplaceOneToOne(replacements))
     }
 }
 

--- a/tests/intermediary_cancellation.rs
+++ b/tests/intermediary_cancellation.rs
@@ -56,27 +56,25 @@ impl IntermediaryCancellationRegistry for Registry {
 struct Resolver(Rc<RefCell<usize>>);
 impl StartupRouteResolver<&'static str> for Resolver {
     type Error = Infallible;
-    fn resolve<'a>(
-        &'a self,
+    async fn resolve(
+        &self,
         _: StartupParameters,
-        _: InitialServerContext<'a, &'static str>,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<ConnectTarget, Self::Error>> + 'a>>
-    {
+        _: InitialServerContext<'_, &'static str>,
+    ) -> Result<ConnectTarget, Self::Error> {
         *self.0.borrow_mut() += 1;
-        Box::pin(async { Ok(ConnectTarget::new("db").with_metadata("tenant", "a")) })
+        Ok(ConnectTarget::new("db").with_metadata("tenant", "a"))
     }
 }
 
 struct FixedResolver;
 impl StartupRouteResolver<()> for FixedResolver {
     type Error = Infallible;
-    fn resolve<'a>(
-        &'a self,
+    async fn resolve(
+        &self,
         _: StartupParameters,
-        _: InitialServerContext<'a, ()>,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<ConnectTarget, Self::Error>> + 'a>>
-    {
-        Box::pin(async { Ok(ConnectTarget::new("hidden-address")) })
+        _: InitialServerContext<'_, ()>,
+    ) -> Result<ConnectTarget, Self::Error> {
+        Ok(ConnectTarget::new("hidden-address"))
     }
 }
 

--- a/tests/server_builder.rs
+++ b/tests/server_builder.rs
@@ -13,9 +13,9 @@ use bytes::Bytes;
 use pg_proto::{
     BuildServerError, DisabledServerTls, FrontendMessage, NegotiatedServerTls, PreStartupMessage,
     ProtocolVersion, Server, ServerAccept, ServerAuthentication, ServerAuthenticationAction,
-    ServerAuthenticationFuture, ServerAuthenticationProvider, ServerAuthenticationRequest,
-    ServerAuthenticationResponse, ServerIdentity, ServerIdentityProvider, ServerProtocolLimits,
-    ServerTlsPolicy, StartupMessage, TrustServerAuthentication,
+    ServerAuthenticationProvider, ServerAuthenticationRequest, ServerAuthenticationResponse,
+    ServerIdentity, ServerIdentityProvider, ServerProtocolLimits, ServerTlsPolicy, StartupMessage,
+    TrustServerAuthentication,
 };
 use rcgen::generate_simple_self_signed;
 use rustls::{
@@ -104,23 +104,19 @@ impl ServerAuthenticationProvider for InvalidSaslAuthentication {
 impl ServerAuthentication<()> for InvalidSaslAuthentication {
     type Identity = ();
     type Error = Infallible;
-    fn start<'a>(
-        &'a mut self,
-        _request: ServerAuthenticationRequest<'a, ()>,
-    ) -> ServerAuthenticationFuture<'a, ServerAuthenticationAction<Self::Identity>, Self::Error>
-    {
-        Box::pin(async {
-            Ok(ServerAuthenticationAction::Sasl {
-                mechanisms: vec![Bytes::from_static(b"bad\0mechanism")],
-            })
+    async fn start(
+        &mut self,
+        _request: ServerAuthenticationRequest<'_, ()>,
+    ) -> Result<ServerAuthenticationAction<Self::Identity>, Self::Error> {
+        Ok(ServerAuthenticationAction::Sasl {
+            mechanisms: vec![Bytes::from_static(b"bad\0mechanism")],
         })
     }
-    fn respond<'a>(
-        &'a mut self,
-        _request: ServerAuthenticationRequest<'a, ()>,
+    async fn respond(
+        &mut self,
+        _request: ServerAuthenticationRequest<'_, ()>,
         _response: ServerAuthenticationResponse,
-    ) -> ServerAuthenticationFuture<'a, ServerAuthenticationAction<Self::Identity>, Self::Error>
-    {
+    ) -> Result<ServerAuthenticationAction<Self::Identity>, Self::Error> {
         unreachable!()
     }
 }
@@ -144,42 +140,38 @@ impl ServerAuthentication<()> for TokenAuthentication {
     type Identity = &'static str;
     type Error = Infallible;
 
-    fn start<'a>(
-        &'a mut self,
-        _request: ServerAuthenticationRequest<'a, ()>,
-    ) -> ServerAuthenticationFuture<'a, ServerAuthenticationAction<Self::Identity>, Self::Error>
-    {
+    async fn start(
+        &mut self,
+        _request: ServerAuthenticationRequest<'_, ()>,
+    ) -> Result<ServerAuthenticationAction<Self::Identity>, Self::Error> {
         let action = match self.method {
             TokenMethod::Kerberos => ServerAuthenticationAction::KerberosV5,
             TokenMethod::Gss => ServerAuthenticationAction::Gss,
             TokenMethod::Sspi => ServerAuthenticationAction::Sspi,
         };
-        Box::pin(async move { Ok(action) })
+        Ok(action)
     }
 
-    fn respond<'a>(
-        &'a mut self,
-        _request: ServerAuthenticationRequest<'a, ()>,
+    async fn respond(
+        &mut self,
+        _request: ServerAuthenticationRequest<'_, ()>,
         response: ServerAuthenticationResponse,
-    ) -> ServerAuthenticationFuture<'a, ServerAuthenticationAction<Self::Identity>, Self::Error>
-    {
-        Box::pin(async move {
-            let ServerAuthenticationResponse::Token(token) = response else {
-                unreachable!()
-            };
-            self.responses += 1;
-            Ok(
-                if matches!(self.method, TokenMethod::Gss) && self.responses == 1 {
-                    assert_eq!(token, b"client-one".as_slice());
-                    ServerAuthenticationAction::GssContinue(Bytes::from_static(b"server-two"))
-                } else {
-                    if matches!(self.method, TokenMethod::Gss) {
-                        assert_eq!(token, b"client-three".as_slice());
-                    }
-                    ServerAuthenticationAction::Accept("gss-user")
-                },
-            )
-        })
+    ) -> Result<ServerAuthenticationAction<Self::Identity>, Self::Error> {
+        let ServerAuthenticationResponse::Token(token) = response else {
+            unreachable!()
+        };
+        self.responses += 1;
+        Ok(
+            if matches!(self.method, TokenMethod::Gss) && self.responses == 1 {
+                assert_eq!(token, b"client-one".as_slice());
+                ServerAuthenticationAction::GssContinue(Bytes::from_static(b"server-two"))
+            } else {
+                if matches!(self.method, TokenMethod::Gss) {
+                    assert_eq!(token, b"client-three".as_slice());
+                }
+                ServerAuthenticationAction::Accept("gss-user")
+            },
+        )
     }
 }
 
@@ -195,26 +187,22 @@ impl ServerAuthentication<()> for Md5Authentication {
     type Identity = Vec<u8>;
     type Error = Infallible;
 
-    fn start<'a>(
-        &'a mut self,
-        _request: ServerAuthenticationRequest<'a, ()>,
-    ) -> ServerAuthenticationFuture<'a, ServerAuthenticationAction<Self::Identity>, Self::Error>
-    {
-        Box::pin(async { Ok(ServerAuthenticationAction::Md5Password { salt: [1, 2, 3, 4] }) })
+    async fn start(
+        &mut self,
+        _request: ServerAuthenticationRequest<'_, ()>,
+    ) -> Result<ServerAuthenticationAction<Self::Identity>, Self::Error> {
+        Ok(ServerAuthenticationAction::Md5Password { salt: [1, 2, 3, 4] })
     }
 
-    fn respond<'a>(
-        &'a mut self,
-        _request: ServerAuthenticationRequest<'a, ()>,
+    async fn respond(
+        &mut self,
+        _request: ServerAuthenticationRequest<'_, ()>,
         response: ServerAuthenticationResponse,
-    ) -> ServerAuthenticationFuture<'a, ServerAuthenticationAction<Self::Identity>, Self::Error>
-    {
-        Box::pin(async move {
-            let ServerAuthenticationResponse::Password(body) = response else {
-                unreachable!()
-            };
-            Ok(ServerAuthenticationAction::Accept(body.to_vec()))
-        })
+    ) -> Result<ServerAuthenticationAction<Self::Identity>, Self::Error> {
+        let ServerAuthenticationResponse::Password(body) = response else {
+            unreachable!()
+        };
+        Ok(ServerAuthenticationAction::Accept(body.to_vec()))
     }
 }
 
@@ -236,45 +224,41 @@ impl ServerAuthentication<&str> for AuthenticationSession {
     type Identity = UserIdentity;
     type Error = AuthenticationFailure;
 
-    fn start<'a>(
-        &'a mut self,
-        _request: ServerAuthenticationRequest<'a, &str>,
-    ) -> ServerAuthenticationFuture<'a, ServerAuthenticationAction<Self::Identity>, Self::Error>
-    {
-        Box::pin(async { Ok(ServerAuthenticationAction::CleartextPassword) })
+    async fn start(
+        &mut self,
+        _request: ServerAuthenticationRequest<'_, &str>,
+    ) -> Result<ServerAuthenticationAction<Self::Identity>, Self::Error> {
+        Ok(ServerAuthenticationAction::CleartextPassword)
     }
 
-    fn respond<'a>(
-        &'a mut self,
-        request: ServerAuthenticationRequest<'a, &str>,
+    async fn respond(
+        &mut self,
+        request: ServerAuthenticationRequest<'_, &str>,
         response: ServerAuthenticationResponse,
-    ) -> ServerAuthenticationFuture<'a, ServerAuthenticationAction<Self::Identity>, Self::Error>
-    {
-        Box::pin(async move {
-            let ServerAuthenticationResponse::Password(credential) = response else {
-                unreachable!()
+    ) -> Result<ServerAuthenticationAction<Self::Identity>, Self::Error> {
+        let ServerAuthenticationResponse::Password(credential) = response else {
+            unreachable!()
+        };
+        if credential != b"secret".as_slice() {
+            return Err(AuthenticationFailure("invalid password"));
+        }
+        if *request.peer() != "peer" {
+            return Err(AuthenticationFailure("unexpected peer"));
+        }
+        let user = request
+            .startup()
+            .parameters
+            .get(b"user".as_slice())
+            .ok_or(AuthenticationFailure("user is required"))?;
+        if let Some(expected) = &self.expected_binding {
+            let NegotiatedServerTls::Tls { server_end_point } = request.tls() else {
+                panic!("expected TLS authentication facts")
             };
-            if credential != b"secret".as_slice() {
-                return Err(AuthenticationFailure("invalid password"));
-            }
-            if *request.peer() != "peer" {
-                return Err(AuthenticationFailure("unexpected peer"));
-            }
-            let user = request
-                .startup()
-                .parameters
-                .get(b"user".as_slice())
-                .ok_or(AuthenticationFailure("user is required"))?;
-            if let Some(expected) = &self.expected_binding {
-                let NegotiatedServerTls::Tls { server_end_point } = request.tls() else {
-                    panic!("expected TLS authentication facts")
-                };
-                assert_eq!(server_end_point, expected);
-            }
-            Ok(ServerAuthenticationAction::Accept(UserIdentity(
-                String::from_utf8_lossy(user).into_owned(),
-            )))
-        })
+            assert_eq!(server_end_point, expected);
+        }
+        Ok(ServerAuthenticationAction::Accept(UserIdentity(
+            String::from_utf8_lossy(user).into_owned(),
+        )))
     }
 }
 

--- a/tests/server_middleware_lifecycle.rs
+++ b/tests/server_middleware_lifecycle.rs
@@ -6,9 +6,9 @@ use bytes::Bytes;
 use pg_proto::{
     BackendMessage, CancellationRequest, FrontendMessage, NegotiatedServerTls, PreStartupMessage,
     ProtocolVersion, Server, ServerAccept, ServerAuthentication, ServerAuthenticationAction,
-    ServerAuthenticationFuture, ServerAuthenticationProvider, ServerAuthenticationRequest,
-    ServerAuthenticationResponse, ServerConnectionContext, ServerMiddleware, ServerTlsPolicy,
-    StartupMessage, TrustIdentity, TrustServerAuthentication,
+    ServerAuthenticationProvider, ServerAuthenticationRequest, ServerAuthenticationResponse,
+    ServerConnectionContext, ServerMiddleware, ServerTlsPolicy, StartupMessage, TrustIdentity,
+    TrustServerAuthentication,
 };
 use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 
@@ -101,23 +101,21 @@ impl ServerAuthenticationProvider for PasswordFactory {
 impl ServerAuthentication<()> for PasswordAuth {
     type Identity = Bytes;
     type Error = Infallible;
-    fn start<'a>(
-        &'a mut self,
-        _: ServerAuthenticationRequest<'a, ()>,
-    ) -> ServerAuthenticationFuture<'a, ServerAuthenticationAction<Bytes>, Infallible> {
-        Box::pin(async { Ok(ServerAuthenticationAction::CleartextPassword) })
+    async fn start(
+        &mut self,
+        _: ServerAuthenticationRequest<'_, ()>,
+    ) -> Result<ServerAuthenticationAction<Bytes>, Infallible> {
+        Ok(ServerAuthenticationAction::CleartextPassword)
     }
-    fn respond<'a>(
-        &'a mut self,
-        _: ServerAuthenticationRequest<'a, ()>,
+    async fn respond(
+        &mut self,
+        _: ServerAuthenticationRequest<'_, ()>,
         response: ServerAuthenticationResponse,
-    ) -> ServerAuthenticationFuture<'a, ServerAuthenticationAction<Bytes>, Infallible> {
-        Box::pin(async move {
-            let ServerAuthenticationResponse::Password(password) = response else {
-                unreachable!()
-            };
-            Ok(ServerAuthenticationAction::Accept(password))
-        })
+    ) -> Result<ServerAuthenticationAction<Bytes>, Infallible> {
+        let ServerAuthenticationResponse::Password(password) = response else {
+            unreachable!()
+        };
+        Ok(ServerAuthenticationAction::Accept(password))
     }
 }
 


### PR DESCRIPTION
## Summary

- replace public `Pin<Box<dyn Future>>` policy methods with native `async fn`
- remove the client and server authentication future aliases from the public facade
- migrate built-in adapters, examples, documentation, tests, and the SCRAM fuzz target
- preserve and document the existing non-`Send` future contract

`ServerAcceptFuture` remains unchanged and outside this refactor.

## Validation

- `cargo test --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo doc --workspace --no-deps`
- `cargo check --manifest-path fuzz/Cargo.toml --bins`
- `git diff --check`