### PR TITLE
fix: discard failed extended-query messages locally

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -444,7 +444,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "pg-proto"
-version = "0.5.0"
+version = "0.10.3"
 dependencies = [
  "base64 0.23.1",
  "bytes",
@@ -465,7 +465,7 @@ dependencies = [
 
 [[package]]
 name = "pg-proto-fsm"
-version = "0.5.0"
+version = "0.10.3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/fuzz/fuzz_targets/backend_codec.rs
+++ b/fuzz/fuzz_targets/backend_codec.rs
@@ -26,8 +26,11 @@ fuzz_target!(|data: &[u8]| {
             .authentication(TrustClientAuthentication)
             .build()
             .unwrap();
-        let _ = client
+        if let Ok(connection) = client
             .connect(ConnectTarget::new("fuzz"), StartupParameters::new("fuzz"), ())
-            .await;
+            .await
+        {
+            let _ = connection.into_parts();
+        }
     });
 });

--- a/src/intermediary_component.rs
+++ b/src/intermediary_component.rs
@@ -1411,11 +1411,13 @@ where
                 return Err(ForwardError::Frontend(error));
             }
         };
-        let FrontendAction::Forward { message, .. } = admission.into_action() else {
-            unreachable!()
-        };
-        self.upstream.send_wire_raw(message.clone()).await?;
-        Ok(FrontendForwarding::Forwarded(message))
+        match admission.into_action() {
+            FrontendAction::Forward { message, .. } => {
+                self.upstream.send_wire_raw(message.clone()).await?;
+                Ok(FrontendForwarding::Forwarded(message))
+            }
+            FrontendAction::Discard { .. } => Ok(FrontendForwarding::Suppressed(message)),
+        }
     }
 
     /// Receives one legal PostgreSQL response and forwards it downstream in

--- a/src/internal_tests/intermediary_pipeline.rs
+++ b/src/internal_tests/intermediary_pipeline.rs
@@ -804,13 +804,20 @@ fn first_local_rejection_discards_through_sync() {
             .accept_frontend(parse(b"bad"), FrontendHandling::Local)
             .unwrap(),
     );
-    pipeline
-        .accept_frontend(bind(), FrontendHandling::Forward)
-        .unwrap();
+    assert!(matches!(
+        pipeline.try_emit_local(rejected, error()).unwrap(),
+        BackendAction::Emit(BackendMessage::ErrorResponse(_))
+    ));
+    assert!(matches!(
+        pipeline
+            .accept_frontend(bind(), FrontendHandling::Forward)
+            .unwrap()
+            .into_action(),
+        FrontendAction::Discard { .. }
+    ));
     pipeline
         .accept_frontend(FrontendMessage::Sync, FrontendHandling::Forward)
         .unwrap();
-    pipeline.try_emit_local(rejected, error()).unwrap();
     assert_eq!(pipeline.state(), PipelineState::Ready);
     assert_eq!(
         pipeline.len(),

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -117,7 +117,8 @@ pub(crate) enum FrontendAction {
         /// Original, unretained frontend message.
         message: FrontendMessage,
     },
-    /// The operation is locally handled and the message can be discarded.
+    /// The operation is locally handled or belongs to a failed extended-query
+    /// cycle and the message must not be sent upstream.
     Discard {
         /// Accepted operation identity.
         id: OperationId,
@@ -736,17 +737,20 @@ impl<P: PipelinePolicy> Pipeline<P> {
         {
             head.response_state = transition.target;
         }
+        let discarded = matches!(self.request_state, RequestState::ExtendedError)
+            && kind != OperationKind::Sync;
         self.operations.push_back(Operation {
             id,
             kind,
             origin,
-            discarded: matches!(self.request_state, RequestState::ExtendedError)
-                && kind != OperationKind::Sync,
+            discarded,
             response_state: initial_response_state(kind),
         });
-        let action = match handling {
-            FrontendHandling::Forward => FrontendAction::Forward { id, message },
-            FrontendHandling::Local => FrontendAction::Discard { id },
+        let action = match (handling, discarded) {
+            (FrontendHandling::Forward, false) => FrontendAction::Forward { id, message },
+            (FrontendHandling::Forward | FrontendHandling::Local, _) => {
+                FrontendAction::Discard { id }
+            }
         };
         let admission = if waiting {
             FrontendAdmission::Waiting(action)

--- a/tests/intermediary_builder.rs
+++ b/tests/intermediary_builder.rs
@@ -821,6 +821,192 @@ async fn async_middleware_supports_suppression_local_responses_and_backend_fanou
     upstream.await.unwrap();
 }
 
+struct RejectParseLocally;
+
+impl
+    IntermediaryMiddleware<
+        (),
+        ServerConnectionContext<String, TrustIdentity>,
+        ClientConnectionContext<()>,
+    > for RejectParseLocally
+{
+    type Error = Infallible;
+
+    async fn frontend(
+        &mut self,
+        _: &ServerConnectionContext<String, TrustIdentity>,
+        _: &ClientConnectionContext<()>,
+        (): &mut (),
+        message: FrontendMessage,
+    ) -> Result<pg_proto::FrontendMiddlewareOutput, Self::Error> {
+        if matches!(&message, FrontendMessage::Parse(parse) if parse.query == "LOCAL ERROR") {
+            return Ok(pg_proto::FrontendMiddlewareOutput::Respond {
+                request: message,
+                responses: vec![BackendMessage::ErrorResponse(
+                    pg_proto::DiagnosticResponse { fields: vec![] },
+                )],
+            });
+        }
+        Ok(pg_proto::FrontendMiddlewareOutput::Forward(message))
+    }
+}
+
+#[tokio::test]
+#[allow(clippy::too_many_lines)]
+async fn local_extended_error_discards_messages_until_sync_and_reuses_connection() {
+    let (downstream_transport, mut downstream_peer) = tokio::io::duplex(16 * 1024);
+    let (upstream_transport, mut upstream_peer) = tokio::io::duplex(16 * 1024);
+    let upstream_transport = std::sync::Mutex::new(Some(upstream_transport));
+
+    let intermediary = Intermediary::builder()
+        .server(
+            Server::builder()
+                .tls(ServerTlsPolicy::Disabled)
+                .authentication(TrustServerAuthentication)
+                .build()
+                .unwrap(),
+        )
+        .client(
+            Client::builder()
+                .connector(move |_| {
+                    let transport = upstream_transport.lock().unwrap().take().unwrap();
+                    async move { Ok::<_, Infallible>(transport) }
+                })
+                .tls(ClientTlsPolicy::Disabled)
+                .authentication(TrustClientAuthentication)
+                .build()
+                .unwrap(),
+        )
+        .startup_resolver(CandidateResolver)
+        .authenticated_route(RefineRoute)
+        .cancellation(CancellationPolicy::Reject)
+        .pipeline(BoundedPipeline::new(8).unwrap())
+        .middleware(
+            |_: &ServerConnectionContext<String, TrustIdentity>,
+             _: &ClientConnectionContext<()>| RejectParseLocally,
+        )
+        .build()
+        .unwrap();
+
+    let downstream = tokio::spawn(async move {
+        let startup = pg_proto::StartupMessage {
+            version: pg_proto::ProtocolVersion::V3_0,
+            parameters: std::iter::once((
+                Bytes::from_static(b"user"),
+                Bytes::from_static(b"alice"),
+            ))
+            .collect(),
+        };
+        downstream_peer
+            .write_all(&startup.encode().unwrap())
+            .await
+            .unwrap();
+        let mut authentication_and_ready = [0; 15];
+        downstream_peer
+            .read_exact(&mut authentication_and_ready)
+            .await
+            .unwrap();
+
+        for message in [
+            FrontendMessage::Parse(Parse {
+                statement: Bytes::from_static(b"s1"),
+                query: Bytes::from_static(b"LOCAL ERROR"),
+                parameter_types: vec![],
+            }),
+            FrontendMessage::Bind(Bind {
+                portal: Bytes::new(),
+                statement: Bytes::from_static(b"s1"),
+                parameter_formats: vec![],
+                parameters: vec![],
+                result_formats: vec![],
+            }),
+            FrontendMessage::Execute(Execute {
+                portal: Bytes::new(),
+                max_rows: 0,
+            }),
+            FrontendMessage::Sync,
+        ] {
+            downstream_peer
+                .write_all(&frontend_bytes(&message))
+                .await
+                .unwrap();
+        }
+        assert_eq!(read_tagged(&mut downstream_peer).await.0, b'E');
+        assert_eq!(read_tagged(&mut downstream_peer).await.0, b'Z');
+
+        downstream_peer
+            .write_all(&frontend_bytes(&FrontendMessage::Query(
+                Bytes::from_static(b"AFTER"),
+            )))
+            .await
+            .unwrap();
+        assert_eq!(read_tagged(&mut downstream_peer).await.0, b'C');
+        assert_eq!(read_tagged(&mut downstream_peer).await.0, b'Z');
+    });
+
+    let upstream = tokio::spawn(async move {
+        let length = upstream_peer.read_u32().await.unwrap();
+        let mut startup = vec![0; usize::try_from(length).unwrap() - 4];
+        upstream_peer.read_exact(&mut startup).await.unwrap();
+        upstream_peer
+            .write_all(&[b'R', 0, 0, 0, 8, 0, 0, 0, 0, b'Z', 0, 0, 0, 5, b'I'])
+            .await
+            .unwrap();
+
+        assert_eq!(read_tagged(&mut upstream_peer).await.0, b'S');
+        upstream_peer
+            .write_all(&backend_bytes(&BackendMessage::ReadyForQuery(
+                pg_proto::TransactionStatus::Idle,
+            )))
+            .await
+            .unwrap();
+        let (tag, body) = read_tagged(&mut upstream_peer).await;
+        assert_eq!((tag, body.as_slice()), (b'Q', b"AFTER\0".as_slice()));
+        upstream_peer
+            .write_all(&backend_bytes(&BackendMessage::CommandComplete(
+                Bytes::from_static(b"AFTER"),
+            )))
+            .await
+            .unwrap();
+        upstream_peer
+            .write_all(&backend_bytes(&BackendMessage::ReadyForQuery(
+                pg_proto::TransactionStatus::Idle,
+            )))
+            .await
+            .unwrap();
+    });
+
+    let mut session =
+        Box::pin(intermediary.accept(downstream_transport, "downstream-peer".to_owned(), ()))
+            .await
+            .unwrap()
+            .into_session();
+    assert!(matches!(
+        session.forward_frontend().await.unwrap(),
+        pg_proto::FrontendForwarding::LocallyHandled(FrontendMessage::Parse(_))
+    ));
+    for _ in 0..2 {
+        assert!(matches!(
+            session.forward_frontend().await.unwrap(),
+            pg_proto::FrontendForwarding::Suppressed(_)
+        ));
+    }
+    assert!(matches!(
+        session.forward_frontend().await.unwrap(),
+        pg_proto::FrontendForwarding::Forwarded(FrontendMessage::Sync)
+    ));
+    session.forward_backend().await.unwrap();
+    assert!(matches!(
+        session.forward_frontend().await.unwrap(),
+        pg_proto::FrontendForwarding::Forwarded(FrontendMessage::Query(query)) if query == "AFTER"
+    ));
+    session.forward_backend().await.unwrap();
+    session.forward_backend().await.unwrap();
+    let _ = session.teardown();
+    downstream.await.unwrap();
+    upstream.await.unwrap();
+}
+
 #[derive(Default)]
 struct OrderedBatch;
 


### PR DESCRIPTION
## Summary

- stop forwarding extended-query messages that the pipeline has marked discarded after a locally generated error
- continue forwarding `Sync` so the upstream connection returns to ready state
- add pipeline and end-to-end intermediary regression coverage proving the connection remains reusable

## Root cause

The pipeline ledger marked `Bind`/`Describe`/`Execute` messages after a locally handled `Parse` error as discarded, but still returned `FrontendAction::Forward`. The intermediary sent those messages upstream, provoking errors such as `prepared statement does not exist`; those responses then violated the projected pipeline and terminated the connection.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --all-targets`