### PR TITLE
fix: forward startup parameter statuses

### DIFF
--- a/src/client_component.rs
+++ b/src/client_component.rs
@@ -1297,6 +1297,21 @@ impl<Transport, State, Cleanliness, Evidence, Handler>
 
 impl<Transport, Cleanliness, Evidence, Handler>
     ClientConnectionCore<Transport, Cleanliness, Evidence, Handler>
+where
+    Transport: AsyncRead + Unpin,
+{
+    pub(crate) fn pop_parameter_status(&mut self) -> Option<crate::codec::BackendMessage> {
+        self.connection.pop_parameter_status().map(|status| {
+            crate::codec::BackendMessage::ParameterStatus {
+                name: status.name,
+                value: status.value,
+            }
+        })
+    }
+}
+
+impl<Transport, Cleanliness, Evidence, Handler>
+    ClientConnectionCore<Transport, Cleanliness, Evidence, Handler>
 {
     pub(crate) const fn context(&self) -> &ClientConnectionContext<Evidence> {
         &self.context

--- a/src/intermediary_component.rs
+++ b/src/intermediary_component.rs
@@ -2158,6 +2158,56 @@ where
             cancellation_registry: self.cancellation_registry.clone(),
             client_cancel_key,
         };
+        while let Some(message) = connection.upstream.pop_parameter_status() {
+            let message = connection
+                .boundary
+                .backend(
+                    connection.downstream.context(),
+                    connection.upstream.context(),
+                    &mut connection.state,
+                    message,
+                )
+                .await;
+            let message = match message {
+                Ok(BackendMiddlewareOutput::Forward(message)) => message,
+                Ok(
+                    BackendMiddlewareOutput::Suppress(_)
+                    | BackendMiddlewareOutput::Expand(_)
+                    | BackendMiddlewareOutput::Hold,
+                ) => {
+                    let _ = connection.detach_cancellation();
+                    let _ = connection.teardown();
+                    return Err(IntermediaryAcceptError::ServerOutput(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "middleware suppressed or expanded startup parameter status",
+                    )));
+                }
+                Err(error) => {
+                    let _ = connection.detach_cancellation();
+                    let _ = connection.teardown();
+                    return Err(IntermediaryAcceptError::Middleware(error));
+                }
+            };
+            let message = connection
+                .downstream
+                .intercept_backend(&mut connection.state, message);
+            if !matches!(
+                message,
+                crate::codec::BackendMessage::ParameterStatus { .. }
+            ) {
+                let _ = connection.detach_cancellation();
+                let _ = connection.teardown();
+                return Err(IntermediaryAcceptError::ServerOutput(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "middleware rejected startup parameter status",
+                )));
+            }
+            if let Err(error) = connection.downstream.send_wire_raw(message).await {
+                let _ = connection.detach_cancellation();
+                let _ = connection.teardown();
+                return Err(IntermediaryAcceptError::ServerOutput(error));
+            }
+        }
         if let Some(message) = backend_key_message {
             let expected = message.clone();
             let message = connection

--- a/src/intermediary_component.rs
+++ b/src/intermediary_component.rs
@@ -2158,50 +2158,10 @@ where
             cancellation_registry: self.cancellation_registry.clone(),
             client_cancel_key,
         };
+        // These messages were already inspected by upstream establishment
+        // middleware. Relay them as part of the startup transcript rather than
+        // attributing them to the first operational query.
         while let Some(message) = connection.upstream.pop_parameter_status() {
-            let message = connection
-                .boundary
-                .backend(
-                    connection.downstream.context(),
-                    connection.upstream.context(),
-                    &mut connection.state,
-                    message,
-                )
-                .await;
-            let message = match message {
-                Ok(BackendMiddlewareOutput::Forward(message)) => message,
-                Ok(
-                    BackendMiddlewareOutput::Suppress(_)
-                    | BackendMiddlewareOutput::Expand(_)
-                    | BackendMiddlewareOutput::Hold,
-                ) => {
-                    let _ = connection.detach_cancellation();
-                    let _ = connection.teardown();
-                    return Err(IntermediaryAcceptError::ServerOutput(io::Error::new(
-                        io::ErrorKind::InvalidData,
-                        "middleware suppressed or expanded startup parameter status",
-                    )));
-                }
-                Err(error) => {
-                    let _ = connection.detach_cancellation();
-                    let _ = connection.teardown();
-                    return Err(IntermediaryAcceptError::Middleware(error));
-                }
-            };
-            let message = connection
-                .downstream
-                .intercept_backend(&mut connection.state, message);
-            if !matches!(
-                message,
-                crate::codec::BackendMessage::ParameterStatus { .. }
-            ) {
-                let _ = connection.detach_cancellation();
-                let _ = connection.teardown();
-                return Err(IntermediaryAcceptError::ServerOutput(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "middleware rejected startup parameter status",
-                )));
-            }
             if let Err(error) = connection.downstream.send_wire_raw(message).await {
                 let _ = connection.detach_cancellation();
                 let _ = connection.teardown();


### PR DESCRIPTION
## Summary

- retain PostgreSQL startup ParameterStatus messages consumed during upstream establishment
- relay them to the downstream client before BackendKeyData and ReadyForQuery
- keep startup transcript messages outside operational query middleware

## Regression

Without this, pgx rejects simple-protocol queries with:

`simple protocol queries must be run with standard_conforming_strings=on`

## Validation

- `cargo clippy -p pg-proto --all-targets -- -D warnings`
- `cargo test -p pg-proto --lib`: 191 passed, 10 ignored; one sandbox-blocked socket-binding test is unrelated
- CipherStash Proxy Go integration suite: pass, including all simple-protocol cases