### PR TITLE
feat: make intermediary futures sendable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,7 +298,9 @@ jobs:
 
       - name: Install nightly Rust
         if: needs.reuse-pr-ci.outputs.tested != 'true'
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2026-08-12
 
       - name: Install cargo-fuzz
         if: needs.reuse-pr-ci.outputs.tested != 'true'
@@ -306,4 +308,4 @@ jobs:
 
       - name: Run fuzz target
         if: needs.reuse-pr-ci.outputs.tested != 'true'
-        run: cargo +nightly fuzz run --fuzz-dir fuzz ${{ matrix.target }} -- -max_total_time=60
+        run: cargo +nightly-2026-08-12 fuzz run --fuzz-dir fuzz ${{ matrix.target }} -- -max_total_time=60

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ use pg_proto::{
 };
 
 struct Route;
-impl<Peer> StartupRouteResolver<Peer> for Route {
+impl<Peer: Sync> StartupRouteResolver<Peer> for Route {
     type Error = Infallible;
     async fn resolve(
         &self,

--- a/examples/intermediary_pipeline.rs
+++ b/examples/intermediary_pipeline.rs
@@ -8,7 +8,7 @@ use pg_proto::{
 use std::convert::Infallible;
 
 struct Route;
-impl<Peer> StartupRouteResolver<Peer> for Route {
+impl<Peer: Sync> StartupRouteResolver<Peer> for Route {
     type Error = Infallible;
     async fn resolve(
         &self,

--- a/examples/proxy_skeleton.rs
+++ b/examples/proxy_skeleton.rs
@@ -10,7 +10,7 @@ use pg_proto::{
 
 struct Route;
 
-impl<Peer> StartupRouteResolver<Peer> for Route {
+impl<Peer: Sync> StartupRouteResolver<Peer> for Route {
     type Error = Infallible;
 
     async fn resolve(

--- a/examples/rewriting_intermediary.rs
+++ b/examples/rewriting_intermediary.rs
@@ -11,7 +11,7 @@ use pg_proto::{
 };
 
 struct Route;
-impl<Peer> StartupRouteResolver<Peer> for Route {
+impl<Peer: Sync> StartupRouteResolver<Peer> for Route {
     type Error = Infallible;
     async fn resolve(
         &self,

--- a/src/client_component.rs
+++ b/src/client_component.rs
@@ -140,14 +140,17 @@ impl fmt::Debug for ClientTlsConfig {
 
 /// Application-owned source of reloadable client TLS material.
 ///
-/// Resolution futures are not required to be [`Send`].
-#[allow(async_fn_in_trait)]
+/// Resolution futures are [`Send`] so connection establishment can run on a
+/// multithreaded executor.
 pub trait ClientTlsProvider {
     /// Provider resolution failure.
     type Error;
 
     /// Resolves material for one connection attempt.
-    async fn resolve(&self, target: &ConnectTarget) -> Result<ClientTlsConfig, Self::Error>;
+    fn resolve(
+        &self,
+        target: &ConnectTarget,
+    ) -> impl Future<Output = Result<ClientTlsConfig, Self::Error>> + Send;
 }
 
 /// Failure while resolving or establishing client TLS.
@@ -357,8 +360,8 @@ pub enum ClientAuthenticationResponse {
 
 /// Factory for asynchronous, fallible per-connection authentication sessions.
 ///
-/// Authentication futures are not required to be [`Send`].
-#[allow(async_fn_in_trait)]
+/// Authentication futures are [`Send`] so connection establishment can run
+/// on a multithreaded executor.
 pub trait ClientAuthentication {
     /// Typed identity evidence produced after server confirmation.
     type Evidence;
@@ -368,13 +371,16 @@ pub trait ClientAuthentication {
     type Error;
 
     /// Creates fresh authentication state using the selected route.
-    async fn begin(&self, target: &ConnectTarget) -> Result<Self::Session, Self::Error>;
+    fn begin(
+        &self,
+        target: &ConnectTarget,
+    ) -> impl Future<Output = Result<Self::Session, Self::Error>> + Send;
 }
 
 /// Mutable authentication policy state owned by one connection attempt.
 ///
-/// Authentication futures are not required to be [`Send`].
-#[allow(async_fn_in_trait)]
+/// Authentication futures are [`Send`] so connection establishment can run
+/// on a multithreaded executor.
 pub trait ClientAuthenticationSession {
     /// Typed identity evidence produced after server confirmation.
     type Evidence;
@@ -382,13 +388,13 @@ pub trait ClientAuthenticationSession {
     type Error;
 
     /// Answers one server authentication challenge.
-    async fn respond(
+    fn respond(
         &mut self,
         challenge: ClientAuthenticationChallenge,
-    ) -> Result<ClientAuthenticationResponse, Self::Error>;
+    ) -> impl Future<Output = Result<ClientAuthenticationResponse, Self::Error>> + Send;
 
     /// Produces identity evidence after `AuthenticationOk` was received.
-    async fn authenticated(self) -> Result<Self::Evidence, Self::Error>;
+    fn authenticated(self) -> impl Future<Output = Result<Self::Evidence, Self::Error>> + Send;
 }
 
 /// Failure while running an application authentication policy.

--- a/src/intermediary_component.rs
+++ b/src/intermediary_component.rs
@@ -267,33 +267,33 @@ impl<'a, Peer> InitialServerContext<'a, Peer> {
 
 /// Required asynchronous startup routing policy.
 ///
-/// Resolution futures are not required to be [`Send`].
-#[allow(async_fn_in_trait)]
+/// Resolution futures are [`Send`] so intermediary sessions can run on a
+/// multithreaded executor.
 pub trait StartupRouteResolver<Peer> {
     /// Application resolver failure.
     type Error;
 
     /// Selects a destination before client-facing authentication begins.
-    async fn resolve(
+    fn resolve(
         &self,
         startup: StartupParameters,
         context: InitialServerContext<'_, Peer>,
-    ) -> Result<ConnectTarget, Self::Error>;
+    ) -> impl Future<Output = Result<ConnectTarget, Self::Error>> + Send;
 }
 
 /// Optional policy that validates or refines a destination after authentication.
 ///
-/// Routing futures are not required to be [`Send`].
-#[allow(async_fn_in_trait)]
+/// Routing futures are [`Send`] so intermediary sessions can run on a
+/// multithreaded executor.
 pub trait AuthenticatedRoutePolicy<Peer, Identity> {
     /// Application policy failure.
     type Error;
     /// Validates or refines the startup-selected target using typed identity evidence.
-    async fn route(
+    fn route(
         &self,
         target: ConnectTarget,
         context: AuthenticatedRouteContext<'_, Peer, Identity>,
-    ) -> Result<ConnectTarget, Self::Error>;
+    ) -> impl Future<Output = Result<ConnectTarget, Self::Error>> + Send;
 }
 
 /// Borrowed facts passed to authenticated route policy.
@@ -321,7 +321,9 @@ impl<Peer, Identity> AuthenticatedRouteContext<'_, Peer, Identity> {
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct AllowAuthenticatedRoute;
 
-impl<Peer, Identity> AuthenticatedRoutePolicy<Peer, Identity> for AllowAuthenticatedRoute {
+impl<Peer: Sync, Identity: Sync> AuthenticatedRoutePolicy<Peer, Identity>
+    for AllowAuthenticatedRoute
+{
     type Error = std::convert::Infallible;
     async fn route(
         &self,
@@ -488,22 +490,22 @@ impl<'a> AttributedBackendMessages<'a> {
 
 /// Asynchronous, fallible middleware at the forwarding boundary.
 ///
-/// Middleware futures are not required to be [`Send`].
-#[allow(async_fn_in_trait)]
+/// Middleware futures are [`Send`] so intermediary sessions can run on a
+/// multithreaded executor.
 pub trait IntermediaryMiddleware<State, ServerContext, ClientContext> {
     /// Application-defined interception failure.
     type Error;
 
     /// Intercepts a client-originated message after server-role middleware and
     /// before client-role middleware.
-    async fn frontend(
+    fn frontend(
         &mut self,
         _server: &ServerContext,
         _client: &ClientContext,
         _state: &mut State,
         message: crate::codec::FrontendMessage,
-    ) -> Result<FrontendMiddlewareOutput, Self::Error> {
-        Ok(FrontendMiddlewareOutput::Forward(message))
+    ) -> impl Future<Output = Result<FrontendMiddlewareOutput, Self::Error>> + Send {
+        async move { Ok(FrontendMiddlewareOutput::Forward(message)) }
     }
 
     /// Intercepts a client-originated message with the identity reserved for
@@ -512,27 +514,27 @@ pub trait IntermediaryMiddleware<State, ServerContext, ClientContext> {
     /// The default preserves existing middleware by delegating to
     /// [`Self::frontend`]. Implementations which attach application state to an
     /// operation should remove that state themselves when they suppress it.
-    async fn frontend_operation(
+    fn frontend_operation(
         &mut self,
         server: &ServerContext,
         client: &ClientContext,
         state: &mut State,
         _operation: OperationId,
         message: crate::codec::FrontendMessage,
-    ) -> Result<FrontendMiddlewareOutput, Self::Error> {
-        self.frontend(server, client, state, message).await
+    ) -> impl Future<Output = Result<FrontendMiddlewareOutput, Self::Error>> + Send {
+        self.frontend(server, client, state, message)
     }
 
     /// Intercepts a PostgreSQL-originated message after client-role middleware
     /// and before server-role middleware.
-    async fn backend(
+    fn backend(
         &mut self,
         _server: &ServerContext,
         _client: &ClientContext,
         _state: &mut State,
         message: crate::codec::BackendMessage,
-    ) -> Result<BackendMiddlewareOutput, Self::Error> {
-        Ok(BackendMiddlewareOutput::Forward(message))
+    ) -> impl Future<Output = Result<BackendMiddlewareOutput, Self::Error>> + Send {
+        async move { Ok(BackendMiddlewareOutput::Forward(message)) }
     }
 
     /// Intercepts a PostgreSQL-originated message with its frontend operation
@@ -540,44 +542,42 @@ pub trait IntermediaryMiddleware<State, ServerContext, ClientContext> {
     ///
     /// Asynchronous backend messages have no operation identity. The default
     /// preserves existing middleware by delegating to [`Self::backend`].
-    async fn backend_operation(
+    fn backend_operation(
         &mut self,
         server: &ServerContext,
         client: &ClientContext,
         state: &mut State,
         _operation: Option<OperationId>,
         message: crate::codec::BackendMessage,
-    ) -> Result<BackendMiddlewareOutput, Self::Error> {
-        self.backend(server, client, state, message).await
+    ) -> impl Future<Output = Result<BackendMiddlewareOutput, Self::Error>> + Send {
+        self.backend(server, client, state, message)
     }
 
     /// Applies policy to an ordered borrowed span of retained backend messages.
-    async fn flush_backend(
+    fn flush_backend(
         &mut self,
         _server: &ServerContext,
         _client: &ClientContext,
         _state: &mut State,
         held: HeldBackendMessages<'_>,
         _reason: BackendFlushReason,
-    ) -> Result<BackendBatchOutput, Self::Error> {
-        Ok(BackendBatchOutput::ReplaceOneToOne(
-            held.iter().cloned().collect(),
-        ))
+    ) -> impl Future<Output = Result<BackendBatchOutput, Self::Error>> + Send {
+        let messages = held.iter().cloned().collect();
+        async move { Ok(BackendBatchOutput::ReplaceOneToOne(messages)) }
     }
 
     /// Applies policy to retained backend messages with operation attribution.
     /// The default preserves existing middleware by delegating to
     /// [`Self::flush_backend`].
-    async fn flush_backend_operations(
+    fn flush_backend_operations(
         &mut self,
         server: &ServerContext,
         client: &ClientContext,
         state: &mut State,
         held: AttributedBackendMessages<'_>,
         reason: BackendFlushReason,
-    ) -> Result<BackendBatchOutput, Self::Error> {
+    ) -> impl Future<Output = Result<BackendBatchOutput, Self::Error>> + Send {
         self.flush_backend(server, client, state, held.messages(), reason)
-            .await
     }
 }
 
@@ -918,7 +918,8 @@ impl<Resolver, State, Peer, Identity>
     crate::server_component::StartupResolver<State, Peer, Identity>
     for StartupResolverAdapter<'_, Resolver>
 where
-    Resolver: StartupRouteResolver<Peer>,
+    Resolver: StartupRouteResolver<Peer> + Sync,
+    Peer: Sync,
 {
     type Route = ConnectTarget;
     type Error = StartupResolutionError<Resolver::Error>;
@@ -932,7 +933,7 @@ where
         startup: &'a crate::startup::StartupMessage,
         context: &'a crate::ServerConnectionContext<Peer, Identity>,
         _state: &'a mut State,
-    ) -> Pin<Box<dyn Future<Output = Result<Self::Route, Self::Error>> + 'a>> {
+    ) -> Pin<Box<dyn Future<Output = Result<Self::Route, Self::Error>> + Send + 'a>> {
         let parameters = StartupParameters::from_wire(startup);
         let initial = context
             .tls_if_known()
@@ -1978,7 +1979,8 @@ where
                     <SA::Authentication as crate::ServerAuthentication<Peer>>::Identity,
                 >,
             >,
-        Resolver: StartupRouteResolver<Peer>,
+        Resolver: StartupRouteResolver<Peer> + Sync,
+        Peer: Sync,
         Connector: Fn(&ConnectTarget) -> CW,
         CW: Future<Output = Result<UT, CE>>,
         <CM as crate::MiddlewareFactory<crate::ClientInitialContext>>::Handler:

--- a/src/server_component.rs
+++ b/src/server_component.rs
@@ -60,7 +60,7 @@ pub(crate) trait StartupResolver<State, Peer, Identity> {
         startup: &'a StartupMessage,
         context: &'a ServerConnectionContext<Peer, Identity>,
         state: &'a mut State,
-    ) -> Pin<Box<dyn Future<Output = Result<Self::Route, Self::Error>> + 'a>>;
+    ) -> Pin<Box<dyn Future<Output = Result<Self::Route, Self::Error>> + Send + 'a>>;
 }
 
 /// Failure from either server establishment or application startup routing.
@@ -89,7 +89,7 @@ impl<State, Peer, Identity> StartupResolver<State, Peer, Identity> for NoStartup
         _startup: &'a StartupMessage,
         _context: &'a ServerConnectionContext<Peer, Identity>,
         _state: &'a mut State,
-    ) -> Pin<Box<dyn Future<Output = Result<(), Self::Error>> + 'a>> {
+    ) -> Pin<Box<dyn Future<Output = Result<(), Self::Error>> + Send + 'a>> {
         Box::pin(async { Ok(()) })
     }
 }
@@ -238,8 +238,8 @@ pub enum ServerAuthenticationResponse {
 
 /// Per-connection asynchronous authentication policy.
 ///
-/// Authentication futures are not required to be [`Send`].
-#[allow(async_fn_in_trait)]
+/// Authentication futures are [`Send`] so connection establishment can run
+/// on a multithreaded executor.
 pub trait ServerAuthentication<Peer> {
     /// Typed evidence produced by successful authentication.
     type Identity;
@@ -247,17 +247,17 @@ pub trait ServerAuthentication<Peer> {
     type Error;
 
     /// Starts the application-driven authentication conversation.
-    async fn start(
+    fn start(
         &mut self,
         request: ServerAuthenticationRequest<'_, Peer>,
-    ) -> Result<ServerAuthenticationAction<Self::Identity>, Self::Error>;
+    ) -> impl Future<Output = Result<ServerAuthenticationAction<Self::Identity>, Self::Error>> + Send;
 
     /// Advances the conversation after one protocol response.
-    async fn respond(
+    fn respond(
         &mut self,
         request: ServerAuthenticationRequest<'_, Peer>,
         response: ServerAuthenticationResponse,
-    ) -> Result<ServerAuthenticationAction<Self::Identity>, Self::Error>;
+    ) -> impl Future<Output = Result<ServerAuthenticationAction<Self::Identity>, Self::Error>> + Send;
 }
 
 /// Factory creating one isolated authentication policy per connection.
@@ -309,7 +309,7 @@ impl ServerAuthenticationProvider for StaticMd5ServerCredentials {
     }
 }
 
-impl<Peer> ServerAuthentication<Peer> for StaticMd5ServerCredentialSession {
+impl<Peer: Sync> ServerAuthentication<Peer> for StaticMd5ServerCredentialSession {
     type Identity = ();
     type Error = crate::StaticCredentialError;
 
@@ -560,7 +560,7 @@ impl ServerAuthenticationProvider for TrustServerAuthentication {
     }
 }
 
-impl<Peer> ServerAuthentication<Peer> for TrustServerAuthentication {
+impl<Peer: Sync> ServerAuthentication<Peer> for TrustServerAuthentication {
     type Identity = TrustIdentity;
     type Error = std::convert::Infallible;
 

--- a/tests/intermediary_cancellation.rs
+++ b/tests/intermediary_cancellation.rs
@@ -6,6 +6,10 @@ use std::{
     convert::Infallible,
     fmt,
     rc::Rc,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
 };
 
 use bytes::Bytes;
@@ -53,7 +57,7 @@ impl IntermediaryCancellationRegistry for Registry {
 }
 
 #[derive(Clone)]
-struct Resolver(Rc<RefCell<usize>>);
+struct Resolver(Arc<AtomicUsize>);
 impl StartupRouteResolver<&'static str> for Resolver {
     type Error = Infallible;
     async fn resolve(
@@ -61,7 +65,7 @@ impl StartupRouteResolver<&'static str> for Resolver {
         _: StartupParameters,
         _: InitialServerContext<'_, &'static str>,
     ) -> Result<ConnectTarget, Self::Error> {
-        *self.0.borrow_mut() += 1;
+        self.0.fetch_add(1, Ordering::Relaxed);
         Ok(ConnectTarget::new("db").with_metadata("tenant", "a"))
     }
 }
@@ -146,7 +150,7 @@ async fn records_rewrites_resolves_without_routing_and_detaches() {
     let (upstream_io, mut upstream) = tokio::io::duplex(4096);
     let (cancel_io, mut cancel_upstream) = tokio::io::duplex(4096);
     let transports = Rc::new(RefCell::new(VecDeque::from([upstream_io, cancel_io])));
-    let resolver_calls = Rc::new(RefCell::new(0));
+    let resolver_calls = Arc::new(AtomicUsize::new(0));
     let observed = Rc::new(RefCell::new(Vec::new()));
     let registry = Registry(Rc::new(RefCell::new(HashMap::new())));
 
@@ -234,7 +238,7 @@ async fn records_rewrites_resolves_without_routing_and_detaches() {
     let proxy_key = downstream_task.await.unwrap();
     upstream_task.await.unwrap();
     assert_eq!(session.cancellation_key(), Some(&proxy_key));
-    assert_eq!(*resolver_calls.borrow(), 1);
+    assert_eq!(resolver_calls.load(Ordering::Relaxed), 1);
     assert_eq!(
         registry
             .resolve(&proxy_key)
@@ -263,7 +267,7 @@ async fn records_rewrites_resolves_without_routing_and_detaches() {
     assert_eq!(&forwarded[8..12], &7_u32.to_be_bytes());
     assert_eq!(&forwarded[12..], b"upstream");
     assert_eq!(
-        *resolver_calls.borrow(),
+        resolver_calls.load(Ordering::Relaxed),
         1,
         "cancellation bypasses startup routing"
     );
@@ -287,7 +291,7 @@ async fn records_rewrites_resolves_without_routing_and_detaches() {
         error,
         pg_proto::IntermediaryAcceptError::CancellationRejected
     ));
-    assert_eq!(*resolver_calls.borrow(), 1);
+    assert_eq!(resolver_calls.load(Ordering::Relaxed), 1);
 }
 
 #[test]

--- a/tests/intermediary_send.rs
+++ b/tests/intermediary_send.rs
@@ -1,0 +1,103 @@
+//! Compile-time coverage for multithreaded intermediary task ownership.
+
+use std::convert::Infallible;
+
+use pg_proto::{
+    CancellationPolicy, Client, ClientConnectionContext, ClientTlsConfig, ClientTlsPolicy,
+    ClientTlsProvider, ConnectTarget, FrontendMessage, FrontendMiddlewareOutput,
+    InitialServerContext, Intermediary, IntermediaryAccept, IntermediaryMiddleware, Server,
+    ServerConnectionContext, ServerTlsPolicy, SslMode, StartupParameters, StartupRouteResolver,
+    TrustClientAuthentication, TrustIdentity, TrustServerAuthentication,
+};
+
+struct Route;
+
+struct Tls;
+
+struct Boundary;
+
+fn boundary_factory(
+    _: &ServerConnectionContext<(), TrustIdentity>,
+    _: &ClientConnectionContext<()>,
+) -> Boundary {
+    Boundary
+}
+
+impl
+    IntermediaryMiddleware<
+        (),
+        ServerConnectionContext<(), TrustIdentity>,
+        ClientConnectionContext<()>,
+    > for Boundary
+{
+    type Error = Infallible;
+
+    async fn frontend(
+        &mut self,
+        _: &ServerConnectionContext<(), TrustIdentity>,
+        _: &ClientConnectionContext<()>,
+        (): &mut (),
+        message: FrontendMessage,
+    ) -> Result<FrontendMiddlewareOutput, Self::Error> {
+        tokio::task::yield_now().await;
+        Ok(FrontendMiddlewareOutput::Forward(message))
+    }
+}
+
+impl ClientTlsProvider for Tls {
+    type Error = Infallible;
+
+    async fn resolve(&self, _: &ConnectTarget) -> Result<ClientTlsConfig, Self::Error> {
+        Ok(ClientTlsConfig::new(
+            "postgres".try_into().unwrap(),
+            rustls::RootCertStore::empty(),
+        ))
+    }
+}
+
+impl StartupRouteResolver<()> for Route {
+    type Error = Infallible;
+
+    async fn resolve(
+        &self,
+        _: StartupParameters,
+        _: InitialServerContext<'_, ()>,
+    ) -> Result<ConnectTarget, Self::Error> {
+        Ok(ConnectTarget::new("postgres"))
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn intermediary_session_can_run_in_a_spawned_task() {
+    let (downstream, _client_peer) = tokio::io::duplex(256);
+    let server = Server::builder()
+        .tls(ServerTlsPolicy::Disabled)
+        .authentication(TrustServerAuthentication)
+        .build()
+        .unwrap();
+    let client = Client::builder()
+        .connector(|_| async { Ok::<_, Infallible>(tokio::io::duplex(256).0) })
+        .tls(ClientTlsPolicy::libpq(SslMode::Prefer, Tls))
+        .authentication(TrustClientAuthentication)
+        .build()
+        .unwrap();
+    let intermediary = Intermediary::builder()
+        .server(server)
+        .client(client)
+        .startup_resolver(Route)
+        .cancellation(CancellationPolicy::Reject)
+        .middleware(boundary_factory)
+        .build()
+        .unwrap();
+
+    let task = tokio::spawn(async move {
+        if let Ok(IntermediaryAccept::Session(mut session)) =
+            Box::pin(intermediary.accept(downstream, (), ())).await
+        {
+            let _ = session.forward_next().await;
+        }
+    });
+
+    task.abort();
+    let _ = task.await;
+}


### PR DESCRIPTION
## Summary

- require `Send` futures from intermediary startup routing and boundary middleware
- require `Send` futures from the TLS and authentication providers awaited during intermediary establishment
- make the internal startup adapter future `Send` and add the necessary `Sync` bounds
- add a multithreaded `tokio::spawn` regression test covering TLS resolution, async middleware, intermediary acceptance, and `forward_next`

## Rationale

An intermediary session could only be driven from a `LocalSet` because its public async extension traits did not promise `Send`, even when implementations were otherwise thread-safe. Expressing `impl Future + Send` at each awaited application extension point lets the compiler prove that an intermediary built from Send-safe components can migrate between Tokio worker threads.

## Compatibility

Existing `async fn` implementations remain source-compatible when their futures are `Send`. Implementations that retain `Rc`, `RefCell`, or other non-Send state across an await must move to thread-safe state (or continue using an older release/current-thread design). Synchronous role middleware and the standalone server accept API retain their existing flexibility.

## Verification

- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --test intermediary_send`
- `cargo test --all-targets -- --skip illegal_facade_usage_does_not_compile`

The trybuild test itself was also run; its three expected diagnostics matched semantically but failed because this nested worktree path was not normalized to `<HOME>` by trybuild.