### PR TITLE
Fix deferred local extended-query errors

### DIFF
--- a/src/internal_tests/intermediary_pipeline.rs
+++ b/src/internal_tests/intermediary_pipeline.rs
@@ -776,13 +776,20 @@ fn local_rejection_waits_behind_forwarded_parse() {
             .accept_frontend(parse(b"b"), FrontendHandling::Local)
             .unwrap(),
     );
-    pipeline
-        .accept_frontend(FrontendMessage::Sync, FrontendHandling::Forward)
-        .unwrap();
     assert!(matches!(
         pipeline.try_emit_local(rejected, error()).unwrap(),
         BackendAction::Deferred(_)
     ));
+    assert!(matches!(
+        pipeline
+            .accept_frontend(describe(), FrontendHandling::Forward)
+            .unwrap()
+            .into_action(),
+        FrontendAction::Discard { .. }
+    ));
+    pipeline
+        .accept_frontend(FrontendMessage::Sync, FrontendHandling::Forward)
+        .unwrap();
     pipeline
         .accept_backend(BackendMessage::ParseComplete)
         .unwrap();

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1058,7 +1058,40 @@ impl<P: PipelinePolicy> Pipeline<P> {
         message: BackendMessage,
     ) -> Result<BackendAction, BackendProjectionError> {
         let prepared = self.prepare_response(local_id, &message);
+        if prepared == PreparedResponse::Deferred
+            && matches!(message, BackendMessage::ErrorResponse(_))
+            && let Some(id) = local_id
+        {
+            self.project_deferred_local_error(id);
+        }
         self.commit_response(prepared, message)
+    }
+
+    fn project_deferred_local_error(&mut self, id: OperationId) {
+        let Some(rejected) = self
+            .operations
+            .iter()
+            .position(|operation| operation.id == id)
+        else {
+            return;
+        };
+        if self.operations[rejected].origin != Origin::Local
+            || !is_extended_kind(self.operations[rejected].kind)
+        {
+            return;
+        }
+
+        let mut sync_accepted = false;
+        for operation in self.operations.iter_mut().skip(rejected + 1) {
+            if operation.kind == OperationKind::Sync {
+                sync_accepted = true;
+                break;
+            }
+            operation.discarded = true;
+        }
+        if !sync_accepted {
+            self.request_state = RequestState::ExtendedError;
+        }
     }
 
     fn commit_response(

--- a/tests/intermediary_builder.rs
+++ b/tests/intermediary_builder.rs
@@ -908,6 +908,7 @@ async fn local_extended_error_discards_messages_until_sync_and_reuses_connection
             .unwrap();
 
         for message in [
+            FrontendMessage::Query(Bytes::from_static(b"BEFORE")),
             FrontendMessage::Parse(Parse {
                 statement: Bytes::from_static(b"s1"),
                 query: Bytes::from_static(b"LOCAL ERROR"),
@@ -931,8 +932,9 @@ async fn local_extended_error_discards_messages_until_sync_and_reuses_connection
                 .await
                 .unwrap();
         }
-        assert_eq!(read_tagged(&mut downstream_peer).await.0, b'E');
-        assert_eq!(read_tagged(&mut downstream_peer).await.0, b'Z');
+        for expected in *b"CZEZ" {
+            assert_eq!(read_tagged(&mut downstream_peer).await.0, expected);
+        }
 
         downstream_peer
             .write_all(&frontend_bytes(&FrontendMessage::Query(
@@ -953,6 +955,20 @@ async fn local_extended_error_discards_messages_until_sync_and_reuses_connection
             .await
             .unwrap();
 
+        let (tag, body) = read_tagged(&mut upstream_peer).await;
+        assert_eq!((tag, body.as_slice()), (b'Q', b"BEFORE\0".as_slice()));
+        upstream_peer
+            .write_all(&backend_bytes(&BackendMessage::CommandComplete(
+                Bytes::from_static(b"BEFORE"),
+            )))
+            .await
+            .unwrap();
+        upstream_peer
+            .write_all(&backend_bytes(&BackendMessage::ReadyForQuery(
+                pg_proto::TransactionStatus::Idle,
+            )))
+            .await
+            .unwrap();
         assert_eq!(read_tagged(&mut upstream_peer).await.0, b'S');
         upstream_peer
             .write_all(&backend_bytes(&BackendMessage::ReadyForQuery(
@@ -983,6 +999,10 @@ async fn local_extended_error_discards_messages_until_sync_and_reuses_connection
             .into_session();
     assert!(matches!(
         session.forward_frontend().await.unwrap(),
+        pg_proto::FrontendForwarding::Forwarded(FrontendMessage::Query(query)) if query == "BEFORE"
+    ));
+    assert!(matches!(
+        session.forward_frontend().await.unwrap(),
         pg_proto::FrontendForwarding::LocallyHandled(FrontendMessage::Parse(_))
     ));
     for _ in 0..2 {
@@ -995,6 +1015,8 @@ async fn local_extended_error_discards_messages_until_sync_and_reuses_connection
         session.forward_frontend().await.unwrap(),
         pg_proto::FrontendForwarding::Forwarded(FrontendMessage::Sync)
     ));
+    session.forward_backend().await.unwrap();
+    session.forward_backend().await.unwrap();
     session.forward_backend().await.unwrap();
     assert!(matches!(
         session.forward_frontend().await.unwrap(),


### PR DESCRIPTION
## Summary

- project extended-query error state as soon as a local ErrorResponse is deferred behind an earlier upstream response
- discard already queued and subsequently received frontend operations until Sync
- preserve ordered downstream emission and connection reuse

This fixes the proxy failure where a rejected Parse was followed by Describe/Sync while the local error waited behind a previous query response. Those messages were forwarded upstream and caused a pipeline legality failure.

## Verification

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace --all-targets