### PR TITLE
feat: add reusable intermediary protocol adapters

### DIFF
--- a/docs/public-api.txt
+++ b/docs/public-api.txt
@@ -5,7 +5,8 @@ pub use client_component::{
     ClientTlsConfig, ClientTlsConfiguration, ClientTlsError, ClientTlsPolicy, ClientTlsProvider,
     ClientTlsStatus, ClientTransport, ConnectError, ConnectTarget, ConnectionChanged,
     ConnectionClean, IdentityHandler, ProtocolLimitError, ProtocolLimits, QueryError,
-    ReloadableClientTls, StartupParameterError, StartupParameters, TrustClientAuthentication,
+    ReloadableClientTls, StartupParameterError, StartupParameters, StaticClientCredentialSession,
+    StaticClientCredentials, StaticCredentialError, TrustClientAuthentication,
 };
 pub use codec::{
     Authentication, BackendMessage, Bind, Close, CopyResponse, DataRow, Describe, DescribeTarget,
@@ -20,11 +21,11 @@ pub use intermediary_component::{
     BackendHoldLimits, BackendMiddlewareOutput, CancellationPolicy, CancellationRoute,
     EstablishmentFailurePolicy, ForwardError, ForwardedMessage, FrontendForwarding,
     FrontendMiddlewareOutput, HeldBackendMessages, IdentityIntermediaryMiddleware,
-    InitialServerContext, Intermediary, IntermediaryAccept, IntermediaryAcceptError,
-    IntermediaryBuildError, IntermediaryBuilder, IntermediaryCancellationRegistry,
-    IntermediaryConnection, IntermediaryContexts, IntermediaryMiddleware,
-    IntermediaryMiddlewareFactory, RejectCancellation, StartupResolutionError,
-    StartupRouteResolver,
+    InMemoryCancellationRegistry, InMemoryCancellationRegistryError, InitialServerContext,
+    Intermediary, IntermediaryAccept, IntermediaryAcceptError, IntermediaryBuildError,
+    IntermediaryBuilder, IntermediaryCancellationRegistry, IntermediaryConnection,
+    IntermediaryContexts, IntermediaryMiddleware, IntermediaryMiddlewareFactory,
+    RejectCancellation, StartupResolutionError, StartupRouteResolver,
 };
 pub use pipeline::{
     BackendProjectionError, BoundedPipeline, FrontendProjectionError, NoPipeline, OperationId,
@@ -41,7 +42,8 @@ pub use server_component::{
     ServerAuthentication, ServerAuthenticationAction, ServerAuthenticationProvider,
     ServerAuthenticationRequest, ServerAuthenticationResponse, ServerBuilder, ServerCancellation,
     ServerConnection, ServerConnectionContext, ServerIdentity, ServerIdentityProvider,
-    ServerProtocolLimits, ServerTlsConfiguration, ServerTlsPolicy, TrustIdentity,
+    ServerProtocolLimits, ServerTlsConfiguration, ServerTlsPolicy,
+    StaticMd5ServerCredentialSession, StaticMd5ServerCredentials, TrustIdentity,
     TrustServerAuthentication,
 };
 pub use startup::{ProtocolVersion, StartupMessage};

--- a/src/client_component.rs
+++ b/src/client_component.rs
@@ -464,6 +464,180 @@ impl fmt::Debug for TrustClientAuthentication {
     }
 }
 
+/// Username and password authentication for PostgreSQL server challenges.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct StaticClientCredentials {
+    username: Bytes,
+    password: Bytes,
+}
+
+impl StaticClientCredentials {
+    /// Creates credentials reused by each connection attempt.
+    #[must_use]
+    pub fn new(username: impl Into<Bytes>, password: impl Into<Bytes>) -> Self {
+        Self {
+            username: username.into(),
+            password: password.into(),
+        }
+    }
+}
+
+/// Per-connection static credential exchange.
+pub struct StaticClientCredentialSession {
+    username: Bytes,
+    password: Bytes,
+    scram: Option<postgres_protocol::authentication::sasl::ScramSha256>,
+}
+
+/// Failure while answering a static credential challenge.
+#[derive(Debug)]
+pub enum StaticCredentialError {
+    /// The server requested an authentication mechanism this adapter does not support.
+    UnsupportedAuthentication,
+    /// The server sent a challenge out of sequence.
+    InvalidChallengeSequence,
+    /// A SCRAM message was invalid or failed verification.
+    Scram(io::Error),
+    /// The supplied password did not match.
+    AuthenticationFailed,
+}
+
+impl fmt::Display for StaticCredentialError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnsupportedAuthentication => {
+                formatter.write_str("unsupported authentication mechanism")
+            }
+            Self::InvalidChallengeSequence => {
+                formatter.write_str("authentication challenge is out of sequence")
+            }
+            Self::Scram(error) => error.fmt(formatter),
+            Self::AuthenticationFailed => formatter.write_str("authentication failed"),
+        }
+    }
+}
+
+impl std::error::Error for StaticCredentialError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Scram(error) => Some(error),
+            _ => None,
+        }
+    }
+}
+
+impl ClientAuthentication for StaticClientCredentials {
+    type Evidence = ();
+    type Session = StaticClientCredentialSession;
+    type Error = StaticCredentialError;
+
+    async fn begin(&self, _: &ConnectTarget) -> Result<Self::Session, Self::Error> {
+        Ok(StaticClientCredentialSession {
+            username: self.username.clone(),
+            password: self.password.clone(),
+            scram: None,
+        })
+    }
+}
+
+impl ClientAuthenticationSession for StaticClientCredentialSession {
+    type Evidence = ();
+    type Error = StaticCredentialError;
+
+    async fn respond(
+        &mut self,
+        challenge: ClientAuthenticationChallenge,
+    ) -> Result<ClientAuthenticationResponse, Self::Error> {
+        use postgres_protocol::authentication::sasl::{ChannelBinding, ScramSha256};
+        match challenge {
+            ClientAuthenticationChallenge::CleartextPassword => Ok(
+                ClientAuthenticationResponse::Password(self.password.clone()),
+            ),
+            ClientAuthenticationChallenge::Md5Password(salt) => {
+                Ok(ClientAuthenticationResponse::Password(Bytes::from(
+                    crate::credentials::md5_response(&self.username, &self.password, salt),
+                )))
+            }
+            ClientAuthenticationChallenge::Sasl(mechanisms)
+                if mechanisms
+                    .iter()
+                    .any(|mechanism| mechanism.as_ref() == b"SCRAM-SHA-256") =>
+            {
+                let scram = self.scram.insert(ScramSha256::new(
+                    &self.password,
+                    ChannelBinding::unsupported(),
+                ));
+                Ok(ClientAuthenticationResponse::SaslInitial {
+                    mechanism: Bytes::from_static(b"SCRAM-SHA-256"),
+                    response: Bytes::copy_from_slice(scram.message()),
+                })
+            }
+            ClientAuthenticationChallenge::Sasl(_) => {
+                Err(StaticCredentialError::UnsupportedAuthentication)
+            }
+            ClientAuthenticationChallenge::SaslContinue(message) => {
+                let scram = self
+                    .scram
+                    .as_mut()
+                    .ok_or(StaticCredentialError::InvalidChallengeSequence)?;
+                scram
+                    .update(&message)
+                    .map_err(StaticCredentialError::Scram)?;
+                Ok(ClientAuthenticationResponse::Sasl(Bytes::copy_from_slice(
+                    scram.message(),
+                )))
+            }
+            ClientAuthenticationChallenge::SaslFinal(message) => {
+                let scram = self
+                    .scram
+                    .as_mut()
+                    .ok_or(StaticCredentialError::InvalidChallengeSequence)?;
+                scram
+                    .finish(&message)
+                    .map_err(StaticCredentialError::Scram)?;
+                Ok(ClientAuthenticationResponse::Verified)
+            }
+            _ => Err(StaticCredentialError::UnsupportedAuthentication),
+        }
+    }
+
+    async fn authenticated(self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod static_credential_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn answers_cleartext_and_md5_challenges() {
+        let credentials = StaticClientCredentials::new("alice", "secret");
+        let mut session = credentials
+            .begin(&ConnectTarget::new("database"))
+            .await
+            .unwrap();
+        assert_eq!(
+            session
+                .respond(ClientAuthenticationChallenge::CleartextPassword)
+                .await
+                .unwrap(),
+            ClientAuthenticationResponse::Password(Bytes::from_static(b"secret"))
+        );
+
+        let salt = [1, 2, 3, 4];
+        assert_eq!(
+            session
+                .respond(ClientAuthenticationChallenge::Md5Password(salt))
+                .await
+                .unwrap(),
+            ClientAuthenticationResponse::Password(Bytes::from(crate::credentials::md5_response(
+                b"alice", b"secret", salt
+            )))
+        );
+    }
+}
+
 /// Application-defined destination supplied to the connector.
 #[derive(Clone, Eq, PartialEq)]
 pub struct ConnectTarget {

--- a/src/intermediary_component.rs
+++ b/src/intermediary_component.rs
@@ -113,6 +113,91 @@ pub trait IntermediaryCancellationRegistry {
     fn detach(&self, client: &crate::demux::CancelKey) -> Option<CancellationRoute>;
 }
 
+/// Thread-safe in-memory cancellation routes which preserve upstream keys.
+///
+/// This is suitable for one-upstream-per-downstream intermediaries which do
+/// not need pool-level cancellation key translation.
+#[derive(Clone, Debug, Default)]
+pub struct InMemoryCancellationRegistry {
+    routes: std::sync::Arc<
+        std::sync::Mutex<std::collections::HashMap<crate::demux::CancelKey, CancellationRoute>>,
+    >,
+}
+
+/// Failure to register an in-memory cancellation route.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum InMemoryCancellationRegistryError {
+    /// Another live route already uses the database-issued key.
+    DuplicateKey,
+    /// A previous registry user panicked while holding the lock.
+    Poisoned,
+}
+
+impl fmt::Display for InMemoryCancellationRegistryError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::DuplicateKey => "duplicate PostgreSQL cancellation key",
+            Self::Poisoned => "cancellation registry lock poisoned",
+        })
+    }
+}
+
+impl std::error::Error for InMemoryCancellationRegistryError {}
+
+impl IntermediaryCancellationRegistry for InMemoryCancellationRegistry {
+    type Error = InMemoryCancellationRegistryError;
+
+    fn register(&self, route: CancellationRoute) -> Result<crate::demux::CancelKey, Self::Error> {
+        let client_key = route.upstream_key().clone();
+        let mut routes = self
+            .routes
+            .lock()
+            .map_err(|_| InMemoryCancellationRegistryError::Poisoned)?;
+        if routes.contains_key(&client_key) {
+            return Err(InMemoryCancellationRegistryError::DuplicateKey);
+        }
+        routes.insert(client_key.clone(), route);
+        drop(routes);
+        Ok(client_key)
+    }
+
+    fn resolve(&self, client: &crate::demux::CancelKey) -> Option<CancellationRoute> {
+        self.routes.lock().ok()?.get(client).cloned()
+    }
+
+    fn detach(&self, client: &crate::demux::CancelKey) -> Option<CancellationRoute> {
+        self.routes.lock().ok()?.remove(client)
+    }
+}
+
+#[cfg(test)]
+mod in_memory_cancellation_registry_tests {
+    use super::*;
+    use bytes::Bytes;
+
+    fn key(process_id: u32) -> crate::demux::CancelKey {
+        crate::demux::CancelKey {
+            process_id,
+            secret_key: Bytes::from_static(b"secret"),
+        }
+    }
+
+    #[test]
+    fn preserves_resolves_and_detaches_upstream_keys() {
+        let registry = InMemoryCancellationRegistry::default();
+        let upstream = key(42);
+        let route = CancellationRoute::new(ConnectTarget::new("database"), upstream.clone());
+        assert_eq!(registry.register(route.clone()), Ok(upstream.clone()));
+        assert_eq!(registry.resolve(&upstream), Some(route.clone()));
+        assert_eq!(
+            registry.register(route.clone()),
+            Err(InMemoryCancellationRegistryError::DuplicateKey)
+        );
+        assert_eq!(registry.detach(&upstream), Some(route));
+        assert_eq!(registry.resolve(&upstream), None);
+    }
+}
+
 /// Marker registry used by explicit cancellation rejection.
 #[derive(Clone, Copy, Debug, Default)]
 pub struct RejectCancellation;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,8 @@ pub use client_component::{
     ClientTlsConfig, ClientTlsConfiguration, ClientTlsError, ClientTlsPolicy, ClientTlsProvider,
     ClientTlsStatus, ClientTransport, ConnectError, ConnectTarget, ConnectionChanged,
     ConnectionClean, IdentityHandler, ProtocolLimitError, ProtocolLimits, QueryError,
-    ReloadableClientTls, StartupParameterError, StartupParameters, TrustClientAuthentication,
+    ReloadableClientTls, StartupParameterError, StartupParameters, StaticClientCredentialSession,
+    StaticClientCredentials, StaticCredentialError, TrustClientAuthentication,
 };
 pub use codec::{
     Authentication, BackendMessage, Bind, Close, CopyResponse, DataRow, Describe, DescribeTarget,
@@ -80,11 +81,11 @@ pub use intermediary_component::{
     BackendHoldLimits, BackendMiddlewareOutput, CancellationPolicy, CancellationRoute,
     EstablishmentFailurePolicy, ForwardError, ForwardedMessage, FrontendForwarding,
     FrontendMiddlewareOutput, HeldBackendMessages, IdentityIntermediaryMiddleware,
-    InitialServerContext, Intermediary, IntermediaryAccept, IntermediaryAcceptError,
-    IntermediaryBuildError, IntermediaryBuilder, IntermediaryCancellationRegistry,
-    IntermediaryConnection, IntermediaryContexts, IntermediaryMiddleware,
-    IntermediaryMiddlewareFactory, RejectCancellation, StartupResolutionError,
-    StartupRouteResolver,
+    InMemoryCancellationRegistry, InMemoryCancellationRegistryError, InitialServerContext,
+    Intermediary, IntermediaryAccept, IntermediaryAcceptError, IntermediaryBuildError,
+    IntermediaryBuilder, IntermediaryCancellationRegistry, IntermediaryConnection,
+    IntermediaryContexts, IntermediaryMiddleware, IntermediaryMiddlewareFactory,
+    RejectCancellation, StartupResolutionError, StartupRouteResolver,
 };
 pub use pipeline::{
     BackendProjectionError, BoundedPipeline, FrontendProjectionError, NoPipeline, OperationId,
@@ -101,7 +102,8 @@ pub use server_component::{
     ServerAuthentication, ServerAuthenticationAction, ServerAuthenticationProvider,
     ServerAuthenticationRequest, ServerAuthenticationResponse, ServerBuilder, ServerCancellation,
     ServerConnection, ServerConnectionContext, ServerIdentity, ServerIdentityProvider,
-    ServerProtocolLimits, ServerTlsConfiguration, ServerTlsPolicy, TrustIdentity,
+    ServerProtocolLimits, ServerTlsConfiguration, ServerTlsPolicy,
+    StaticMd5ServerCredentialSession, StaticMd5ServerCredentials, TrustIdentity,
     TrustServerAuthentication,
 };
 pub use startup::{ProtocolVersion, StartupMessage};

--- a/src/server_component.rs
+++ b/src/server_component.rs
@@ -3,6 +3,7 @@
 use std::{fmt, future::Future, io, pin::Pin, sync::Arc};
 
 use bytes::Bytes;
+use rand::RngExt as _;
 use rustls::{ServerConfig, pki_types::CertificateDer};
 use tokio::io::{AsyncRead, AsyncWrite};
 
@@ -243,6 +244,77 @@ pub trait ServerAuthenticationProvider {
 
     /// Creates a fresh policy instance.
     fn create(&self) -> Self::Authentication;
+}
+
+/// Static username/password verification using PostgreSQL MD5 authentication.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct StaticMd5ServerCredentials {
+    username: Bytes,
+    password: Bytes,
+}
+
+impl StaticMd5ServerCredentials {
+    /// Creates a reusable credential provider.
+    #[must_use]
+    pub fn new(username: impl Into<Bytes>, password: impl Into<Bytes>) -> Self {
+        Self {
+            username: username.into(),
+            password: password.into(),
+        }
+    }
+}
+
+/// Isolated MD5 exchange for one connection.
+#[derive(Clone, Debug)]
+pub struct StaticMd5ServerCredentialSession {
+    username: Bytes,
+    password: Bytes,
+    salt: [u8; 4],
+}
+
+impl ServerAuthenticationProvider for StaticMd5ServerCredentials {
+    type Authentication = StaticMd5ServerCredentialSession;
+
+    fn create(&self) -> Self::Authentication {
+        let mut salt = [0; 4];
+        rand::rng().fill(&mut salt);
+        StaticMd5ServerCredentialSession {
+            username: self.username.clone(),
+            password: self.password.clone(),
+            salt,
+        }
+    }
+}
+
+impl<Peer> ServerAuthentication<Peer> for StaticMd5ServerCredentialSession {
+    type Identity = ();
+    type Error = crate::StaticCredentialError;
+
+    async fn start(
+        &mut self,
+        _: ServerAuthenticationRequest<'_, Peer>,
+    ) -> Result<ServerAuthenticationAction<()>, Self::Error> {
+        Ok(ServerAuthenticationAction::Md5Password { salt: self.salt })
+    }
+
+    async fn respond(
+        &mut self,
+        _: ServerAuthenticationRequest<'_, Peer>,
+        response: ServerAuthenticationResponse,
+    ) -> Result<ServerAuthenticationAction<()>, Self::Error> {
+        let ServerAuthenticationResponse::Password(received) = response else {
+            return Err(crate::StaticCredentialError::AuthenticationFailed);
+        };
+        if !crate::credentials::verify_md5_response(
+            &received,
+            &self.username,
+            &self.password,
+            self.salt,
+        ) {
+            return Err(crate::StaticCredentialError::AuthenticationFailed);
+        }
+        Ok(ServerAuthenticationAction::Accept(()))
+    }
 }
 
 /// Typed evidence for an explicitly trusted connection.


### PR DESCRIPTION
## Summary

<!-- What changes, and why? -->

## Protocol impact

<!-- Which states/messages change? Write "None" when not applicable. -->

## Verification

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo test --workspace`
- [ ] Public documentation updated where required
- [ ] `PLAN.md` updated where required
