### PR TITLE
feat: expose intermediary operation correlation

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -399,6 +399,9 @@ checked middleware belongs on the state-aware session APIs above it.
   - [x] Consolidate inbound receipt, middleware interception, phase legality,
     and reconstruction validation across backend, frontend, pre-startup, and
     encryption-reply traffic without combining receipt with projection.
+  - [x] Expose opaque operation identity to forwarding-boundary middleware and
+    held backend batches so application state can follow pipelined responses
+    without duplicating the private ordering ledger.
 - [x] Use the repository README as the crate-level Rustdoc landing page.
 - [x] License both published crates and the repository under the MIT License.
 - [x] Add descriptive crates.io keywords and categories to both package manifests.

--- a/PROXY_COMPATIBILITY.md
+++ b/PROXY_COMPATIBILITY.md
@@ -33,6 +33,7 @@ messages, transaction state, and connection cleanup.
 | Pool cleanliness evidence | pgcat tracks transactions, SET, PREPARE, COPY, and prepared cache state | Implemented as extensible evidence consumed by application-owned pool policy |
 | Opaque forwarding escape hatch | Unknown or uninspected traffic must be forwardable without monomorphising every state | Exact state erasure, checked re-entry, and neutral two-sided composition are implemented |
 | Output batching and backpressure | Current Proxy buffers rows and pgcat buffers extended/COPY messages | Cancellation-safe push/flush exists; the composition façade must permit downstream buffering without hiding command boundaries |
+| Application operation correlation | Rewriters retain per-query encryption, portal, and metrics data across pipelined responses | Implemented with opaque operation identities on intermediary middleware and held backend spans |
 
 ## Behaviour that remains downstream
 

--- a/README.md
+++ b/README.md
@@ -322,6 +322,15 @@ admits local operations and emits their responses through its connection-owned
 pipeline, so they cannot overtake earlier PostgreSQL responses. Middleware
 failures retain their application error in `ForwardError::Middleware`.
 
+Middleware which needs to correlate application data with protocol responses
+can override `frontend_operation` and `backend_operation`. Both hooks receive the
+same opaque `OperationId` for one accepted request and all of its ordered
+responses; asynchronous backend messages receive no operation identity. Held
+batch policy can obtain the same attribution by overriding
+`flush_backend_operations` and iterating its `AttributedBackendMessages`. The
+identity is deliberately not a pipeline handle: projection, ordering, and
+backpressure remain connection-owned.
+
 `forward_frontend()` and `forward_backend()` report whether traffic was
 forwarded, suppressed, held, or locally handled; `forward_next()` reports the same
 decisions while driving both directions.

--- a/docs/public-api-inventory.md
+++ b/docs/public-api-inventory.md
@@ -13,7 +13,7 @@ Issue #38 classifies the former public surface by responsibility:
 | runtime/generated middleware adapters | implementation-only | builder middleware factories and role middleware traits |
 | `Client`, `Server`, and `Intermediary` configuration, policy, context, errors, and owned connection types | facade-required | exported at the crate root |
 | frontend/backend/startup message values used by application middleware | facade-required vocabulary | exported at the crate root; wire framing remains internal |
-| bounded-pipeline configuration and forwarding errors | facade-required nested configuration | supplied through `IntermediaryBuilder::pipeline` |
+| bounded-pipeline configuration, opaque operation identity, and forwarding errors | facade-required nested configuration | supplied through `IntermediaryBuilder::pipeline` and operation-aware boundary middleware |
 
 The exact reviewed root export manifest is [`public-api.txt`](public-api.txt).
 `tests/public_surface.rs` rejects public modules, root declarations outside that

--- a/docs/public-api.txt
+++ b/docs/public-api.txt
@@ -14,19 +14,20 @@ pub use codec::{
 };
 pub use demux::CancelKey;
 pub use intermediary_component::{
-    AllowAuthenticatedRoute, AuthenticatedRouteContext, AuthenticatedRoutePolicy,
-    BackendBatchForwarding, BackendBatchOutput, BackendBatchProjectionError, BackendFlushReason,
-    BackendForwarding, BackendHoldConfigError, BackendHoldLimits, BackendMiddlewareOutput,
-    CancellationPolicy, CancellationRoute, EstablishmentFailurePolicy, ForwardError,
-    ForwardedMessage, FrontendForwarding, FrontendMiddlewareOutput, HeldBackendMessages,
-    IdentityIntermediaryMiddleware, InitialServerContext, Intermediary, IntermediaryAccept,
-    IntermediaryAcceptError, IntermediaryBuildError, IntermediaryBuilder,
-    IntermediaryCancellationRegistry, IntermediaryConnection, IntermediaryContexts,
-    IntermediaryMiddleware, IntermediaryMiddlewareFactory, RejectCancellation,
-    StartupResolutionError, StartupRouteResolver,
+    AllowAuthenticatedRoute, AttributedBackendMessages, AuthenticatedRouteContext,
+    AuthenticatedRoutePolicy, BackendBatchForwarding, BackendBatchOutput,
+    BackendBatchProjectionError, BackendFlushReason, BackendForwarding, BackendHoldConfigError,
+    BackendHoldLimits, BackendMiddlewareOutput, CancellationPolicy, CancellationRoute,
+    EstablishmentFailurePolicy, ForwardError, ForwardedMessage, FrontendForwarding,
+    FrontendMiddlewareOutput, HeldBackendMessages, IdentityIntermediaryMiddleware,
+    InitialServerContext, Intermediary, IntermediaryAccept, IntermediaryAcceptError,
+    IntermediaryBuildError, IntermediaryBuilder, IntermediaryCancellationRegistry,
+    IntermediaryConnection, IntermediaryContexts, IntermediaryMiddleware,
+    IntermediaryMiddlewareFactory, RejectCancellation, StartupResolutionError,
+    StartupRouteResolver,
 };
 pub use pipeline::{
-    BackendProjectionError, BoundedPipeline, FrontendProjectionError, NoPipeline,
+    BackendProjectionError, BoundedPipeline, FrontendProjectionError, NoPipeline, OperationId,
     PipelineConfigError, PipelinePolicy,
 };
 pub use pre_startup::{CertificateVerification, PreStartupMessage, SslMode, SslStrategy};

--- a/src/intermediary_component.rs
+++ b/src/intermediary_component.rs
@@ -6,7 +6,9 @@ use tokio::io::{AsyncRead, AsyncWrite};
 
 use crate::{
     ConnectTarget, NoPipeline, StartupParameters,
-    pipeline::{BackendAction, FrontendAction, FrontendHandling, Pipeline, PipelinePolicy},
+    pipeline::{
+        BackendAction, FrontendAction, FrontendHandling, OperationId, Pipeline, PipelinePolicy,
+    },
 };
 
 fn is_backend_batch_barrier(message: &crate::codec::BackendMessage) -> bool {
@@ -374,6 +376,31 @@ impl<'a> HeldBackendMessages<'a> {
     }
 }
 
+/// Ordered held backend messages paired with their originating operations.
+#[derive(Clone, Debug)]
+pub struct AttributedBackendMessages<'a> {
+    held: HeldBackendMessages<'a>,
+    operation_ids: Vec<Option<OperationId>>,
+}
+
+impl<'a> AttributedBackendMessages<'a> {
+    /// Returns the existing un-attributed held-message view.
+    #[must_use]
+    pub const fn messages(&self) -> HeldBackendMessages<'a> {
+        self.held
+    }
+
+    /// Iterates over messages and their originating operation identities.
+    /// Asynchronous backend messages carry no operation identity.
+    #[must_use]
+    pub fn iter(
+        &self,
+    ) -> impl ExactSizeIterator<Item = (Option<OperationId>, &'a crate::codec::BackendMessage)> + '_
+    {
+        self.operation_ids.iter().copied().zip(self.held.messages)
+    }
+}
+
 /// Asynchronous, fallible middleware at the forwarding boundary.
 ///
 /// Middleware futures are not required to be [`Send`].
@@ -394,6 +421,23 @@ pub trait IntermediaryMiddleware<State, ServerContext, ClientContext> {
         Ok(FrontendMiddlewareOutput::Forward(message))
     }
 
+    /// Intercepts a client-originated message with the identity reserved for
+    /// the operation if it is forwarded or handled locally.
+    ///
+    /// The default preserves existing middleware by delegating to
+    /// [`Self::frontend`]. Implementations which attach application state to an
+    /// operation should remove that state themselves when they suppress it.
+    async fn frontend_operation(
+        &mut self,
+        server: &ServerContext,
+        client: &ClientContext,
+        state: &mut State,
+        _operation: OperationId,
+        message: crate::codec::FrontendMessage,
+    ) -> Result<FrontendMiddlewareOutput, Self::Error> {
+        self.frontend(server, client, state, message).await
+    }
+
     /// Intercepts a PostgreSQL-originated message after client-role middleware
     /// and before server-role middleware.
     async fn backend(
@@ -404,6 +448,22 @@ pub trait IntermediaryMiddleware<State, ServerContext, ClientContext> {
         message: crate::codec::BackendMessage,
     ) -> Result<BackendMiddlewareOutput, Self::Error> {
         Ok(BackendMiddlewareOutput::Forward(message))
+    }
+
+    /// Intercepts a PostgreSQL-originated message with its frontend operation
+    /// identity when the message advances an operation.
+    ///
+    /// Asynchronous backend messages have no operation identity. The default
+    /// preserves existing middleware by delegating to [`Self::backend`].
+    async fn backend_operation(
+        &mut self,
+        server: &ServerContext,
+        client: &ClientContext,
+        state: &mut State,
+        _operation: Option<OperationId>,
+        message: crate::codec::BackendMessage,
+    ) -> Result<BackendMiddlewareOutput, Self::Error> {
+        self.backend(server, client, state, message).await
     }
 
     /// Applies policy to an ordered borrowed span of retained backend messages.
@@ -418,6 +478,21 @@ pub trait IntermediaryMiddleware<State, ServerContext, ClientContext> {
         Ok(BackendBatchOutput::ReplaceOneToOne(
             held.iter().cloned().collect(),
         ))
+    }
+
+    /// Applies policy to retained backend messages with operation attribution.
+    /// The default preserves existing middleware by delegating to
+    /// [`Self::flush_backend`].
+    async fn flush_backend_operations(
+        &mut self,
+        server: &ServerContext,
+        client: &ClientContext,
+        state: &mut State,
+        held: AttributedBackendMessages<'_>,
+        reason: BackendFlushReason,
+    ) -> Result<BackendBatchOutput, Self::Error> {
+        self.flush_backend(server, client, state, held.messages(), reason)
+            .await
     }
 }
 
@@ -1198,11 +1273,13 @@ where
     ) -> Result<FrontendForwarding, ForwardError<Boundary::Error>> {
         let decision = if intercept_source_and_boundary {
             let message = self.downstream.intercept_frontend(&mut self.state, message);
+            let operation = self.pipeline.next_operation_id();
             self.boundary
-                .frontend(
+                .frontend_operation(
                     self.downstream.context(),
                     self.upstream.context(),
                     &mut self.state,
+                    operation,
                     message,
                 )
                 .await
@@ -1318,12 +1395,14 @@ where
             .pending()
             .expect("pending backend processing requires a source")
             .clone();
+        let operation = self.pipeline.backend_operation_id(&source);
         let decision = self
             .boundary
-            .backend(
+            .backend_operation(
                 self.downstream.context(),
                 self.upstream.context(),
                 &mut self.state,
+                operation,
                 source.clone(),
             )
             .await
@@ -1410,13 +1489,18 @@ where
         if self.backend_hold.is_empty() {
             return Ok(BackendBatchForwarding::Empty);
         }
-        let held = HeldBackendMessages {
-            messages: self.backend_hold.messages(),
-            bytes: self.backend_hold.bytes(),
+        let held = AttributedBackendMessages {
+            held: HeldBackendMessages {
+                messages: self.backend_hold.messages(),
+                bytes: self.backend_hold.bytes(),
+            },
+            operation_ids: self
+                .pipeline
+                .backend_operation_ids(self.backend_hold.messages()),
         };
         let decision = self
             .boundary
-            .flush_backend(
+            .flush_backend_operations(
                 self.downstream.context(),
                 self.upstream.context(),
                 &mut self.state,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,19 +74,20 @@ pub use codec::{
 };
 pub use demux::CancelKey;
 pub use intermediary_component::{
-    AllowAuthenticatedRoute, AuthenticatedRouteContext, AuthenticatedRoutePolicy,
-    BackendBatchForwarding, BackendBatchOutput, BackendBatchProjectionError, BackendFlushReason,
-    BackendForwarding, BackendHoldConfigError, BackendHoldLimits, BackendMiddlewareOutput,
-    CancellationPolicy, CancellationRoute, EstablishmentFailurePolicy, ForwardError,
-    ForwardedMessage, FrontendForwarding, FrontendMiddlewareOutput, HeldBackendMessages,
-    IdentityIntermediaryMiddleware, InitialServerContext, Intermediary, IntermediaryAccept,
-    IntermediaryAcceptError, IntermediaryBuildError, IntermediaryBuilder,
-    IntermediaryCancellationRegistry, IntermediaryConnection, IntermediaryContexts,
-    IntermediaryMiddleware, IntermediaryMiddlewareFactory, RejectCancellation,
-    StartupResolutionError, StartupRouteResolver,
+    AllowAuthenticatedRoute, AttributedBackendMessages, AuthenticatedRouteContext,
+    AuthenticatedRoutePolicy, BackendBatchForwarding, BackendBatchOutput,
+    BackendBatchProjectionError, BackendFlushReason, BackendForwarding, BackendHoldConfigError,
+    BackendHoldLimits, BackendMiddlewareOutput, CancellationPolicy, CancellationRoute,
+    EstablishmentFailurePolicy, ForwardError, ForwardedMessage, FrontendForwarding,
+    FrontendMiddlewareOutput, HeldBackendMessages, IdentityIntermediaryMiddleware,
+    InitialServerContext, Intermediary, IntermediaryAccept, IntermediaryAcceptError,
+    IntermediaryBuildError, IntermediaryBuilder, IntermediaryCancellationRegistry,
+    IntermediaryConnection, IntermediaryContexts, IntermediaryMiddleware,
+    IntermediaryMiddlewareFactory, RejectCancellation, StartupResolutionError,
+    StartupRouteResolver,
 };
 pub use pipeline::{
-    BackendProjectionError, BoundedPipeline, FrontendProjectionError, NoPipeline,
+    BackendProjectionError, BoundedPipeline, FrontendProjectionError, NoPipeline, OperationId,
     PipelineConfigError, PipelinePolicy,
 };
 pub use pre_startup::{CertificateVerification, PreStartupMessage, SslMode, SslStrategy};

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -24,9 +24,13 @@ use crate::{
     },
 };
 
-/// Stable identity of an accepted frontend operation.
+/// Stable identity of one accepted frontend operation.
+///
+/// The identity is opaque: it permits application state to be correlated with
+/// ordered responses without exposing the intermediary's pipeline ledger or
+/// projection controls.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub(crate) struct OperationId(u64);
+pub struct OperationId(u64);
 
 /// Pipeline policy which preserves the historical lock-step behaviour.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -541,6 +545,45 @@ impl Default for Pipeline<NoPipeline> {
 }
 
 impl<P: PipelinePolicy> Pipeline<P> {
+    /// Returns the identity that will be assigned to the next accepted
+    /// frontend operation.
+    pub(crate) const fn next_operation_id(&self) -> OperationId {
+        OperationId(self.next_id)
+    }
+
+    /// Attributes a backend message to its forwarded frontend operation.
+    /// Asynchronous messages have no operation identity.
+    pub(crate) fn backend_operation_id(&self, message: &BackendMessage) -> Option<OperationId> {
+        if is_asynchronous(message) {
+            return None;
+        }
+        self.operations
+            .iter()
+            .find(|operation| {
+                operation.origin == Origin::Forwarded
+                    && !operation.discarded
+                    && response_fits(**operation, message)
+            })
+            .map(|operation| operation.id)
+    }
+
+    /// Attributes an ordered backend span while projecting each source against
+    /// a private ledger snapshot.
+    pub(crate) fn backend_operation_ids(
+        &self,
+        messages: &[BackendMessage],
+    ) -> Vec<Option<OperationId>> {
+        let mut projection = self.snapshot();
+        messages
+            .iter()
+            .map(|message| {
+                let id = projection.backend_operation_id(message);
+                let _ = projection.accept_backend(message.clone());
+                id
+            })
+            .collect()
+    }
+
     fn snapshot(&self) -> Self {
         Self {
             policy: self.policy,

--- a/tests/intermediary_builder.rs
+++ b/tests/intermediary_builder.rs
@@ -7,7 +7,7 @@ use pg_proto::{
     AuthenticatedRouteContext, AuthenticatedRoutePolicy, BackendMessage, Bind, BoundedPipeline,
     CancellationPolicy, Client, ClientConnectionContext, ClientInitialContext, ClientMiddleware,
     ClientTlsPolicy, ConnectTarget, CopyResponse, Execute, FrontendMessage, InitialServerContext,
-    Intermediary, IntermediaryBuildError, IntermediaryMiddleware, Parse, Server,
+    Intermediary, IntermediaryBuildError, IntermediaryMiddleware, OperationId, Parse, Server,
     ServerConnectionContext, ServerMiddleware, ServerTlsPolicy, StartupParameters,
     StartupRouteResolver, TrustClientAuthentication, TrustIdentity, TrustServerAuthentication,
 };
@@ -209,8 +209,11 @@ impl ClientMiddleware<Vec<&'static str>, ClientConnectionContext<()>> for Client
     }
 }
 
-#[derive(Clone, Copy)]
-struct BoundaryOrder;
+#[derive(Default)]
+struct BoundaryOrder {
+    frontend_operations: Vec<OperationId>,
+    backend_operations: Vec<Option<OperationId>>,
+}
 impl
     IntermediaryMiddleware<
         Vec<&'static str>,
@@ -232,6 +235,18 @@ impl
         Ok(pg_proto::FrontendMiddlewareOutput::Forward(message))
     }
 
+    async fn frontend_operation(
+        &mut self,
+        server: &ServerConnectionContext<String, TrustIdentity>,
+        client: &ClientConnectionContext<()>,
+        state: &mut Vec<&'static str>,
+        operation: OperationId,
+        message: FrontendMessage,
+    ) -> Result<pg_proto::FrontendMiddlewareOutput, Self::Error> {
+        self.frontend_operations.push(operation);
+        self.frontend(server, client, state, message).await
+    }
+
     async fn backend(
         &mut self,
         _: &ServerConnectionContext<String, TrustIdentity>,
@@ -242,6 +257,18 @@ impl
         tokio::task::yield_now().await;
         state.push("boundary-backend");
         Ok(pg_proto::BackendMiddlewareOutput::Forward(message))
+    }
+
+    async fn backend_operation(
+        &mut self,
+        server: &ServerConnectionContext<String, TrustIdentity>,
+        client: &ClientConnectionContext<()>,
+        state: &mut Vec<&'static str>,
+        operation: Option<OperationId>,
+        message: BackendMessage,
+    ) -> Result<pg_proto::BackendMiddlewareOutput, Self::Error> {
+        self.backend_operations.push(operation);
+        self.backend(server, client, state, message).await
     }
 }
 
@@ -295,7 +322,7 @@ async fn intermediary_routes_authenticates_and_forwards_a_simple_query() {
              client: &ClientConnectionContext<()>| {
                 assert_eq!(server.peer(), "downstream-peer");
                 assert_eq!(client.target().name(), "tenant-a");
-                BoundaryOrder
+                BoundaryOrder::default()
             },
         )
         .build()
@@ -540,7 +567,18 @@ async fn intermediary_routes_authenticates_and_forwards_a_simple_query() {
     assert!(
         matches!(session.forward_next().await.unwrap(), pg_proto::ForwardedMessage::Frontend(FrontendMessage::CopyData(data)) if data == "r-standby-status")
     );
-    let (_downstream, _upstream, state, _boundary, _handlers, contexts) = session.teardown();
+    let (_downstream, _upstream, state, boundary, _handlers, contexts) = session.teardown();
+    let backend_operations: Vec<_> = boundary
+        .backend_operations
+        .iter()
+        .copied()
+        .flatten()
+        .collect();
+    assert!(boundary.backend_operations.iter().any(Option::is_none));
+    assert_eq!(boundary.frontend_operations[0], backend_operations[0]);
+    assert_eq!(boundary.frontend_operations[0], backend_operations[1]);
+    assert_eq!(boundary.frontend_operations[1], backend_operations[2]);
+    assert_eq!(boundary.frontend_operations[1], backend_operations[3]);
     assert!(
         state[traffic_entries..].starts_with(&[
             "server-frontend",
@@ -809,17 +847,21 @@ impl
         }
     }
 
-    async fn flush_backend(
+    async fn flush_backend_operations(
         &mut self,
         _: &ServerConnectionContext<String, TrustIdentity>,
         _: &ClientConnectionContext<()>,
         flushes: &mut usize,
-        held: pg_proto::HeldBackendMessages<'_>,
+        held: pg_proto::AttributedBackendMessages<'_>,
         reason: pg_proto::BackendFlushReason,
     ) -> Result<pg_proto::BackendBatchOutput, Self::Error> {
         assert_eq!(reason, pg_proto::BackendFlushReason::ProtocolBarrier);
         *flushes += 1;
+        let operation_ids: Vec<_> = held.iter().map(|(operation, _)| operation).collect();
+        assert!(operation_ids.iter().all(Option::is_some));
+        assert!(operation_ids.windows(2).all(|ids| ids[0] == ids[1]));
         let replacements = held
+            .messages()
             .iter()
             .map(|message| {
                 let BackendMessage::DataRow(row) = message else {


### PR DESCRIPTION
## Summary

- expose opaque `OperationId` values to forwarding-boundary middleware
- correlate frontend operations with ordered backend responses without exposing the private pipeline ledger
- provide operation attribution for held backend batches while preserving the existing `HeldBackendMessages` API
- retain source compatibility through default delegation to existing middleware hooks

## Motivation

Protocol-aware proxies need to retain application metadata for rewritten Parse, Bind, Describe, Execute, and Query operations. Without operation attribution, they must maintain parallel FIFO queues that duplicate pg-proto ordering state.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- workspace tests pass excluding existing compiler-path-sensitive trybuild snapshots
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo package --workspace`
