### PR TITLE
fix: diagnose plaintext startup when TLS is required

### DIFF
--- a/src/server_component.rs
+++ b/src/server_component.rs
@@ -21,6 +21,29 @@ use crate::{
     transport::Buffered,
 };
 
+fn tls_required_diagnostic() -> BackendMessage {
+    BackendMessage::ErrorResponse(crate::codec::DiagnosticResponse {
+        fields: vec![
+            crate::codec::DiagnosticField {
+                code: b'S',
+                value: Bytes::from_static(b"FATAL"),
+            },
+            crate::codec::DiagnosticField {
+                code: b'V',
+                value: Bytes::from_static(b"FATAL"),
+            },
+            crate::codec::DiagnosticField {
+                code: b'C',
+                value: Bytes::from_static(b"08001"),
+            },
+            crate::codec::DiagnosticField {
+                code: b'M',
+                value: Bytes::from_static(b"Transport Layer Security (TLS) connection is required"),
+            },
+        ],
+    })
+}
+
 /// Async startup routing hook used by the intermediary facade.
 #[allow(clippy::type_complexity)]
 pub(crate) trait StartupResolver<State, Peer, Identity> {
@@ -1332,10 +1355,14 @@ where
                     ));
                 }
                 PreStartupOffer::Startup {
-                    conn: startup_conn,
+                    conn: mut startup_conn,
                     message,
                 } => {
                     if self.tls.required() {
+                        if let Ok(frame) = tls_required_diagnostic().to_frame() {
+                            let _ = startup_conn.push_frame(frame);
+                            let _ = startup_conn.flush().await;
+                        }
                         let _ = startup_conn.into_transport();
                         return Err(RoutedAcceptError::Accept(AcceptError::TlsRequired));
                     }

--- a/tests/server_builder.rs
+++ b/tests/server_builder.rs
@@ -393,6 +393,13 @@ async fn required_tls_rejects_plaintext_and_authentication_rejection_is_typed() 
         server.accept(server_io, "peer", ()).await,
         Err(pg_proto::AcceptError::TlsRequired)
     ));
+    let mut response = Vec::new();
+    client.read_to_end(&mut response).await.unwrap();
+    assert!(
+        response
+            .windows(b"Transport Layer Security (TLS) connection is required".len())
+            .any(|window| window == b"Transport Layer Security (TLS) connection is required")
+    );
 
     let server = Server::builder()
         .tls(ServerTlsPolicy::Disabled)


### PR DESCRIPTION
## Summary

- emit a PostgreSQL FATAL diagnostic when plaintext startup bypasses required TLS
- preserve the typed `AcceptError::TlsRequired` return after best-effort delivery
- add regression coverage for the client-visible diagnostic

## Context

CipherStash Proxy PR 443 switched required TLS enforcement to `ServerTlsPolicy::Required`. Plaintext clients then received an abrupt close because the server role returned `TlsRequired` before intermediary failure policy could emit a diagnostic.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets -- --skip net::tests::connects_with_configurable_retry`
- focused required-TLS regression test