### PR TITLE
Add protocol burn-in smoke harness and stable coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,6 +617,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
 name = "ferroid"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1500,6 +1506,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "pg-proto-burn-in"
+version = "0.1.0"
+dependencies = [
+ "pg-proto",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "testcontainers-modules",
+ "tokio",
+ "tokio-postgres",
+]
+
+[[package]]
 name = "pg-proto-fsm"
 version = "0.10.7"
 dependencies = [
@@ -2242,6 +2261,19 @@ name = "target-triple"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3a6bfce3d99adfa72d24750a61f782f3036a81e7f86d8841ee1326deaebd171"
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "termcolor"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1509,8 +1509,10 @@ dependencies = [
 name = "pg-proto-burn-in"
 version = "0.1.0"
 dependencies = [
+ "bytes",
  "futures-util",
  "pg-proto",
+ "postgres-protocol",
  "rcgen",
  "rustls",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1509,9 +1509,11 @@ dependencies = [
 name = "pg-proto-burn-in"
 version = "0.1.0"
 dependencies = [
+ "futures-util",
  "pg-proto",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "testcontainers-modules",
  "tokio",
@@ -1613,6 +1615,8 @@ dependencies = [
  "bytes",
  "fallible-iterator",
  "postgres-protocol",
+ "serde_core",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1511,6 +1511,8 @@ version = "0.1.0"
 dependencies = [
  "futures-util",
  "pg-proto",
+ "rcgen",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 repository = "https://github.com/freshtonic/pg-proto"
 
 [workspace]
-members = ["pg-proto-fsm"]
+members = ["pg-proto-burn-in", "pg-proto-fsm"]
 exclude = ["fuzz"]
 resolver = "3"
 

--- a/docs/public-api.txt
+++ b/docs/public-api.txt
@@ -25,7 +25,8 @@ pub use intermediary_component::{
     Intermediary, IntermediaryAccept, IntermediaryAcceptError, IntermediaryBuildError,
     IntermediaryBuilder, IntermediaryCancellationRegistry, IntermediaryConnection,
     IntermediaryContexts, IntermediaryMiddleware, IntermediaryMiddlewareFactory,
-    RejectCancellation, StartupResolutionError, StartupRouteResolver,
+    ProtocolTransitionDirection, ProtocolTransitionObservation, RejectCancellation,
+    StartupResolutionError, StartupRouteResolver,
 };
 pub use pipeline::{
     BackendProjectionError, BoundedPipeline, FrontendProjectionError, NoPipeline, OperationId,

--- a/pg-proto-burn-in/Cargo.toml
+++ b/pg-proto-burn-in/Cargo.toml
@@ -8,6 +8,8 @@ publish = false
 [dependencies]
 futures-util = "0.3"
 pg-proto = { version = "0.10.7", path = ".." }
+rcgen = "0.14.8"
+rustls = "0.23.43"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.11"

--- a/pg-proto-burn-in/Cargo.toml
+++ b/pg-proto-burn-in/Cargo.toml
@@ -6,8 +6,10 @@ rust-version = "1.88"
 publish = false
 
 [dependencies]
+bytes = "1.12"
 futures-util = "0.3"
 pg-proto = { version = "0.10.7", path = ".." }
+postgres-protocol = "0.6.12"
 rcgen = "0.14.8"
 rustls = "0.23.43"
 serde = { version = "1.0", features = ["derive"] }

--- a/pg-proto-burn-in/Cargo.toml
+++ b/pg-proto-burn-in/Cargo.toml
@@ -6,7 +6,7 @@ rust-version = "1.88"
 publish = false
 
 [dependencies]
-pg-proto = { path = ".." }
+pg-proto = { version = "0.10.7", path = ".." }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 testcontainers-modules = { version = "0.15.0", features = ["postgres"] }

--- a/pg-proto-burn-in/Cargo.toml
+++ b/pg-proto-burn-in/Cargo.toml
@@ -6,12 +6,14 @@ rust-version = "1.88"
 publish = false
 
 [dependencies]
+futures-util = "0.3"
 pg-proto = { version = "0.10.7", path = ".." }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+sha2 = "0.11"
 testcontainers-modules = { version = "0.15.0", features = ["postgres"] }
 tokio = { version = "1.53.1", features = ["fs", "io-std", "io-util", "macros", "net", "process", "rt-multi-thread", "time"] }
-tokio-postgres = "0.7.18"
+tokio-postgres = { version = "0.7.18", features = ["with-serde_json-1"] }
 
 [dev-dependencies]
 tempfile = "3.20"

--- a/pg-proto-burn-in/Cargo.toml
+++ b/pg-proto-burn-in/Cargo.toml
@@ -16,7 +16,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.11"
 testcontainers-modules = { version = "0.15.0", features = ["postgres"] }
-tokio = { version = "1.53.1", features = ["fs", "io-std", "io-util", "macros", "net", "process", "rt-multi-thread", "time"] }
+tokio = { version = "1.53.1", features = ["fs", "io-std", "io-util", "macros", "net", "process", "rt-multi-thread", "sync", "time"] }
 tokio-postgres = { version = "0.7.18", features = ["with-serde_json-1"] }
 
 [dev-dependencies]

--- a/pg-proto-burn-in/Cargo.toml
+++ b/pg-proto-burn-in/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "pg-proto-burn-in"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.88"
+publish = false
+
+[dependencies]
+pg-proto = { path = ".." }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+testcontainers-modules = { version = "0.15.0", features = ["postgres"] }
+tokio = { version = "1.53.1", features = ["fs", "io-std", "io-util", "macros", "net", "process", "rt-multi-thread", "time"] }
+tokio-postgres = "0.7.18"
+
+[dev-dependencies]
+tempfile = "3.20"

--- a/pg-proto-burn-in/fixtures/schema-v1.sql
+++ b/pg-proto-burn-in/fixtures/schema-v1.sql
@@ -1,0 +1,43 @@
+DO $fixture_schema$
+BEGIN
+    CREATE SCHEMA IF NOT EXISTS burnin_type_lab;
+    CREATE TABLE IF NOT EXISTS burnin_type_lab.samples (
+        id integer PRIMARY KEY,
+        scalar integer NOT NULL,
+        nullable_text text,
+        binary_value bytea NOT NULL,
+        tags text[] NOT NULL,
+        document jsonb NOT NULL,
+        wide_text text NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS burnin_type_lab.bulk_values (
+        id integer PRIMARY KEY,
+        nullable_text text,
+        binary_value bytea NOT NULL,
+        wide_text text NOT NULL
+    );
+
+    CREATE SCHEMA IF NOT EXISTS burnin_commerce;
+    CREATE TABLE IF NOT EXISTS burnin_commerce.customers (
+        id integer PRIMARY KEY,
+        name text NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS burnin_commerce.products (
+        id integer PRIMARY KEY,
+        sku text NOT NULL UNIQUE,
+        price_cents integer NOT NULL CHECK (price_cents > 0)
+    );
+    CREATE TABLE IF NOT EXISTS burnin_commerce.orders (
+        id integer PRIMARY KEY,
+        customer_id integer NOT NULL REFERENCES burnin_commerce.customers(id),
+        status text NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS burnin_commerce.order_lines (
+        order_id integer NOT NULL REFERENCES burnin_commerce.orders(id),
+        line_number integer NOT NULL,
+        product_id integer NOT NULL REFERENCES burnin_commerce.products(id),
+        quantity integer NOT NULL CHECK (quantity > 0),
+        PRIMARY KEY (order_id, line_number)
+    );
+END
+$fixture_schema$;

--- a/pg-proto-burn-in/fixtures/seed-v1.sql
+++ b/pg-proto-burn-in/fixtures/seed-v1.sql
@@ -1,0 +1,42 @@
+DO $fixture_seed$
+BEGIN
+    TRUNCATE burnin_type_lab.samples, burnin_type_lab.bulk_values,
+        burnin_commerce.order_lines, burnin_commerce.orders,
+        burnin_commerce.products, burnin_commerce.customers;
+
+    INSERT INTO burnin_type_lab.samples
+        (id, scalar, nullable_text, binary_value, tags, document, wide_text)
+    VALUES
+        (1, 10, NULL, decode('000102ff', 'hex'), ARRAY['alpha', 'one'],
+            '{"kind":"alpha","enabled":true}'::jsonb, repeat('wide-alpha-', 40)),
+        (2, 20, 'second', decode('10203040', 'hex'), ARRAY[]::text[],
+            '{"kind":"beta","count":2}'::jsonb, repeat('wide-beta-', 40)),
+        (3, 30, NULL, decode('deadbeef', 'hex'), ARRAY['nullable'],
+            '{"kind":"gamma","values":[1,2,3]}'::jsonb, repeat('wide-gamma-', 40)),
+        (4, 40, 'fourth', decode('cafebabe', 'hex'), ARRAY['delta', 'four'],
+            '{"kind":"delta","value":null}'::jsonb, repeat('wide-delta-', 40));
+
+    INSERT INTO burnin_type_lab.bulk_values (id, nullable_text, binary_value, wide_text)
+    SELECT value,
+        CASE WHEN value % 5 = 0 THEN NULL ELSE 'value-' || value END,
+        decode(md5(value::text), 'hex'),
+        repeat(lpad(value::text, 8, '0') || '-deterministic-wide-value-', 12)
+    FROM generate_series(1, 4096) AS value;
+
+    INSERT INTO burnin_commerce.customers (id, name)
+    SELECT value, 'customer-' || lpad(value::text, 3, '0')
+    FROM generate_series(1, 64) AS value;
+    INSERT INTO burnin_commerce.products (id, sku, price_cents)
+    SELECT value, 'SKU-' || lpad(value::text, 4, '0'), 100 + value * 7
+    FROM generate_series(1, 128) AS value;
+    INSERT INTO burnin_commerce.orders (id, customer_id, status)
+    SELECT value, ((value - 1) % 64) + 1,
+        CASE WHEN value % 4 = 0 THEN 'shipped' ELSE 'open' END
+    FROM generate_series(1, 256) AS value;
+    INSERT INTO burnin_commerce.order_lines (order_id, line_number, product_id, quantity)
+    SELECT order_id, line_number, ((order_id * 3 + line_number - 1) % 128) + 1,
+        ((order_id + line_number) % 5) + 1
+    FROM generate_series(1, 256) AS order_id
+    CROSS JOIN generate_series(1, 2) AS line_number;
+END
+$fixture_seed$;

--- a/pg-proto-burn-in/src/lib.rs
+++ b/pg-proto-burn-in/src/lib.rs
@@ -17,7 +17,7 @@ use pg_proto::{
     ConnectTarget, ForwardedMessage, FrontendMessage, InitialServerContext, Intermediary,
     IntermediaryMiddleware, ProtocolTransitionDirection, ProtocolTransitionObservation, Server,
     ServerConnectionContext, ServerTlsPolicy, StartupParameters, StartupRouteResolver,
-    TrustClientAuthentication, TrustIdentity, TrustServerAuthentication,
+    StaticClientCredentials, TrustClientAuthentication, TrustIdentity, TrustServerAuthentication,
 };
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -56,7 +56,19 @@ struct RunResult {
     fixtures: FixtureResult,
     data_scenarios: Vec<DataScenarioResult>,
     coverage: CoverageReport,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    authentication_profiles: Vec<AuthenticationProfileResult>,
     success: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct AuthenticationProfileResult {
+    id: String,
+    postgres_versions: String,
+    tls_mode: String,
+    auth_method: String,
+    expected_outcome: String,
+    evidence: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -135,9 +147,17 @@ async fn run_conformance(arguments: &[String]) -> Result<(), Box<dyn Error>> {
                 scripted: coverage,
                 ..CoverageReport::default()
             },
+            authentication_profiles: Vec::new(),
             success: true,
         };
         return write_artifacts(&artifacts, &result).await;
+    }
+    if profile == "authentication" {
+        return run_authentication_conformance(
+            arguments.first().ok_or("missing executable path")?,
+            &artifacts,
+        )
+        .await;
     }
     if profile != "smoke" {
         return Err(format!("unsupported conformance profile: {profile}").into());
@@ -157,6 +177,7 @@ async fn run_conformance(arguments: &[String]) -> Result<(), Box<dyn Error>> {
             fixtures: fixtures.clone(),
             data_scenarios: data_scenarios.clone(),
             coverage: coverage_report(coverage)?,
+            authentication_profiles: Vec::new(),
             success: true,
         },
         Err(_) => RunResult {
@@ -171,11 +192,158 @@ async fn run_conformance(arguments: &[String]) -> Result<(), Box<dyn Error>> {
             fixtures: FixtureResult::default(),
             data_scenarios: Vec::new(),
             coverage: CoverageReport::default(),
+            authentication_profiles: Vec::new(),
             success: false,
         },
     };
     write_artifacts(&artifacts, &result).await?;
     outcome.map(|_| ())
+}
+
+async fn run_authentication_conformance(
+    executable: &str,
+    artifacts: &Path,
+) -> Result<(), Box<dyn Error>> {
+    let outcome = supervise_authentication(executable).await;
+    let profiles = outcome.as_ref().map_or_else(
+        |_| authentication_profile_results(false),
+        |()| authentication_profile_results(true),
+    );
+    let result = RunResult {
+        schema_version: 1,
+        command: "conformance".into(),
+        profile: "authentication".into(),
+        postgres_version: "14-18".into(),
+        scenario: ScenarioResult {
+            name: "authentication-matrix".into(),
+            value: i32::try_from(profiles.len())?,
+        },
+        fixtures: FixtureResult::default(),
+        data_scenarios: Vec::new(),
+        coverage: CoverageReport::default(),
+        authentication_profiles: profiles,
+        success: outcome.is_ok(),
+    };
+    write_artifacts(artifacts, &result).await?;
+    outcome
+}
+
+fn authentication_profile_results(executed: bool) -> Vec<AuthenticationProfileResult> {
+    [
+        (
+            "auth.plaintext.trust",
+            "plaintext",
+            "trust",
+            "accepted",
+            "authenticated SELECT through public intermediary",
+        ),
+        (
+            "auth.plaintext.cleartext-password",
+            "plaintext",
+            "cleartext-password",
+            "accepted",
+            "password challenge answered and SELECT validated",
+        ),
+        (
+            "auth.plaintext.md5",
+            "plaintext",
+            "md5",
+            "accepted",
+            "MD5 challenge answered and SELECT validated",
+        ),
+        (
+            "auth.plaintext.scram-sha-256",
+            "plaintext",
+            "scram-sha-256",
+            "accepted",
+            "SCRAM verifier accepted and SELECT validated",
+        ),
+        (
+            "auth.tls.scram-sha-256-plus",
+            "tls",
+            "scram-sha-256-plus",
+            "unsupported",
+            "static credentials reject a PLUS-only offer because channel binding is unavailable",
+        ),
+        (
+            "auth.tls.negotiation",
+            "tls",
+            "trust",
+            "accepted",
+            "TLS negotiation completed before startup",
+        ),
+        (
+            "auth.tls.rejection",
+            "plaintext",
+            "trust",
+            "rejected",
+            "required TLS rejects a plaintext-only server",
+        ),
+    ]
+    .into_iter()
+    .map(
+        |(id, tls_mode, auth_method, expected_outcome, evidence)| AuthenticationProfileResult {
+            id: id.into(),
+            postgres_versions: "14-18".into(),
+            tls_mode: tls_mode.into(),
+            auth_method: auth_method.into(),
+            expected_outcome: expected_outcome.into(),
+            evidence: if executed || expected_outcome == "unsupported" {
+                evidence.into()
+            } else {
+                "profile did not complete".into()
+            },
+        },
+    )
+    .collect()
+}
+
+async fn supervise_authentication(executable: &str) -> Result<(), Box<dyn Error>> {
+    run_password_profile(executable, "trust", None).await?;
+    run_password_profile(executable, "password", Some("postgres")).await?;
+    run_password_profile(executable, "md5", Some("postgres")).await?;
+    run_password_profile(executable, "scram-sha-256", Some("postgres")).await?;
+    Ok(())
+}
+
+async fn run_password_profile(
+    executable: &str,
+    host_auth: &str,
+    password: Option<&str>,
+) -> Result<(), Box<dyn Error>> {
+    let image = if host_auth == "trust" {
+        Postgres::default().with_host_auth().with_tag("18-alpine")
+    } else {
+        Postgres::default()
+            .with_password(password.expect("password authentication requires a password"))
+            .with_tag("18-alpine")
+            .with_env_var("POSTGRES_HOST_AUTH_METHOD", host_auth)
+    };
+    let container = image.start().await?;
+    let upstream = SocketAddr::new(
+        IpAddr::V4(Ipv4Addr::LOCALHOST),
+        container.get_host_port_ipv4(5432).await?,
+    );
+    let mut intermediary =
+        spawn_authenticated_child(executable, "intermediary-child", upstream, password).await?;
+    let ChildEvent::Ready { listen_addr, .. } = read_event(&mut intermediary).await? else {
+        return Err("expected intermediary ready event".into());
+    };
+    let mut driver =
+        spawn_authenticated_child(executable, "driver-child", listen_addr, password).await?;
+    let ChildEvent::Completed {
+        value: Some(42), ..
+    } = read_event(&mut driver).await?
+    else {
+        return Err(format!("{host_auth} driver did not validate SELECT").into());
+    };
+    wait_success(&mut driver, "driver").await?;
+    let ChildEvent::Completed { .. } = read_event(&mut intermediary).await? else {
+        return Err(format!("{host_auth} intermediary did not complete").into());
+    };
+    wait_success(&mut intermediary, "intermediary").await?;
+    drop(container);
+    Ok(())
 }
 
 async fn supervise_smoke(
@@ -305,6 +473,23 @@ async fn spawn_child(
         .spawn()?)
 }
 
+async fn spawn_authenticated_child(
+    executable: &str,
+    role: &str,
+    address: SocketAddr,
+    password: Option<&str>,
+) -> Result<Child, Box<dyn Error>> {
+    let mut command = Command::new(executable);
+    command.args([role, "--address", &address.to_string()]);
+    if let Some(password) = password {
+        command.args(["--password", password]);
+    }
+    Ok(command
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()?)
+}
+
 async fn read_event(child: &mut Child) -> Result<ChildEvent, Box<dyn Error>> {
     let stdout = child.stdout.as_mut().ok_or("child stdout unavailable")?;
     let mut line = String::new();
@@ -380,6 +565,9 @@ impl StartupRouteResolver<SocketAddr> for Route {
 
 async fn run_intermediary_child(arguments: &[String]) -> Result<(), Box<dyn Error>> {
     let upstream: SocketAddr = option(arguments, "--address")?.parse()?;
+    if let Ok(password) = option(arguments, "--password") {
+        return run_credential_intermediary(upstream, password).await;
+    }
     let server = Server::builder()
         .tls(ServerTlsPolicy::Disabled)
         .authentication(TrustServerAuthentication)
@@ -439,6 +627,71 @@ async fn run_intermediary_child(arguments: &[String]) -> Result<(), Box<dyn Erro
     .await
 }
 
+async fn run_credential_intermediary(
+    upstream: SocketAddr,
+    password: &str,
+) -> Result<(), Box<dyn Error>> {
+    let server = Server::builder()
+        .tls(ServerTlsPolicy::Disabled)
+        .authentication(TrustServerAuthentication)
+        .build()
+        .map_err(debug_error)?;
+    let client = Client::builder()
+        .connector(move |_| TcpStream::connect(upstream))
+        .tls(ClientTlsPolicy::Disabled)
+        .authentication(StaticClientCredentials::new(
+            "postgres",
+            password.to_owned(),
+        ))
+        .build()
+        .map_err(debug_error)?;
+    let intermediary = Intermediary::builder()
+        .server(server)
+        .client(client)
+        .startup_resolver(Route(upstream))
+        .cancellation(CancellationPolicy::Reject)
+        .pipeline(BoundedPipeline::new(64).expect("non-zero authentication pipeline capacity"))
+        .middleware(
+            |_: &ServerConnectionContext<SocketAddr, TrustIdentity>,
+             _: &ClientConnectionContext<()>| CoverageObserver,
+        )
+        .build()
+        .map_err(debug_error)?;
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await?;
+    write_event(&ChildEvent::Ready {
+        version: 1,
+        listen_addr: listener.local_addr()?,
+    })
+    .await?;
+    let (transport, peer) = listener.accept().await?;
+    let mut session = Box::pin(intermediary.accept(transport, peer, CoverageState::default()))
+        .await
+        .map_err(debug_error)?
+        .into_session();
+    let coverage = loop {
+        match session.forward_next().await {
+            Ok(ForwardedMessage::Frontend(FrontendMessage::Terminate)) => {
+                let (_, _, state, ..) = session.teardown();
+                break state.0;
+            }
+            Ok(_) => {}
+            Err(error) => {
+                let message = format!("intermediary forwarding failed: {error:?}");
+                let _transports = session.teardown();
+                return Err(message.into());
+            }
+        }
+    };
+    write_event(&ChildEvent::Completed {
+        version: 1,
+        value: None,
+        coverage: coverage.into_iter().collect(),
+        fixtures: None,
+        data_scenarios: Vec::new(),
+    })
+    .await
+}
+
 async fn run_driver_child(arguments: &[String]) -> Result<(), Box<dyn Error>> {
     let proxy: SocketAddr = option(arguments, "--address")?.parse()?;
     let mut config = tokio_postgres::Config::new();
@@ -447,6 +700,9 @@ async fn run_driver_child(arguments: &[String]) -> Result<(), Box<dyn Error>> {
         .port(proxy.port())
         .user("postgres")
         .dbname("postgres");
+    if let Ok(password) = option(arguments, "--password") {
+        config.password(password);
+    }
     let (client, connection) = config.connect(tokio_postgres::NoTls).await?;
     let connection_task = tokio::spawn(connection);
     let value: i32 = client.query_one("SELECT 42::int4", &[]).await?.get(0);
@@ -725,7 +981,10 @@ fn debug_error(error: impl std::fmt::Debug) -> io::Error {
 
 #[cfg(test)]
 mod tests {
-    use super::{REQUIRED_SMOKE_COVERAGE, REQUIRED_SMOKE_STAGES, coverage_report};
+    use super::{
+        REQUIRED_SMOKE_COVERAGE, REQUIRED_SMOKE_STAGES, authentication_profile_results,
+        coverage_report,
+    };
 
     #[test]
     fn required_smoke_coverage_is_stable_and_complete() {
@@ -743,5 +1002,18 @@ mod tests {
         observed.push("backend.Renamed.WithoutMigration".into());
         let error = coverage_report(&observed).expect_err("unknown ID must fail");
         assert!(error.to_string().contains("unknown required coverage IDs"));
+    }
+
+    #[test]
+    fn authentication_catalogue_has_stable_version_scoped_profiles() {
+        let profiles = authentication_profile_results(true);
+        assert_eq!(profiles.len(), 7);
+        assert!(
+            profiles
+                .iter()
+                .all(|profile| profile.postgres_versions == "14-18")
+        );
+        assert_eq!(profiles[0].id, "auth.plaintext.trust");
+        assert_eq!(profiles[6].id, "auth.tls.rejection");
     }
 }

--- a/pg-proto-burn-in/src/lib.rs
+++ b/pg-proto-burn-in/src/lib.rs
@@ -8,6 +8,7 @@ use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
     path::{Path, PathBuf},
     process::Stdio,
+    sync::Arc,
     time::Duration,
 };
 
@@ -64,6 +65,7 @@ struct RunResult {
     fixtures: FixtureResult,
     data_scenarios: Vec<DataScenarioResult>,
     query_lifecycle: Vec<QueryLifecycleResult>,
+    error_scenarios: Vec<SqlErrorScenarioResult>,
     coverage: CoverageReport,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     authentication_profiles: Vec<AuthenticationProfileResult>,
@@ -111,6 +113,15 @@ struct QueryLifecycleResult {
     validated: bool,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct SqlErrorScenarioResult {
+    name: String,
+    expected_sqlstate: String,
+    actual_sqlstate: String,
+    protocol_ready: bool,
+    connection_clean: bool,
+}
+
 #[derive(Debug, Default, Serialize, Deserialize)]
 struct CoverageReport {
     observed_ids: Vec<String>,
@@ -139,6 +150,8 @@ enum ChildEvent {
         data_scenarios: Vec<DataScenarioResult>,
         #[serde(default)]
         query_lifecycle: Vec<QueryLifecycleResult>,
+        #[serde(default)]
+        error_scenarios: Vec<SqlErrorScenarioResult>,
     },
 }
 
@@ -161,6 +174,7 @@ async fn run_conformance(arguments: &[String]) -> Result<(), Box<dyn Error>> {
             fixtures: FixtureResult::default(),
             data_scenarios: Vec::new(),
             query_lifecycle: Vec::new(),
+            error_scenarios: Vec::new(),
             coverage: CoverageReport {
                 observed_ids: coverage.clone(),
                 scripted: coverage,
@@ -184,22 +198,25 @@ async fn run_conformance(arguments: &[String]) -> Result<(), Box<dyn Error>> {
 
     let outcome = supervise_smoke(arguments.first().ok_or("missing executable path")?).await;
     let result = match &outcome {
-        Ok((value, coverage, fixtures, data_scenarios, query_lifecycle)) => RunResult {
-            schema_version: 1,
-            command: "conformance".into(),
-            profile: profile.into(),
-            postgres_version: "18".into(),
-            scenario: ScenarioResult {
-                name: "extended-select-scalar".into(),
-                value: *value,
-            },
-            fixtures: fixtures.clone(),
-            data_scenarios: data_scenarios.clone(),
-            query_lifecycle: query_lifecycle.clone(),
-            coverage: coverage_report(coverage)?,
-            authentication_profiles: Vec::new(),
-            success: true,
-        },
+        Ok((value, coverage, fixtures, data_scenarios, query_lifecycle, error_scenarios)) => {
+            RunResult {
+                schema_version: 1,
+                command: "conformance".into(),
+                profile: profile.into(),
+                postgres_version: "18".into(),
+                scenario: ScenarioResult {
+                    name: "extended-select-scalar".into(),
+                    value: *value,
+                },
+                fixtures: fixtures.clone(),
+                data_scenarios: data_scenarios.clone(),
+                query_lifecycle: query_lifecycle.clone(),
+                error_scenarios: error_scenarios.clone(),
+                coverage: coverage_report(coverage)?,
+                authentication_profiles: Vec::new(),
+                success: true,
+            }
+        }
         Err(_) => RunResult {
             schema_version: 1,
             command: "conformance".into(),
@@ -212,6 +229,7 @@ async fn run_conformance(arguments: &[String]) -> Result<(), Box<dyn Error>> {
             fixtures: FixtureResult::default(),
             data_scenarios: Vec::new(),
             query_lifecycle: Vec::new(),
+            error_scenarios: Vec::new(),
             coverage: CoverageReport::default(),
             authentication_profiles: Vec::new(),
             success: false,
@@ -242,6 +260,7 @@ async fn run_authentication_conformance(
         fixtures: FixtureResult::default(),
         data_scenarios: Vec::new(),
         query_lifecycle: Vec::new(),
+        error_scenarios: Vec::new(),
         coverage: CoverageReport::default(),
         authentication_profiles: profiles,
         success: outcome.is_ok(),
@@ -493,6 +512,7 @@ async fn supervise_smoke(
         FixtureResult,
         Vec<DataScenarioResult>,
         Vec<QueryLifecycleResult>,
+        Vec<SqlErrorScenarioResult>,
     ),
     Box<dyn Error>,
 > {
@@ -506,7 +526,17 @@ async fn supervise_smoke(
         container.get_host_port_ipv4(5432).await?,
     );
 
-    let mut intermediary = spawn_child(executable, "intermediary-child", upstream).await?;
+    let mut intermediary = Command::new(executable)
+        .args([
+            "intermediary-child",
+            "--address",
+            &upstream.to_string(),
+            "--connections",
+            "3",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()?;
     let ready = read_event(&mut intermediary).await?;
     let listen_addr = match ready {
         ChildEvent::Ready { listen_addr, .. } => listen_addr,
@@ -515,17 +545,26 @@ async fn supervise_smoke(
 
     let mut driver = spawn_child(executable, "driver-child", listen_addr).await?;
     let completed = read_event(&mut driver).await?;
-    let (value, mut coverage, fixtures, data_scenarios, query_lifecycle) = match completed {
-        ChildEvent::Completed {
-            value: Some(value),
-            coverage,
-            fixtures: Some(fixtures),
-            data_scenarios,
-            query_lifecycle,
-            ..
-        } => (value, coverage, fixtures, data_scenarios, query_lifecycle),
-        event => return Err(format!("expected driver completion event, got {event:?}").into()),
-    };
+    let (value, mut coverage, fixtures, data_scenarios, query_lifecycle, error_scenarios) =
+        match completed {
+            ChildEvent::Completed {
+                value: Some(value),
+                coverage,
+                fixtures: Some(fixtures),
+                data_scenarios,
+                query_lifecycle,
+                error_scenarios,
+                ..
+            } => (
+                value,
+                coverage,
+                fixtures,
+                data_scenarios,
+                query_lifecycle,
+                error_scenarios,
+            ),
+            event => return Err(format!("expected driver completion event, got {event:?}").into()),
+        };
     wait_success(&mut driver, "driver").await?;
     let intermediary_completed = read_event(&mut intermediary).await?;
     let ChildEvent::Completed {
@@ -538,7 +577,14 @@ async fn supervise_smoke(
     coverage.extend(intermediary_coverage);
     wait_success(&mut intermediary, "intermediary").await?;
     drop(container);
-    Ok((value, coverage, fixtures, data_scenarios, query_lifecycle))
+    Ok((
+        value,
+        coverage,
+        fixtures,
+        data_scenarios,
+        query_lifecycle,
+        error_scenarios,
+    ))
 }
 
 const REQUIRED_SMOKE_STAGES: [&str; 7] = [
@@ -551,8 +597,9 @@ const REQUIRED_SMOKE_STAGES: [&str; 7] = [
     "smoke.extended-select.driver-validated",
 ];
 
-const REQUIRED_SMOKE_COVERAGE: [&str; 23] = [
+const REQUIRED_SMOKE_COVERAGE: [&str; 28] = [
     "backend.BindResponse.Complete",
+    "backend.BindResponse.Error",
     "backend.Building.Bind",
     "backend.Building.Describe",
     "backend.Building.Execute",
@@ -563,9 +610,11 @@ const REQUIRED_SMOKE_COVERAGE: [&str; 23] = [
     "backend.DescribeResponse.RowDescription",
     "backend.ExecuteResponse.CommandComplete",
     "backend.ExecuteResponse.Continue",
+    "backend.ExecuteResponse.Error",
     "backend.ExecuteResponse.PortalSuspended",
     "backend.Building.Flush",
     "backend.ParseResponse.Complete",
+    "backend.ParseResponse.Error",
     "backend.Ready.Bind",
     "backend.Ready.Close",
     "backend.Ready.Execute",
@@ -573,6 +622,8 @@ const REQUIRED_SMOKE_COVERAGE: [&str; 23] = [
     "backend.Ready.Terminate",
     "backend.Ready.Query",
     "backend.Simple.Continue",
+    "backend.Simple.Error",
+    "backend.SimpleError.Ready",
     "backend.Simple.Ready",
     "backend.SyncResponse.Ready",
 ];
@@ -731,6 +782,9 @@ impl StartupRouteResolver<SocketAddr> for Route {
 
 async fn run_intermediary_child(arguments: &[String]) -> Result<(), Box<dyn Error>> {
     let upstream: SocketAddr = option(arguments, "--address")?.parse()?;
+    let connection_count = option(arguments, "--connections")
+        .unwrap_or("1")
+        .parse::<usize>()?;
     if let Ok(password) = option(arguments, "--password") {
         if let Ok(root) = option(arguments, "--tls-root") {
             return run_tls_credential_intermediary(upstream, password, root).await;
@@ -748,18 +802,20 @@ async fn run_intermediary_child(arguments: &[String]) -> Result<(), Box<dyn Erro
         .authentication(TrustClientAuthentication)
         .build()
         .map_err(debug_error)?;
-    let intermediary = Intermediary::builder()
-        .server(server)
-        .client(client)
-        .startup_resolver(Route(upstream))
-        .cancellation(CancellationPolicy::Reject)
-        .pipeline(BoundedPipeline::new(64).expect("non-zero smoke pipeline capacity"))
-        .middleware(
-            |_: &ServerConnectionContext<SocketAddr, TrustIdentity>,
-             _: &ClientConnectionContext<()>| CoverageObserver,
-        )
-        .build()
-        .map_err(debug_error)?;
+    let intermediary = Arc::new(
+        Intermediary::builder()
+            .server(server)
+            .client(client)
+            .startup_resolver(Route(upstream))
+            .cancellation(CancellationPolicy::Reject)
+            .pipeline(BoundedPipeline::new(64).expect("non-zero smoke pipeline capacity"))
+            .middleware(
+                |_: &ServerConnectionContext<SocketAddr, TrustIdentity>,
+                 _: &ClientConnectionContext<()>| CoverageObserver,
+            )
+            .build()
+            .map_err(debug_error)?,
+    );
 
     let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await?;
     write_event(&ChildEvent::Ready {
@@ -767,28 +823,35 @@ async fn run_intermediary_child(arguments: &[String]) -> Result<(), Box<dyn Erro
         listen_addr: listener.local_addr()?,
     })
     .await?;
-    let mut coverage = BTreeSet::new();
-    for _ in 0..2 {
+    let mut sessions = tokio::task::JoinSet::new();
+    for _ in 0..connection_count {
         let (transport, peer) = listener.accept().await?;
-        let mut session = Box::pin(intermediary.accept(transport, peer, CoverageState::default()))
-            .await
-            .map_err(debug_error)?
-            .into_session();
-        loop {
-            match session.forward_next().await {
-                Ok(ForwardedMessage::Frontend(FrontendMessage::Terminate)) => {
-                    let (_, _, state, ..) = session.teardown();
-                    coverage.extend(state.0);
-                    break;
-                }
-                Ok(_) => {}
-                Err(error) => {
-                    let message = format!("intermediary forwarding failed: {error:?}");
-                    let _transports = session.teardown();
-                    return Err(message.into());
+        let intermediary = Arc::clone(&intermediary);
+        sessions.spawn(async move {
+            let mut session =
+                Box::pin(intermediary.accept(transport, peer, CoverageState::default()))
+                    .await
+                    .map_err(debug_error)?
+                    .into_session();
+            loop {
+                match session.forward_next().await {
+                    Ok(ForwardedMessage::Frontend(FrontendMessage::Terminate)) => {
+                        let (_, _, state, ..) = session.teardown();
+                        return Ok::<_, io::Error>(state.0);
+                    }
+                    Ok(_) => {}
+                    Err(error) => {
+                        let message = format!("intermediary forwarding failed: {error:?}");
+                        let _transports = session.teardown();
+                        return Err(io::Error::other(message));
+                    }
                 }
             }
-        }
+        });
+    }
+    let mut coverage = BTreeSet::new();
+    while let Some(result) = sessions.join_next().await {
+        coverage.extend(result??);
     }
     write_event(&ChildEvent::Completed {
         version: 1,
@@ -797,6 +860,7 @@ async fn run_intermediary_child(arguments: &[String]) -> Result<(), Box<dyn Erro
         fixtures: None,
         data_scenarios: Vec::new(),
         query_lifecycle: Vec::new(),
+        error_scenarios: Vec::new(),
     })
     .await
 }
@@ -871,6 +935,7 @@ async fn run_tls_credential_intermediary(
         fixtures: None,
         data_scenarios: Vec::new(),
         query_lifecycle: Vec::new(),
+        error_scenarios: Vec::new(),
     })
     .await
 }
@@ -937,6 +1002,7 @@ async fn run_credential_intermediary(
         fixtures: None,
         data_scenarios: Vec::new(),
         query_lifecycle: Vec::new(),
+        error_scenarios: Vec::new(),
     })
     .await
 }
@@ -961,6 +1027,7 @@ async fn run_driver_child(arguments: &[String]) -> Result<(), Box<dyn Error>> {
     let fixtures = install_and_verify_fixtures(&client).await?;
     let data_scenarios = run_data_scenarios(&client).await?;
     let mut query_lifecycle = run_query_lifecycles(&mut client).await?;
+    let error_scenarios = run_sql_error_scenarios(&mut client, proxy).await?;
     drop(client);
     timeout(CHILD_TIMEOUT, connection_task).await???;
     query_lifecycle.push(run_flush_lifecycle(proxy).await?);
@@ -974,8 +1041,250 @@ async fn run_driver_child(arguments: &[String]) -> Result<(), Box<dyn Error>> {
         fixtures: Some(fixtures),
         data_scenarios,
         query_lifecycle,
+        error_scenarios,
     })
     .await
+}
+
+async fn run_sql_error_scenarios(
+    client: &mut tokio_postgres::Client,
+    proxy: SocketAddr,
+) -> Result<Vec<SqlErrorScenarioResult>, Box<dyn Error>> {
+    let mut outcomes = Vec::new();
+
+    for (name, sql, expected) in [
+        ("syntax", "SELEC 1", "42601"),
+        (
+            "missing-table",
+            "SELECT * FROM burnin_table_that_does_not_exist",
+            "42P01",
+        ),
+        ("type", "SELECT TRUE + 1", "42883"),
+        ("arithmetic", "SELECT 1 / 0", "22012"),
+    ] {
+        let error = client
+            .batch_execute(sql)
+            .await
+            .expect_err("error scenario unexpectedly succeeded");
+        outcomes.push(error_outcome(client, name, expected, &error).await?);
+    }
+
+    client
+        .batch_execute(
+            "CREATE TEMP TABLE burnin_constraint_error (id integer PRIMARY KEY); \
+             INSERT INTO burnin_constraint_error VALUES (1)",
+        )
+        .await?;
+    let constraint = client
+        .execute("INSERT INTO burnin_constraint_error VALUES (1)", &[])
+        .await
+        .expect_err("duplicate key unexpectedly succeeded");
+    client
+        .batch_execute("DROP TABLE burnin_constraint_error")
+        .await?;
+    outcomes.push(error_outcome(client, "constraint", "23505", &constraint).await?);
+
+    client
+        .batch_execute(
+            "CREATE ROLE burnin_no_access; \
+             CREATE TABLE burnin_permission_error (id integer); \
+             SET ROLE burnin_no_access",
+        )
+        .await?;
+    let permission = client
+        .query("SELECT * FROM burnin_permission_error", &[])
+        .await
+        .expect_err("unprivileged query unexpectedly succeeded");
+    client
+        .batch_execute("RESET ROLE; DROP TABLE burnin_permission_error; DROP ROLE burnin_no_access")
+        .await?;
+    outcomes.push(error_outcome(client, "permission", "42501", &permission).await?);
+
+    let transaction = client.transaction().await?;
+    transaction
+        .batch_execute("SELECT 1 / 0")
+        .await
+        .expect_err("transaction arithmetic error unexpectedly succeeded");
+    let aborted = transaction
+        .query("SELECT 1", &[])
+        .await
+        .expect_err("failed transaction unexpectedly accepted a query");
+    transaction.rollback().await?;
+    outcomes.push(error_outcome(client, "failed-transaction", "25P02", &aborted).await?);
+
+    client
+        .batch_execute("SET statement_timeout = '25ms'")
+        .await?;
+    let timed_out = client
+        .query("SELECT pg_sleep(0.2)", &[])
+        .await
+        .expect_err("timed statement unexpectedly completed");
+    client.batch_execute("RESET statement_timeout").await?;
+    outcomes.push(error_outcome(client, "timeout", "57014", &timed_out).await?);
+
+    let (mut other, other_connection) = connect_driver(proxy).await?;
+    let other_task = tokio::spawn(other_connection);
+
+    client
+        .batch_execute(
+            "CREATE TABLE burnin_serialization_error (id integer PRIMARY KEY, value integer); \
+             INSERT INTO burnin_serialization_error VALUES (1, 0)",
+        )
+        .await?;
+    let first = client.transaction().await?;
+    let second = other.transaction().await?;
+    first
+        .batch_execute("SET TRANSACTION ISOLATION LEVEL SERIALIZABLE")
+        .await?;
+    second
+        .batch_execute("SET TRANSACTION ISOLATION LEVEL SERIALIZABLE")
+        .await?;
+    first
+        .query_one(
+            "SELECT value FROM burnin_serialization_error WHERE id = 1",
+            &[],
+        )
+        .await?;
+    second
+        .query_one(
+            "SELECT value FROM burnin_serialization_error WHERE id = 1",
+            &[],
+        )
+        .await?;
+    first
+        .execute(
+            "UPDATE burnin_serialization_error SET value = value + 1 WHERE id = 1",
+            &[],
+        )
+        .await?;
+    first.commit().await?;
+    let serialization = second
+        .execute(
+            "UPDATE burnin_serialization_error SET value = value + 1 WHERE id = 1",
+            &[],
+        )
+        .await
+        .expect_err("serialization conflict unexpectedly succeeded");
+    second.rollback().await?;
+    client
+        .batch_execute("DROP TABLE burnin_serialization_error")
+        .await?;
+    outcomes.push(error_outcome(client, "serialization", "40001", &serialization).await?);
+
+    client
+        .batch_execute(
+            "SET deadlock_timeout = '25ms'; \
+             CREATE TABLE burnin_deadlock_error (id integer PRIMARY KEY); \
+             INSERT INTO burnin_deadlock_error VALUES (1), (2)",
+        )
+        .await?;
+    let first = client.transaction().await?;
+    let second = other.transaction().await?;
+    first
+        .execute(
+            "SELECT id FROM burnin_deadlock_error WHERE id = 1 FOR UPDATE",
+            &[],
+        )
+        .await?;
+    second
+        .execute(
+            "SELECT id FROM burnin_deadlock_error WHERE id = 2 FOR UPDATE",
+            &[],
+        )
+        .await?;
+    let (left, right) = tokio::join!(
+        first.execute("UPDATE burnin_deadlock_error SET id = id WHERE id = 2", &[]),
+        second.execute("UPDATE burnin_deadlock_error SET id = id WHERE id = 1", &[]),
+    );
+    let deadlock = left
+        .err()
+        .or_else(|| right.err())
+        .ok_or("deadlock unexpectedly succeeded")?;
+    first.rollback().await?;
+    second.rollback().await?;
+    client
+        .batch_execute("RESET deadlock_timeout; DROP TABLE burnin_deadlock_error")
+        .await?;
+    outcomes.push(error_outcome(client, "deadlock", "40P01", &deadlock).await?);
+
+    client
+        .batch_execute(
+            "CREATE TABLE burnin_prepare_error (value integer); \
+             INSERT INTO burnin_prepare_error VALUES (1)",
+        )
+        .await?;
+    let statement = client
+        .prepare("SELECT value FROM burnin_prepare_error")
+        .await?;
+    other
+        .batch_execute("ALTER TABLE burnin_prepare_error ALTER COLUMN value TYPE bigint")
+        .await?;
+    let invalidated = client
+        .query(&statement, &[])
+        .await
+        .expect_err("invalidated prepared result unexpectedly succeeded");
+    drop(statement);
+    client
+        .batch_execute("DROP TABLE burnin_prepare_error")
+        .await?;
+    outcomes.push(error_outcome(client, "invalidated-prepare", "0A000", &invalidated).await?);
+
+    drop(other);
+    timeout(CHILD_TIMEOUT, other_task).await???;
+    Ok(outcomes)
+}
+
+async fn connect_driver(
+    proxy: SocketAddr,
+) -> Result<
+    (
+        tokio_postgres::Client,
+        tokio_postgres::Connection<tokio_postgres::Socket, tokio_postgres::tls::NoTlsStream>,
+    ),
+    tokio_postgres::Error,
+> {
+    let mut config = tokio_postgres::Config::new();
+    config
+        .host(proxy.ip().to_string())
+        .port(proxy.port())
+        .user("postgres")
+        .dbname("postgres");
+    config.connect(tokio_postgres::NoTls).await
+}
+
+async fn error_outcome(
+    client: &tokio_postgres::Client,
+    name: &str,
+    expected: &str,
+    error: &tokio_postgres::Error,
+) -> Result<SqlErrorScenarioResult, Box<dyn Error>> {
+    let actual = error
+        .as_db_error()
+        .ok_or_else(|| format!("{name} did not return a PostgreSQL error"))?
+        .code()
+        .code();
+    if actual != expected {
+        return Err(format!("{name} returned SQLSTATE {actual}, expected {expected}").into());
+    }
+    let protocol_ready = client
+        .query_one("SELECT 1::int4", &[])
+        .await?
+        .get::<_, i32>(0)
+        == 1;
+    let connection_clean = client
+        .query_one(
+            "SELECT current_user = 'postgres' AND current_setting('statement_timeout') = '0'",
+            &[],
+        )
+        .await?
+        .get(0);
+    Ok(SqlErrorScenarioResult {
+        name: name.into(),
+        expected_sqlstate: expected.into(),
+        actual_sqlstate: actual.into(),
+        protocol_ready,
+        connection_clean,
+    })
 }
 
 async fn run_query_lifecycles(
@@ -1393,7 +1702,7 @@ mod tests {
         let mut observed: Vec<_> = REQUIRED_SMOKE_COVERAGE.map(str::to_owned).into();
         observed.extend(REQUIRED_SMOKE_STAGES.map(str::to_owned));
         let report = coverage_report(&observed).expect("complete known coverage");
-        assert_eq!(report.observed_ids.len(), 23);
+        assert_eq!(report.observed_ids.len(), 28);
         assert!(report.missing.is_empty());
     }
 

--- a/pg-proto-burn-in/src/lib.rs
+++ b/pg-proto-burn-in/src/lib.rs
@@ -12,8 +12,8 @@ use std::{
     time::Duration,
 };
 
-use bytes::{BufMut, BytesMut};
-use futures_util::TryStreamExt;
+use bytes::{BufMut, Bytes, BytesMut};
+use futures_util::{SinkExt, TryStreamExt};
 use pg_proto::{
     BackendMessage, BackendMiddlewareOutput, BoundedPipeline, CancelKey, CancellationPolicy,
     CancellationRoute, Client, ClientConnectionContext, ClientTlsConfig, ClientTlsPolicy,
@@ -67,6 +67,8 @@ struct RunResult {
     data_scenarios: Vec<DataScenarioResult>,
     query_lifecycle: Vec<QueryLifecycleResult>,
     error_scenarios: Vec<SqlErrorScenarioResult>,
+    #[serde(default)]
+    copy_scenarios: Vec<CopyScenarioResult>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     async_traffic: Option<AsyncTrafficResult>,
     coverage: CoverageReport,
@@ -141,6 +143,19 @@ struct ParameterStatusResult {
     value: String,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct CopyScenarioResult {
+    name: String,
+    direction: String,
+    payload_bytes: u64,
+    chunks: u64,
+    completed: bool,
+    aborted: bool,
+    failed: bool,
+    recovered: bool,
+    validated: bool,
+}
+
 #[derive(Debug, Default, Serialize, Deserialize)]
 struct CoverageReport {
     observed_ids: Vec<String>,
@@ -172,6 +187,8 @@ enum ChildEvent {
         #[serde(default)]
         error_scenarios: Vec<SqlErrorScenarioResult>,
         #[serde(default)]
+        copy_scenarios: Vec<CopyScenarioResult>,
+        #[serde(default)]
         async_traffic: Option<Box<AsyncTrafficResult>>,
     },
 }
@@ -196,6 +213,7 @@ async fn run_conformance(arguments: &[String]) -> Result<(), Box<dyn Error>> {
             data_scenarios: Vec::new(),
             query_lifecycle: Vec::new(),
             error_scenarios: Vec::new(),
+            copy_scenarios: Vec::new(),
             async_traffic: None,
             coverage: CoverageReport {
                 observed_ids: coverage.clone(),
@@ -227,6 +245,7 @@ async fn run_conformance(arguments: &[String]) -> Result<(), Box<dyn Error>> {
             data_scenarios,
             query_lifecycle,
             error_scenarios,
+            copy_scenarios,
             async_traffic,
         )) => RunResult {
             schema_version: 1,
@@ -241,6 +260,7 @@ async fn run_conformance(arguments: &[String]) -> Result<(), Box<dyn Error>> {
             data_scenarios: data_scenarios.clone(),
             query_lifecycle: query_lifecycle.clone(),
             error_scenarios: error_scenarios.clone(),
+            copy_scenarios: copy_scenarios.clone(),
             async_traffic: Some(async_traffic.clone()),
             coverage: coverage_report(coverage)?,
             authentication_profiles: Vec::new(),
@@ -259,6 +279,7 @@ async fn run_conformance(arguments: &[String]) -> Result<(), Box<dyn Error>> {
             data_scenarios: Vec::new(),
             query_lifecycle: Vec::new(),
             error_scenarios: Vec::new(),
+            copy_scenarios: Vec::new(),
             async_traffic: None,
             coverage: CoverageReport::default(),
             authentication_profiles: Vec::new(),
@@ -291,6 +312,7 @@ async fn run_authentication_conformance(
         data_scenarios: Vec::new(),
         query_lifecycle: Vec::new(),
         error_scenarios: Vec::new(),
+        copy_scenarios: Vec::new(),
         async_traffic: None,
         coverage: CoverageReport::default(),
         authentication_profiles: profiles,
@@ -544,6 +566,7 @@ async fn supervise_smoke(
         Vec<DataScenarioResult>,
         Vec<QueryLifecycleResult>,
         Vec<SqlErrorScenarioResult>,
+        Vec<CopyScenarioResult>,
         AsyncTrafficResult,
     ),
     Box<dyn Error>,
@@ -564,7 +587,7 @@ async fn supervise_smoke(
             "--address",
             &upstream.to_string(),
             "--connections",
-            "3",
+            "4",
         ])
         .stdout(Stdio::piped())
         .stderr(Stdio::inherit())
@@ -594,6 +617,7 @@ async fn supervise_smoke(
         data_scenarios,
         query_lifecycle,
         error_scenarios,
+        copy_scenarios,
         mut async_traffic,
     ) = match completed {
         ChildEvent::Completed {
@@ -603,6 +627,7 @@ async fn supervise_smoke(
             data_scenarios,
             query_lifecycle,
             error_scenarios,
+            copy_scenarios,
             async_traffic: Some(async_traffic),
             ..
         } => (
@@ -612,6 +637,7 @@ async fn supervise_smoke(
             data_scenarios,
             query_lifecycle,
             error_scenarios,
+            copy_scenarios,
             *async_traffic,
         ),
         event => return Err(format!("expected driver completion event, got {event:?}").into()),
@@ -640,6 +666,7 @@ async fn supervise_smoke(
         data_scenarios,
         query_lifecycle,
         error_scenarios,
+        copy_scenarios,
         async_traffic,
     ))
 }
@@ -669,7 +696,7 @@ const REQUIRED_SMOKE_STAGES: [&str; 7] = [
     "smoke.extended-select.driver-validated",
 ];
 
-const REQUIRED_SMOKE_COVERAGE: [&str; 28] = [
+const REQUIRED_SMOKE_COVERAGE: [&str; 37] = [
     "backend.BindResponse.Complete",
     "backend.BindResponse.Error",
     "backend.Building.Bind",
@@ -682,8 +709,17 @@ const REQUIRED_SMOKE_COVERAGE: [&str; 28] = [
     "backend.DescribeResponse.RowDescription",
     "backend.ExecuteResponse.CommandComplete",
     "backend.ExecuteResponse.Continue",
+    "backend.ExecuteResponse.CopyIn",
+    "backend.ExecuteResponse.CopyOut",
     "backend.ExecuteResponse.Error",
     "backend.ExecuteResponse.PortalSuspended",
+    "backend.ExtendedCopyIn.Data",
+    "backend.ExtendedCopyIn.Done",
+    "backend.ExtendedCopyInDone.CommandComplete",
+    "backend.ExtendedCopyInDone.Error",
+    "backend.ExtendedCopyOut.Data",
+    "backend.ExtendedCopyOut.Done",
+    "backend.ExtendedCopyOutDone.CommandComplete",
     "backend.Building.Flush",
     "backend.ParseResponse.Complete",
     "backend.ParseResponse.Error",
@@ -1022,6 +1058,7 @@ async fn run_intermediary_child(arguments: &[String]) -> Result<(), Box<dyn Erro
         data_scenarios: Vec::new(),
         query_lifecycle: Vec::new(),
         error_scenarios: Vec::new(),
+        copy_scenarios: Vec::new(),
         async_traffic: Some(Box::new(AsyncTrafficResult {
             parameter_status: accumulated.parameter_status.unwrap_or_default(),
             backend_key_forwarded: accumulated.causally_unattributed.contains("backend-key"),
@@ -1103,6 +1140,7 @@ async fn run_tls_credential_intermediary(
         data_scenarios: Vec::new(),
         query_lifecycle: Vec::new(),
         error_scenarios: Vec::new(),
+        copy_scenarios: Vec::new(),
         async_traffic: None,
     })
     .await
@@ -1171,6 +1209,7 @@ async fn run_credential_intermediary(
         data_scenarios: Vec::new(),
         query_lifecycle: Vec::new(),
         error_scenarios: Vec::new(),
+        copy_scenarios: Vec::new(),
         async_traffic: None,
     })
     .await
@@ -1268,6 +1307,7 @@ async fn run_driver_child(arguments: &[String]) -> Result<(), Box<dyn Error>> {
     let error_scenarios = run_sql_error_scenarios(&mut client, proxy).await?;
     drop(client);
     timeout(CHILD_TIMEOUT, connection_task).await???;
+    let copy_scenarios = run_copy_connection(proxy, option(arguments, "--password").ok()).await?;
     query_lifecycle.push(run_flush_lifecycle(proxy).await?);
     write_event(&ChildEvent::Completed {
         version: 1,
@@ -1280,9 +1320,31 @@ async fn run_driver_child(arguments: &[String]) -> Result<(), Box<dyn Error>> {
         data_scenarios,
         query_lifecycle,
         error_scenarios,
+        copy_scenarios,
         async_traffic: Some(Box::new(async_traffic)),
     })
     .await
+}
+
+async fn run_copy_connection(
+    proxy: SocketAddr,
+    password: Option<&str>,
+) -> Result<Vec<CopyScenarioResult>, Box<dyn Error>> {
+    let mut config = tokio_postgres::Config::new();
+    config
+        .host(proxy.ip().to_string())
+        .port(proxy.port())
+        .user("postgres")
+        .dbname("postgres");
+    if let Some(password) = password {
+        config.password(password);
+    }
+    let (client, connection) = config.connect(tokio_postgres::NoTls).await?;
+    let connection_task = tokio::spawn(connection);
+    let scenarios = run_copy_scenarios(&client).await?;
+    drop(client);
+    timeout(CHILD_TIMEOUT, connection_task).await???;
+    Ok(scenarios)
 }
 
 async fn run_sql_error_scenarios(
@@ -1582,6 +1644,256 @@ async fn run_query_lifecycles(
         .await?,
     );
     Ok(results)
+}
+
+async fn run_copy_scenarios(
+    client: &tokio_postgres::Client,
+) -> Result<Vec<CopyScenarioResult>, Box<dyn Error>> {
+    client
+        .batch_execute(
+            "DROP SCHEMA IF EXISTS burnin_copy CASCADE; \
+             CREATE SCHEMA burnin_copy; \
+             CREATE TABLE burnin_copy.small_values (id integer PRIMARY KEY, payload text); \
+             CREATE TABLE burnin_copy.large_values (id integer PRIMARY KEY, payload text); \
+             CREATE TABLE burnin_copy.abort_values (id integer PRIMARY KEY);",
+        )
+        .await?;
+    let small_in_statement = client
+        .prepare("COPY burnin_copy.small_values (id, payload) FROM STDIN")
+        .await?;
+    let large_in_statement = client
+        .prepare("COPY burnin_copy.large_values (id, payload) FROM STDIN")
+        .await?;
+    let abort_in_statement = client
+        .prepare("COPY burnin_copy.abort_values (id) FROM STDIN")
+        .await?;
+    let small_out_statement = client
+        .prepare("COPY (SELECT id, payload FROM burnin_copy.small_values ORDER BY id) TO STDOUT")
+        .await?;
+    let large_out_statement = client
+        .prepare("COPY (SELECT id, payload FROM burnin_copy.large_values ORDER BY id) TO STDOUT")
+        .await?;
+
+    let small = b"1\talpha\n2\tbeta\n3\t\\N\n".to_vec();
+    let small_chunks: Vec<Bytes> = small.chunks(3).map(Bytes::copy_from_slice).collect();
+    let small_rows = copy_in_chunks(client, &small_in_statement, &small_chunks, false).await?;
+    let small_valid = small_rows == 3
+        && client
+            .query_one(
+                "SELECT count(*)::bigint FROM burnin_copy.small_values \
+                 WHERE (id, payload) IN ((1, 'alpha'), (2, 'beta')) OR (id = 3 AND payload IS NULL)",
+                &[],
+            )
+            .await?
+            .get::<_, i64>(0)
+            == 3;
+    let small_recovered = copy_recovered(client).await?;
+
+    let large = deterministic_copy_payload(2_048);
+    let large_chunks: Vec<Bytes> = large.chunks(257).map(Bytes::copy_from_slice).collect();
+    let large_rows = copy_in_chunks(client, &large_in_statement, &large_chunks, true).await?;
+    let aggregate = client
+        .query_one(
+            "SELECT count(*)::bigint, sum(id)::bigint, sum(octet_length(payload))::bigint \
+             FROM burnin_copy.large_values",
+            &[],
+        )
+        .await?;
+    let expected_payload_bytes: i64 = (1..=2_048)
+        .map(|id| format!("copy-payload-{id:04}-{}", "x".repeat(id % 31)).len() as i64)
+        .sum();
+    let large_valid = large_rows == 2_048
+        && aggregate.get::<_, i64>(0) == 2_048
+        && aggregate.get::<_, i64>(1) == 2_098_176
+        && aggregate.get::<_, i64>(2) == expected_payload_bytes;
+    let large_recovered = copy_recovered(client).await?;
+
+    let failure_bytes = Bytes::from_static(b"not-an-integer\n");
+    let failure = {
+        let sink = client.copy_in::<_, Bytes>(&abort_in_statement).await?;
+        tokio::pin!(sink);
+        sink.as_mut().send(failure_bytes.clone()).await?;
+        sink.as_mut().finish().await
+    };
+    let failure_is_expected = failure
+        .as_ref()
+        .err()
+        .and_then(tokio_postgres::Error::as_db_error)
+        .is_some_and(|error| {
+            error.code() == &tokio_postgres::error::SqlState::INVALID_TEXT_REPRESENTATION
+        });
+    let failure_recovered = copy_recovered(client).await?;
+    let failed_rows = client
+        .query_one("SELECT count(*)::bigint FROM burnin_copy.abort_values", &[])
+        .await?
+        .get::<_, i64>(0);
+
+    let (small_out, small_out_chunks) = copy_out_bytes(client, &small_out_statement, false).await?;
+    let small_out_recovered = copy_recovered(client).await?;
+
+    let (large_out, large_out_chunks) = copy_out_bytes(client, &large_out_statement, true).await?;
+    let large_out_recovered = copy_recovered(client).await?;
+
+    let (early_bytes, early_chunks) = {
+        let stream = client.copy_out(&large_out_statement).await?;
+        tokio::pin!(stream);
+        let first = stream
+            .as_mut()
+            .try_next()
+            .await?
+            .ok_or("COPY OUT produced no data before abort")?;
+        (first.len() as u64, 1_u64)
+        // Dropping the response stream early exercises client-side COPY OUT abandonment.
+    };
+    let early_recovered = copy_recovered(client).await?;
+
+    Ok(vec![
+        copy_result(
+            "copy-in-small-chunked",
+            "in",
+            small.len(),
+            small_chunks.len(),
+            true,
+            false,
+            false,
+            small_recovered,
+            small_valid,
+        ),
+        copy_result(
+            "copy-in-large-backpressured",
+            "in",
+            large.len(),
+            large_chunks.len(),
+            true,
+            false,
+            false,
+            large_recovered,
+            large_valid,
+        ),
+        copy_result(
+            "copy-in-malformed-failure",
+            "in",
+            failure_bytes.len(),
+            1,
+            false,
+            false,
+            true,
+            failure_recovered,
+            failure_is_expected && failed_rows == 0,
+        ),
+        copy_result(
+            "copy-out-small",
+            "out",
+            small_out.len(),
+            small_out_chunks,
+            true,
+            false,
+            false,
+            small_out_recovered,
+            small_out == small,
+        ),
+        copy_result(
+            "copy-out-large-slow-consumer",
+            "out",
+            large_out.len(),
+            large_out_chunks,
+            true,
+            false,
+            false,
+            large_out_recovered,
+            large_out == large,
+        ),
+        copy_result(
+            "copy-out-early-abort",
+            "out",
+            early_bytes as usize,
+            early_chunks as usize,
+            false,
+            true,
+            false,
+            early_recovered,
+            early_bytes > 0,
+        ),
+    ])
+}
+
+async fn copy_in_chunks(
+    client: &tokio_postgres::Client,
+    statement: &tokio_postgres::Statement,
+    chunks: &[Bytes],
+    slow: bool,
+) -> Result<u64, Box<dyn Error>> {
+    let sink = client.copy_in::<_, Bytes>(statement).await?;
+    tokio::pin!(sink);
+    for (index, chunk) in chunks.iter().enumerate() {
+        sink.as_mut().send(chunk.clone()).await?;
+        if slow && index % 16 == 15 {
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+    }
+    Ok(sink.as_mut().finish().await?)
+}
+
+async fn copy_out_bytes(
+    client: &tokio_postgres::Client,
+    statement: &tokio_postgres::Statement,
+    slow: bool,
+) -> Result<(Vec<u8>, usize), Box<dyn Error>> {
+    let stream = client.copy_out(statement).await?;
+    tokio::pin!(stream);
+    let mut bytes = Vec::new();
+    let mut chunks = 0;
+    while let Some(chunk) = stream.as_mut().try_next().await? {
+        bytes.extend_from_slice(&chunk);
+        chunks += 1;
+        if slow {
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+    }
+    Ok((bytes, chunks))
+}
+
+fn deterministic_copy_payload(rows: usize) -> Vec<u8> {
+    let mut payload = Vec::new();
+    for id in 1..=rows {
+        payload.extend_from_slice(
+            format!("{id}\tcopy-payload-{id:04}-{}\n", "x".repeat(id % 31)).as_bytes(),
+        );
+    }
+    payload
+}
+
+async fn copy_recovered(client: &tokio_postgres::Client) -> Result<bool, Box<dyn Error>> {
+    Ok(client
+        .query_one("SELECT 1::int4", &[])
+        .await?
+        .get::<_, i32>(0)
+        == 1)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn copy_result(
+    name: &str,
+    direction: &str,
+    payload_bytes: usize,
+    chunks: usize,
+    completed: bool,
+    aborted: bool,
+    failed: bool,
+    recovered: bool,
+    validated: bool,
+) -> CopyScenarioResult {
+    CopyScenarioResult {
+        name: name.into(),
+        direction: direction.into(),
+        payload_bytes: payload_bytes as u64,
+        chunks: chunks as u64,
+        completed,
+        aborted,
+        failed,
+        recovered,
+        validated,
+    }
 }
 
 async fn lifecycle_result(
@@ -1941,7 +2253,7 @@ mod tests {
         let mut observed: Vec<_> = REQUIRED_SMOKE_COVERAGE.map(str::to_owned).into();
         observed.extend(REQUIRED_SMOKE_STAGES.map(str::to_owned));
         let report = coverage_report(&observed).expect("complete known coverage");
-        assert_eq!(report.observed_ids.len(), 28);
+        assert_eq!(report.observed_ids.len(), 37);
         assert!(report.missing.is_empty());
     }
 

--- a/pg-proto-burn-in/src/lib.rs
+++ b/pg-proto-burn-in/src/lib.rs
@@ -1,0 +1,309 @@
+//! Multi-process PostgreSQL protocol verification harness.
+
+use std::{
+    convert::Infallible,
+    error::Error,
+    io,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    path::{Path, PathBuf},
+    process::Stdio,
+    time::Duration,
+};
+
+use pg_proto::{
+    BoundedPipeline, CancellationPolicy, Client, ClientTlsPolicy, ConnectTarget, ForwardedMessage,
+    FrontendMessage, InitialServerContext, Intermediary, Server, ServerTlsPolicy,
+    StartupParameters, StartupRouteResolver, TrustClientAuthentication, TrustServerAuthentication,
+};
+use serde::{Deserialize, Serialize};
+use testcontainers_modules::{
+    postgres::Postgres,
+    testcontainers::{ImageExt, runners::AsyncRunner},
+};
+use tokio::{
+    io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
+    net::{TcpListener, TcpStream},
+    process::{Child, Command},
+    time::timeout,
+};
+
+const CHILD_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Runs the requested harness command.
+pub async fn run(arguments: Vec<String>) -> Result<(), Box<dyn Error>> {
+    match arguments.get(1).map(String::as_str) {
+        Some("conformance") => run_conformance(&arguments).await,
+        Some("intermediary-child") => run_intermediary_child(&arguments).await,
+        Some("driver-child") => run_driver_child(&arguments).await,
+        _ => Err("usage: pg-proto-burn-in conformance --profile smoke --artifacts DIR".into()),
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct RunResult {
+    schema_version: u32,
+    command: String,
+    profile: String,
+    postgres_version: String,
+    scenario: ScenarioResult,
+    success: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct ScenarioResult {
+    name: String,
+    value: i32,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "event", rename_all = "kebab-case")]
+enum ChildEvent {
+    Ready {
+        version: u32,
+        listen_addr: SocketAddr,
+    },
+    Completed {
+        version: u32,
+        value: Option<i32>,
+    },
+}
+
+async fn run_conformance(arguments: &[String]) -> Result<(), Box<dyn Error>> {
+    let profile = option(arguments, "--profile")?;
+    if profile != "smoke" {
+        return Err(format!("unsupported conformance profile: {profile}").into());
+    }
+    let artifacts = PathBuf::from(option(arguments, "--artifacts")?);
+    tokio::fs::create_dir_all(&artifacts).await?;
+
+    let outcome = supervise_smoke(arguments.first().ok_or("missing executable path")?).await;
+    let result = match &outcome {
+        Ok(value) => RunResult {
+            schema_version: 1,
+            command: "conformance".into(),
+            profile: profile.into(),
+            postgres_version: "18".into(),
+            scenario: ScenarioResult {
+                name: "extended-select-scalar".into(),
+                value: *value,
+            },
+            success: true,
+        },
+        Err(_) => RunResult {
+            schema_version: 1,
+            command: "conformance".into(),
+            profile: profile.into(),
+            postgres_version: "18".into(),
+            scenario: ScenarioResult {
+                name: "extended-select-scalar".into(),
+                value: 0,
+            },
+            success: false,
+        },
+    };
+    write_artifacts(&artifacts, &result).await?;
+    outcome.map(|_| ())
+}
+
+async fn supervise_smoke(executable: &str) -> Result<i32, Box<dyn Error>> {
+    let container = Postgres::default()
+        .with_host_auth()
+        .with_tag("18-alpine")
+        .start()
+        .await?;
+    let upstream = SocketAddr::new(
+        IpAddr::V4(Ipv4Addr::LOCALHOST),
+        container.get_host_port_ipv4(5432).await?,
+    );
+
+    let mut intermediary = spawn_child(executable, "intermediary-child", upstream).await?;
+    let ready = read_event(&mut intermediary).await?;
+    let listen_addr = match ready {
+        ChildEvent::Ready { listen_addr, .. } => listen_addr,
+        event => return Err(format!("expected intermediary ready event, got {event:?}").into()),
+    };
+
+    let mut driver = spawn_child(executable, "driver-child", listen_addr).await?;
+    let completed = read_event(&mut driver).await?;
+    let value = match completed {
+        ChildEvent::Completed {
+            value: Some(value), ..
+        } => value,
+        event => return Err(format!("expected driver completion event, got {event:?}").into()),
+    };
+    wait_success(&mut driver, "driver").await?;
+    let intermediary_completed = read_event(&mut intermediary).await?;
+    if !matches!(intermediary_completed, ChildEvent::Completed { .. }) {
+        return Err(format!(
+            "expected intermediary completion event, got {intermediary_completed:?}"
+        )
+        .into());
+    }
+    wait_success(&mut intermediary, "intermediary").await?;
+    drop(container);
+    Ok(value)
+}
+
+async fn spawn_child(
+    executable: &str,
+    role: &str,
+    address: SocketAddr,
+) -> Result<Child, Box<dyn Error>> {
+    Ok(Command::new(executable)
+        .args([role, "--address", &address.to_string()])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()?)
+}
+
+async fn read_event(child: &mut Child) -> Result<ChildEvent, Box<dyn Error>> {
+    let stdout = child.stdout.as_mut().ok_or("child stdout unavailable")?;
+    let mut line = String::new();
+    timeout(CHILD_TIMEOUT, BufReader::new(stdout).read_line(&mut line)).await??;
+    if line.is_empty() {
+        return Err("child exited without a status record".into());
+    }
+    Ok(serde_json::from_str(&line)?)
+}
+
+async fn wait_success(child: &mut Child, role: &str) -> Result<(), Box<dyn Error>> {
+    let status = timeout(CHILD_TIMEOUT, child.wait()).await??;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!("{role} child exited with {status}").into())
+    }
+}
+
+#[derive(Clone, Copy)]
+struct Route(SocketAddr);
+
+impl StartupRouteResolver<SocketAddr> for Route {
+    type Error = Infallible;
+
+    async fn resolve(
+        &self,
+        _startup: StartupParameters,
+        _context: InitialServerContext<'_, SocketAddr>,
+    ) -> Result<ConnectTarget, Self::Error> {
+        Ok(ConnectTarget::new(self.0.to_string()))
+    }
+}
+
+async fn run_intermediary_child(arguments: &[String]) -> Result<(), Box<dyn Error>> {
+    let upstream: SocketAddr = option(arguments, "--address")?.parse()?;
+    let server = Server::builder()
+        .tls(ServerTlsPolicy::Disabled)
+        .authentication(TrustServerAuthentication)
+        .build()
+        .map_err(debug_error)?;
+    let client = Client::builder()
+        .connector(move |_| TcpStream::connect(upstream))
+        .tls(ClientTlsPolicy::Disabled)
+        .authentication(TrustClientAuthentication)
+        .build()
+        .map_err(debug_error)?;
+    let intermediary = Intermediary::builder()
+        .server(server)
+        .client(client)
+        .startup_resolver(Route(upstream))
+        .cancellation(CancellationPolicy::Reject)
+        .pipeline(BoundedPipeline::new(64).expect("non-zero smoke pipeline capacity"))
+        .build()
+        .map_err(debug_error)?;
+
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await?;
+    write_event(&ChildEvent::Ready {
+        version: 1,
+        listen_addr: listener.local_addr()?,
+    })
+    .await?;
+    let (transport, peer) = listener.accept().await?;
+    let mut session = Box::pin(intermediary.accept(transport, peer, ()))
+        .await
+        .map_err(debug_error)?
+        .into_session();
+    loop {
+        match session.forward_next().await {
+            Ok(ForwardedMessage::Frontend(FrontendMessage::Terminate)) => {
+                let _transports = session.teardown();
+                break;
+            }
+            Ok(_) => {}
+            Err(error) => {
+                let message = format!("intermediary forwarding failed: {error:?}");
+                let _transports = session.teardown();
+                return Err(message.into());
+            }
+        }
+    }
+    write_event(&ChildEvent::Completed {
+        version: 1,
+        value: None,
+    })
+    .await
+}
+
+async fn run_driver_child(arguments: &[String]) -> Result<(), Box<dyn Error>> {
+    let proxy: SocketAddr = option(arguments, "--address")?.parse()?;
+    let mut config = tokio_postgres::Config::new();
+    config
+        .host(proxy.ip().to_string())
+        .port(proxy.port())
+        .user("postgres")
+        .dbname("postgres");
+    let (client, connection) = config.connect(tokio_postgres::NoTls).await?;
+    let connection_task = tokio::spawn(connection);
+    let value: i32 = client.query_one("SELECT 42::int4", &[]).await?.get(0);
+    if value != 42 {
+        return Err(format!("expected 42, got {value}").into());
+    }
+    drop(client);
+    timeout(CHILD_TIMEOUT, connection_task).await???;
+    write_event(&ChildEvent::Completed {
+        version: 1,
+        value: Some(value),
+    })
+    .await
+}
+
+async fn write_event(event: &ChildEvent) -> Result<(), Box<dyn Error>> {
+    let mut stdout = tokio::io::stdout();
+    stdout.write_all(&serde_json::to_vec(event)?).await?;
+    stdout.write_all(b"\n").await?;
+    stdout.flush().await?;
+    Ok(())
+}
+
+async fn write_artifacts(path: &Path, result: &RunResult) -> Result<(), Box<dyn Error>> {
+    let json = serde_json::to_vec_pretty(result)?;
+    atomic_write(&path.join("result.json"), &json).await?;
+    let status = if result.success { "PASS" } else { "FAIL" };
+    let markdown = format!(
+        "# pg-proto smoke conformance\n\n{status}: `{}` returned `{}` through PostgreSQL {}.\n",
+        result.scenario.name, result.scenario.value, result.postgres_version
+    );
+    atomic_write(&path.join("summary.md"), markdown.as_bytes()).await
+}
+
+async fn atomic_write(path: &Path, contents: &[u8]) -> Result<(), Box<dyn Error>> {
+    let temporary = path.with_extension("tmp");
+    tokio::fs::write(&temporary, contents).await?;
+    tokio::fs::rename(temporary, path).await?;
+    Ok(())
+}
+
+fn option<'a>(arguments: &'a [String], name: &str) -> Result<&'a str, Box<dyn Error>> {
+    let index = arguments
+        .iter()
+        .position(|argument| argument == name)
+        .ok_or_else(|| format!("missing {name}"))?;
+    arguments
+        .get(index + 1)
+        .map(String::as_str)
+        .ok_or_else(|| format!("missing value for {name}").into())
+}
+
+fn debug_error(error: impl std::fmt::Debug) -> io::Error {
+    io::Error::other(format!("{error:?}"))
+}

--- a/pg-proto-burn-in/src/lib.rs
+++ b/pg-proto-burn-in/src/lib.rs
@@ -32,6 +32,8 @@ use tokio::{
     time::timeout,
 };
 
+mod scripted;
+
 const CHILD_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Runs the requested harness command.
@@ -112,11 +114,34 @@ enum ChildEvent {
 
 async fn run_conformance(arguments: &[String]) -> Result<(), Box<dyn Error>> {
     let profile = option(arguments, "--profile")?;
+    let artifacts = PathBuf::from(option(arguments, "--artifacts")?);
+    tokio::fs::create_dir_all(&artifacts).await?;
+
+    if profile == "scripted" {
+        let coverage = scripted::run().await?;
+        let result = RunResult {
+            schema_version: 1,
+            command: "conformance".into(),
+            profile: profile.into(),
+            postgres_version: "not-applicable".into(),
+            scenario: ScenarioResult {
+                name: "scripted-exceptional-paths".into(),
+                value: 0,
+            },
+            fixtures: FixtureResult::default(),
+            data_scenarios: Vec::new(),
+            coverage: CoverageReport {
+                observed_ids: coverage.clone(),
+                scripted: coverage,
+                ..CoverageReport::default()
+            },
+            success: true,
+        };
+        return write_artifacts(&artifacts, &result).await;
+    }
     if profile != "smoke" {
         return Err(format!("unsupported conformance profile: {profile}").into());
     }
-    let artifacts = PathBuf::from(option(arguments, "--artifacts")?);
-    tokio::fs::create_dir_all(&artifacts).await?;
 
     let outcome = supervise_smoke(arguments.first().ok_or("missing executable path")?).await;
     let result = match &outcome {
@@ -670,8 +695,8 @@ async fn write_artifacts(path: &Path, result: &RunResult) -> Result<(), Box<dyn 
     atomic_write(&path.join("result.json"), &json).await?;
     let status = if result.success { "PASS" } else { "FAIL" };
     let markdown = format!(
-        "# pg-proto smoke conformance\n\n{status}: `{}` returned `{}` through PostgreSQL {}.\n",
-        result.scenario.name, result.scenario.value, result.postgres_version
+        "# pg-proto {} conformance\n\n{status}: `{}` completed with result `{}` (PostgreSQL: {}).\n",
+        result.profile, result.scenario.name, result.scenario.value, result.postgres_version
     );
     atomic_write(&path.join("summary.md"), markdown.as_bytes()).await
 }

--- a/pg-proto-burn-in/src/lib.rs
+++ b/pg-proto-burn-in/src/lib.rs
@@ -13,17 +13,23 @@ use std::{
 
 use futures_util::TryStreamExt;
 use pg_proto::{
-    BoundedPipeline, CancellationPolicy, Client, ClientConnectionContext, ClientTlsPolicy,
-    ConnectTarget, ForwardedMessage, FrontendMessage, InitialServerContext, Intermediary,
-    IntermediaryMiddleware, ProtocolTransitionDirection, ProtocolTransitionObservation, Server,
-    ServerConnectionContext, ServerTlsPolicy, StartupParameters, StartupRouteResolver,
-    StaticClientCredentials, TrustClientAuthentication, TrustIdentity, TrustServerAuthentication,
+    BoundedPipeline, CancellationPolicy, Client, ClientConnectionContext, ClientTlsConfig,
+    ClientTlsPolicy, ClientTlsProvider, ConnectTarget, ForwardedMessage, FrontendMessage,
+    InitialServerContext, Intermediary, IntermediaryMiddleware, ProtocolTransitionDirection,
+    ProtocolTransitionObservation, Server, ServerConnectionContext, ServerTlsPolicy, SslMode,
+    StartupParameters, StartupRouteResolver, StaticClientCredentials, TrustClientAuthentication,
+    TrustIdentity, TrustServerAuthentication,
+};
+use rcgen::generate_simple_self_signed;
+use rustls::{
+    RootCertStore,
+    pki_types::{CertificateDer, ServerName},
 };
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use testcontainers_modules::{
     postgres::Postgres,
-    testcontainers::{ImageExt, runners::AsyncRunner},
+    testcontainers::{CopyDataSource, CopyTargetOptions, ImageExt, runners::AsyncRunner},
 };
 use tokio::{
     io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
@@ -204,7 +210,7 @@ async fn run_authentication_conformance(
     executable: &str,
     artifacts: &Path,
 ) -> Result<(), Box<dyn Error>> {
-    let outcome = supervise_authentication(executable).await;
+    let outcome = supervise_authentication(executable, artifacts).await;
     let profiles = outcome.as_ref().map_or_else(
         |_| authentication_profile_results(false),
         |()| authentication_profile_results(true),
@@ -298,11 +304,59 @@ fn authentication_profile_results(executed: bool) -> Vec<AuthenticationProfileRe
     .collect()
 }
 
-async fn supervise_authentication(executable: &str) -> Result<(), Box<dyn Error>> {
+async fn supervise_authentication(
+    executable: &str,
+    artifacts: &Path,
+) -> Result<(), Box<dyn Error>> {
     run_password_profile(executable, "trust", None).await?;
     run_password_profile(executable, "password", Some("postgres")).await?;
     run_password_profile(executable, "md5", Some("postgres")).await?;
     run_password_profile(executable, "scram-sha-256", Some("postgres")).await?;
+    run_tls_profile(executable, artifacts).await?;
+    run_tls_rejection_profile(executable, artifacts).await?;
+    Ok(())
+}
+
+async fn run_tls_rejection_profile(
+    executable: &str,
+    artifacts: &Path,
+) -> Result<(), Box<dyn Error>> {
+    let generated = generate_simple_self_signed(vec!["localhost".into()])?;
+    let certificate_path = artifacts.join("rejection-root.der");
+    tokio::fs::write(&certificate_path, generated.cert.der()).await?;
+    let container = Postgres::default()
+        .with_host_auth()
+        .with_tag("18-alpine")
+        .start()
+        .await?;
+    let upstream = SocketAddr::new(
+        IpAddr::V4(Ipv4Addr::LOCALHOST),
+        container.get_host_port_ipv4(5432).await?,
+    );
+    let mut intermediary = Command::new(executable)
+        .args([
+            "intermediary-child",
+            "--address",
+            &upstream.to_string(),
+            "--password",
+            "postgres",
+            "--tls-root",
+            certificate_path.to_str().ok_or("non-UTF8 TLS root path")?,
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()?;
+    let ChildEvent::Ready { listen_addr, .. } = read_event(&mut intermediary).await? else {
+        return Err("expected rejection intermediary ready event".into());
+    };
+    let mut driver =
+        spawn_authenticated_child(executable, "driver-child", listen_addr, None).await?;
+    let driver_status = timeout(CHILD_TIMEOUT, driver.wait()).await??;
+    let intermediary_status = timeout(CHILD_TIMEOUT, intermediary.wait()).await??;
+    if driver_status.success() || intermediary_status.success() {
+        return Err("required TLS unexpectedly accepted a plaintext PostgreSQL server".into());
+    }
+    drop(container);
     Ok(())
 }
 
@@ -313,6 +367,15 @@ async fn run_password_profile(
 ) -> Result<(), Box<dyn Error>> {
     let image = if host_auth == "trust" {
         Postgres::default().with_host_auth().with_tag("18-alpine")
+    } else if host_auth == "md5" {
+        Postgres::default()
+            .with_password(password.expect("MD5 authentication requires a password"))
+            .with_init_sql(
+                b"SET password_encryption = 'md5'; ALTER ROLE postgres PASSWORD 'postgres';"
+                    .to_vec(),
+            )
+            .with_tag("18-alpine")
+            .with_env_var("POSTGRES_HOST_AUTH_METHOD", "md5")
     } else {
         Postgres::default()
             .with_password(password.expect("password authentication requires a password"))
@@ -342,6 +405,63 @@ async fn run_password_profile(
         return Err(format!("{host_auth} intermediary did not complete").into());
     };
     wait_success(&mut intermediary, "intermediary").await?;
+    drop(container);
+    Ok(())
+}
+
+async fn run_tls_profile(executable: &str, artifacts: &Path) -> Result<(), Box<dyn Error>> {
+    let generated = generate_simple_self_signed(vec!["localhost".into()])?;
+    let certificate_der = generated.cert.der().to_vec();
+    let certificate_path = artifacts.join("tls-root.der");
+    tokio::fs::write(&certificate_path, &certificate_der).await?;
+    let setup = b"#!/bin/sh\nset -eu\ncp /docker-entrypoint-initdb.d/server.crt /var/lib/postgresql/server.crt\ncp /docker-entrypoint-initdb.d/server.key /var/lib/postgresql/server.key\nchown postgres:postgres /var/lib/postgresql/server.crt /var/lib/postgresql/server.key\nchmod 600 /var/lib/postgresql/server.key\nprintf '\\nssl=on\\nssl_cert_file=\"/var/lib/postgresql/server.crt\"\\nssl_key_file=\"/var/lib/postgresql/server.key\"\\n' >> \"$PGDATA/postgresql.conf\"\n".to_vec();
+    let image = Postgres::default()
+        .with_password("postgres")
+        .with_tag("18-alpine")
+        .with_copy_to(
+            CopyTargetOptions::new("/docker-entrypoint-initdb.d/00_tls.sh").with_mode(0o755),
+            CopyDataSource::Data(setup),
+        )
+        .with_copy_to(
+            "/docker-entrypoint-initdb.d/server.crt",
+            CopyDataSource::Data(generated.cert.pem().into_bytes()),
+        )
+        .with_copy_to(
+            CopyTargetOptions::new("/docker-entrypoint-initdb.d/server.key").with_mode(0o600),
+            CopyDataSource::Data(generated.signing_key.serialize_pem().into_bytes()),
+        );
+    let container = image.start().await?;
+    let upstream = SocketAddr::new(
+        IpAddr::V4(Ipv4Addr::LOCALHOST),
+        container.get_host_port_ipv4(5432).await?,
+    );
+    let mut intermediary = Command::new(executable)
+        .args([
+            "intermediary-child",
+            "--address",
+            &upstream.to_string(),
+            "--password",
+            "postgres",
+            "--tls-root",
+            certificate_path.to_str().ok_or("non-UTF8 TLS root path")?,
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()?;
+    let ChildEvent::Ready { listen_addr, .. } = read_event(&mut intermediary).await? else {
+        return Err("expected TLS intermediary ready event".into());
+    };
+    let mut driver =
+        spawn_authenticated_child(executable, "driver-child", listen_addr, None).await?;
+    let ChildEvent::Completed {
+        value: Some(42), ..
+    } = read_event(&mut driver).await?
+    else {
+        return Err("TLS driver did not validate SELECT".into());
+    };
+    wait_success(&mut driver, "TLS driver").await?;
+    let _ = read_event(&mut intermediary).await?;
+    wait_success(&mut intermediary, "TLS intermediary").await?;
     drop(container);
     Ok(())
 }
@@ -512,6 +632,17 @@ async fn wait_success(child: &mut Child, role: &str) -> Result<(), Box<dyn Error
 #[derive(Clone, Copy)]
 struct Route(SocketAddr);
 
+#[derive(Clone)]
+struct RootedTls(ClientTlsConfig);
+
+impl ClientTlsProvider for RootedTls {
+    type Error = Infallible;
+
+    async fn resolve(&self, _: &ConnectTarget) -> Result<ClientTlsConfig, Self::Error> {
+        Ok(self.0.clone())
+    }
+}
+
 #[derive(Default)]
 struct CoverageState(BTreeSet<String>);
 
@@ -566,6 +697,9 @@ impl StartupRouteResolver<SocketAddr> for Route {
 async fn run_intermediary_child(arguments: &[String]) -> Result<(), Box<dyn Error>> {
     let upstream: SocketAddr = option(arguments, "--address")?.parse()?;
     if let Ok(password) = option(arguments, "--password") {
+        if let Ok(root) = option(arguments, "--tls-root") {
+            return run_tls_credential_intermediary(upstream, password, root).await;
+        }
         return run_credential_intermediary(upstream, password).await;
     }
     let server = Server::builder()
@@ -613,6 +747,78 @@ async fn run_intermediary_child(arguments: &[String]) -> Result<(), Box<dyn Erro
             Err(error) => {
                 let message = format!("intermediary forwarding failed: {error:?}");
                 let _transports = session.teardown();
+                return Err(message.into());
+            }
+        }
+    };
+    write_event(&ChildEvent::Completed {
+        version: 1,
+        value: None,
+        coverage: coverage.into_iter().collect(),
+        fixtures: None,
+        data_scenarios: Vec::new(),
+    })
+    .await
+}
+
+async fn run_tls_credential_intermediary(
+    upstream: SocketAddr,
+    password: &str,
+    root: &str,
+) -> Result<(), Box<dyn Error>> {
+    let mut roots = RootCertStore::empty();
+    roots.add(CertificateDer::from(tokio::fs::read(root).await?))?;
+    let tls = RootedTls(ClientTlsConfig::new(
+        ServerName::try_from("localhost")?.to_owned(),
+        roots,
+    ));
+    let server = Server::builder()
+        .tls(ServerTlsPolicy::Disabled)
+        .authentication(TrustServerAuthentication)
+        .build()
+        .map_err(debug_error)?;
+    let client = Client::builder()
+        .connector(move |_| TcpStream::connect(upstream))
+        .tls(ClientTlsPolicy::libpq(SslMode::Require, tls))
+        .authentication(StaticClientCredentials::new(
+            "postgres",
+            password.to_owned(),
+        ))
+        .build()
+        .map_err(debug_error)?;
+    let intermediary = Intermediary::builder()
+        .server(server)
+        .client(client)
+        .startup_resolver(Route(upstream))
+        .cancellation(CancellationPolicy::Reject)
+        .pipeline(BoundedPipeline::new(64).expect("non-zero TLS pipeline capacity"))
+        .middleware(
+            |_: &ServerConnectionContext<SocketAddr, TrustIdentity>,
+             _: &ClientConnectionContext<()>| CoverageObserver,
+        )
+        .build()
+        .map_err(debug_error)?;
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await?;
+    write_event(&ChildEvent::Ready {
+        version: 1,
+        listen_addr: listener.local_addr()?,
+    })
+    .await?;
+    let (transport, peer) = listener.accept().await?;
+    let mut session = Box::pin(intermediary.accept(transport, peer, CoverageState::default()))
+        .await
+        .map_err(debug_error)?
+        .into_session();
+    let coverage = loop {
+        match session.forward_next().await {
+            Ok(ForwardedMessage::Frontend(FrontendMessage::Terminate)) => {
+                let (_, _, state, ..) = session.teardown();
+                break state.0;
+            }
+            Ok(_) => {}
+            Err(error) => {
+                let message = format!("TLS intermediary forwarding failed: {error:?}");
+                let _ = session.teardown();
                 return Err(message.into());
             }
         }
@@ -985,6 +1191,10 @@ mod tests {
         REQUIRED_SMOKE_COVERAGE, REQUIRED_SMOKE_STAGES, authentication_profile_results,
         coverage_report,
     };
+    use pg_proto::{
+        ClientAuthentication, ClientAuthenticationChallenge, ClientAuthenticationSession,
+        ConnectTarget, StaticClientCredentials, StaticCredentialError,
+    };
 
     #[test]
     fn required_smoke_coverage_is_stable_and_complete() {
@@ -1015,5 +1225,22 @@ mod tests {
         );
         assert_eq!(profiles[0].id, "auth.plaintext.trust");
         assert_eq!(profiles[6].id, "auth.tls.rejection");
+    }
+
+    #[tokio::test]
+    async fn plus_only_offer_is_explicitly_unsupported_without_channel_binding() {
+        let mut credentials = StaticClientCredentials::new("postgres", "postgres")
+            .begin(&ConnectTarget::new("postgres"))
+            .await
+            .expect("credential session");
+        let result = credentials
+            .respond(ClientAuthenticationChallenge::Sasl(vec![
+                b"SCRAM-SHA-256-PLUS".as_slice().into(),
+            ]))
+            .await;
+        assert!(matches!(
+            result,
+            Err(StaticCredentialError::UnsupportedAuthentication)
+        ));
     }
 }

--- a/pg-proto-burn-in/src/lib.rs
+++ b/pg-proto-burn-in/src/lib.rs
@@ -57,6 +57,8 @@ pub async fn run(arguments: Vec<String>) -> Result<(), Box<dyn Error>> {
         Some("soak") => soak::run_soak(&arguments).await,
         Some("replay") => soak::run_replay(&arguments).await,
         Some("soak-driver-child") => soak::run_driver_child(&arguments).await,
+        Some("resource-driver-child") => soak::run_resource_driver_child(&arguments).await,
+        Some("resource-hold-child") => soak::run_resource_hold_child(&arguments).await,
         Some("intermediary-child") => run_intermediary_child(&arguments).await,
         Some("driver-child") => run_driver_child(&arguments).await,
         _ => Err("usage: pg-proto-burn-in <conformance|soak|replay> [options]".into()),

--- a/pg-proto-burn-in/src/lib.rs
+++ b/pg-proto-burn-in/src/lib.rs
@@ -1054,6 +1054,9 @@ async fn run_intermediary_child(arguments: &[String]) -> Result<(), Box<dyn Erro
     let connection_count = option(arguments, "--connections")
         .unwrap_or("1")
         .parse::<usize>()?;
+    let allow_abrupt_disconnects = arguments
+        .iter()
+        .any(|argument| argument == "--allow-abrupt-disconnects");
     if let Ok(password) = option(arguments, "--password") {
         if let Ok(root) = option(arguments, "--tls-root") {
             return run_tls_credential_intermediary(upstream, password, root).await;
@@ -1113,7 +1116,10 @@ async fn run_intermediary_child(arguments: &[String]) -> Result<(), Box<dyn Erro
                     Ok(_) => {}
                     Err(error) => {
                         let message = format!("intermediary forwarding failed: {error:?}");
-                        let _transports = session.teardown();
+                        let (_, _, state, ..) = session.teardown();
+                        if allow_abrupt_disconnects {
+                            return Ok(Some(state));
+                        }
                         return Err(io::Error::other(message));
                     }
                 }

--- a/pg-proto-burn-in/src/lib.rs
+++ b/pg-proto-burn-in/src/lib.rs
@@ -8,7 +8,10 @@ use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
     path::{Path, PathBuf},
     process::Stdio,
-    sync::{Arc, Mutex},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    },
     time::Duration,
 };
 
@@ -18,10 +21,10 @@ use pg_proto::{
     BackendMessage, BackendMiddlewareOutput, BoundedPipeline, CancelKey, CancellationPolicy,
     CancellationRoute, Client, ClientConnectionContext, ClientTlsConfig, ClientTlsPolicy,
     ClientTlsProvider, ConnectTarget, ForwardedMessage, FrontendMessage, InitialServerContext,
-    Intermediary, IntermediaryCancellationRegistry, IntermediaryMiddleware, OperationId,
-    ProtocolTransitionDirection, ProtocolTransitionObservation, Server, ServerConnectionContext,
-    ServerTlsPolicy, SslMode, StartupParameters, StartupRouteResolver, StaticClientCredentials,
-    TrustClientAuthentication, TrustIdentity, TrustServerAuthentication,
+    Intermediary, IntermediaryAccept, IntermediaryCancellationRegistry, IntermediaryMiddleware,
+    OperationId, ProtocolTransitionDirection, ProtocolTransitionObservation, Server,
+    ServerConnectionContext, ServerTlsPolicy, SslMode, StartupParameters, StartupRouteResolver,
+    StaticClientCredentials, TrustClientAuthentication, TrustIdentity, TrustServerAuthentication,
 };
 use postgres_protocol::message::{backend, frontend};
 use rcgen::generate_simple_self_signed;
@@ -75,6 +78,8 @@ struct RunResult {
     copy_scenarios: Vec<CopyScenarioResult>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     async_traffic: Option<AsyncTrafficResult>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    cancellation: Option<CancellationResult>,
     coverage: CoverageReport,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     authentication_profiles: Vec<AuthenticationProfileResult>,
@@ -160,6 +165,22 @@ struct CopyScenarioResult {
     validated: bool,
 }
 
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+struct CancellationResult {
+    selected_sqlstate: String,
+    selected_session_survived: bool,
+    unaffected_value: i32,
+    unaffected_session_survived: bool,
+    all_keys_rewritten: bool,
+    mappings_after_teardown: usize,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+struct CancellationRegistryResult {
+    all_keys_rewritten: bool,
+    mappings_after_teardown: usize,
+}
+
 #[derive(Debug, Default, Serialize, Deserialize)]
 struct CoverageReport {
     observed_ids: Vec<String>,
@@ -194,6 +215,10 @@ enum ChildEvent {
         copy_scenarios: Vec<CopyScenarioResult>,
         #[serde(default)]
         async_traffic: Option<Box<AsyncTrafficResult>>,
+        #[serde(default)]
+        cancellation: Option<Box<CancellationResult>>,
+        #[serde(default)]
+        cancellation_registry: Option<CancellationRegistryResult>,
     },
 }
 
@@ -219,6 +244,7 @@ async fn run_conformance(arguments: &[String]) -> Result<(), Box<dyn Error>> {
             error_scenarios: Vec::new(),
             copy_scenarios: Vec::new(),
             async_traffic: None,
+            cancellation: None,
             coverage: CoverageReport {
                 observed_ids: coverage.clone(),
                 scripted: coverage,
@@ -251,6 +277,7 @@ async fn run_conformance(arguments: &[String]) -> Result<(), Box<dyn Error>> {
             error_scenarios,
             copy_scenarios,
             async_traffic,
+            cancellation,
         )) => RunResult {
             schema_version: 1,
             command: "conformance".into(),
@@ -266,6 +293,7 @@ async fn run_conformance(arguments: &[String]) -> Result<(), Box<dyn Error>> {
             error_scenarios: error_scenarios.clone(),
             copy_scenarios: copy_scenarios.clone(),
             async_traffic: Some(async_traffic.clone()),
+            cancellation: Some(cancellation.clone()),
             coverage: coverage_report(coverage)?,
             authentication_profiles: Vec::new(),
             success: true,
@@ -285,6 +313,7 @@ async fn run_conformance(arguments: &[String]) -> Result<(), Box<dyn Error>> {
             error_scenarios: Vec::new(),
             copy_scenarios: Vec::new(),
             async_traffic: None,
+            cancellation: None,
             coverage: CoverageReport::default(),
             authentication_profiles: Vec::new(),
             success: false,
@@ -318,6 +347,7 @@ async fn run_authentication_conformance(
         error_scenarios: Vec::new(),
         copy_scenarios: Vec::new(),
         async_traffic: None,
+        cancellation: None,
         coverage: CoverageReport::default(),
         authentication_profiles: profiles,
         success: outcome.is_ok(),
@@ -572,6 +602,7 @@ async fn supervise_smoke(
         Vec<SqlErrorScenarioResult>,
         Vec<CopyScenarioResult>,
         AsyncTrafficResult,
+        CancellationResult,
     ),
     Box<dyn Error>,
 > {
@@ -591,7 +622,7 @@ async fn supervise_smoke(
             "--address",
             &upstream.to_string(),
             "--connections",
-            "4",
+            "7",
         ])
         .stdout(Stdio::piped())
         .stderr(Stdio::inherit())
@@ -623,6 +654,7 @@ async fn supervise_smoke(
         error_scenarios,
         copy_scenarios,
         mut async_traffic,
+        mut cancellation,
     ) = match completed {
         ChildEvent::Completed {
             value: Some(value),
@@ -633,6 +665,8 @@ async fn supervise_smoke(
             error_scenarios,
             copy_scenarios,
             async_traffic: Some(async_traffic),
+            cancellation: Some(cancellation),
+            cancellation_registry: None,
             ..
         } => (
             value,
@@ -643,6 +677,7 @@ async fn supervise_smoke(
             error_scenarios,
             copy_scenarios,
             *async_traffic,
+            *cancellation,
         ),
         event => return Err(format!("expected driver completion event, got {event:?}").into()),
     };
@@ -651,6 +686,7 @@ async fn supervise_smoke(
     let ChildEvent::Completed {
         coverage: intermediary_coverage,
         async_traffic: Some(intermediary_async),
+        cancellation_registry: Some(cancellation_registry),
         ..
     } = intermediary_completed
     else {
@@ -660,7 +696,10 @@ async fn supervise_smoke(
     async_traffic.parameter_status = intermediary_async.parameter_status;
     async_traffic.backend_key_forwarded = intermediary_async.backend_key_forwarded;
     async_traffic.causally_unattributed = intermediary_async.causally_unattributed;
+    cancellation.all_keys_rewritten = cancellation_registry.all_keys_rewritten;
+    cancellation.mappings_after_teardown = cancellation_registry.mappings_after_teardown;
     validate_async_traffic(&async_traffic)?;
+    validate_cancellation(&cancellation)?;
     wait_success(&mut intermediary, "intermediary").await?;
     drop(container);
     Ok((
@@ -672,7 +711,21 @@ async fn supervise_smoke(
         error_scenarios,
         copy_scenarios,
         async_traffic,
+        cancellation,
     ))
+}
+
+fn validate_cancellation(evidence: &CancellationResult) -> Result<(), Box<dyn Error>> {
+    if evidence.selected_sqlstate != "57014"
+        || !evidence.selected_session_survived
+        || evidence.unaffected_value != 7
+        || !evidence.unaffected_session_survived
+        || !evidence.all_keys_rewritten
+        || evidence.mappings_after_teardown != 0
+    {
+        return Err(format!("incomplete cancellation evidence: {evidence:?}").into());
+    }
+    Ok(())
 }
 
 fn validate_async_traffic(evidence: &AsyncTrafficResult) -> Result<(), Box<dyn Error>> {
@@ -821,6 +874,19 @@ struct Route(SocketAddr);
 #[derive(Clone, Default)]
 struct FourByteCancellationRegistry {
     routes: Arc<Mutex<HashMap<CancelKey, CancellationRoute>>>,
+    registrations: Arc<AtomicUsize>,
+    rewrites: Arc<AtomicUsize>,
+}
+
+impl FourByteCancellationRegistry {
+    fn evidence(&self) -> CancellationRegistryResult {
+        let registrations = self.registrations.load(Ordering::Relaxed);
+        CancellationRegistryResult {
+            all_keys_rewritten: registrations > 0
+                && self.rewrites.load(Ordering::Relaxed) == registrations,
+            mappings_after_teardown: self.routes.lock().map_or(usize::MAX, |routes| routes.len()),
+        }
+    }
 }
 
 impl IntermediaryCancellationRegistry for FourByteCancellationRegistry {
@@ -828,14 +894,17 @@ impl IntermediaryCancellationRegistry for FourByteCancellationRegistry {
 
     fn register(&self, route: CancellationRoute) -> Result<CancelKey, Self::Error> {
         let upstream = route.upstream_key();
-        let secret = upstream
+        let mut secret = upstream
             .secret_key
             .get(..4)
-            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "short cancellation key"))?;
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "short cancellation key"))?
+            .to_owned();
+        secret[0] ^= 0x80;
         let client = CancelKey {
-            process_id: upstream.process_id,
-            secret_key: bytes::Bytes::copy_from_slice(secret),
+            process_id: upstream.process_id ^ 0x8000_0000,
+            secret_key: bytes::Bytes::from(secret),
         };
+        let rewritten = &client != upstream;
         let mut routes = self
             .routes
             .lock()
@@ -845,6 +914,10 @@ impl IntermediaryCancellationRegistry for FourByteCancellationRegistry {
                 io::ErrorKind::AlreadyExists,
                 "duplicate cancellation key",
             ));
+        }
+        self.registrations.fetch_add(1, Ordering::Relaxed);
+        if rewritten {
+            self.rewrites.fetch_add(1, Ordering::Relaxed);
         }
         Ok(client)
     }
@@ -996,12 +1069,13 @@ async fn run_intermediary_child(arguments: &[String]) -> Result<(), Box<dyn Erro
         .authentication(TrustClientAuthentication)
         .build()
         .map_err(debug_error)?;
+    let cancellation_registry = FourByteCancellationRegistry::default();
     let intermediary = Arc::new(
         Intermediary::builder()
             .server(server)
             .client(client)
             .startup_resolver(Route(upstream))
-            .cancellation_registry(FourByteCancellationRegistry::default())
+            .cancellation_registry(cancellation_registry.clone())
             .pipeline(BoundedPipeline::new(64).expect("non-zero smoke pipeline capacity"))
             .middleware(
                 |_: &ServerConnectionContext<SocketAddr, TrustIdentity>,
@@ -1022,16 +1096,17 @@ async fn run_intermediary_child(arguments: &[String]) -> Result<(), Box<dyn Erro
         let (transport, peer) = listener.accept().await?;
         let intermediary = Arc::clone(&intermediary);
         sessions.spawn(async move {
-            let mut session =
-                Box::pin(intermediary.accept(transport, peer, CoverageState::default()))
-                    .await
-                    .map_err(debug_error)?
-                    .into_session();
+            let accepted = Box::pin(intermediary.accept(transport, peer, CoverageState::default()))
+                .await
+                .map_err(debug_error)?;
+            let IntermediaryAccept::Session(mut session) = accepted else {
+                return Ok::<_, io::Error>(None);
+            };
             loop {
                 match session.forward_next().await {
                     Ok(ForwardedMessage::Frontend(FrontendMessage::Terminate)) => {
                         let (_, _, state, ..) = session.teardown();
-                        return Ok::<_, io::Error>(state);
+                        return Ok::<_, io::Error>(Some(state));
                     }
                     Ok(_) => {}
                     Err(error) => {
@@ -1045,7 +1120,9 @@ async fn run_intermediary_child(arguments: &[String]) -> Result<(), Box<dyn Erro
     }
     let mut accumulated = CoverageState::default();
     while let Some(result) = sessions.join_next().await {
-        let state = result??;
+        let Some(state) = result?? else {
+            continue;
+        };
         accumulated.transitions.extend(state.transitions);
         accumulated
             .causally_unattributed
@@ -1069,6 +1146,8 @@ async fn run_intermediary_child(arguments: &[String]) -> Result<(), Box<dyn Erro
             causally_unattributed: accumulated.causally_unattributed.into_iter().collect(),
             ..AsyncTrafficResult::default()
         })),
+        cancellation: None,
+        cancellation_registry: Some(cancellation_registry.evidence()),
     })
     .await
 }
@@ -1146,6 +1225,8 @@ async fn run_tls_credential_intermediary(
         error_scenarios: Vec::new(),
         copy_scenarios: Vec::new(),
         async_traffic: None,
+        cancellation: None,
+        cancellation_registry: None,
     })
     .await
 }
@@ -1215,6 +1296,8 @@ async fn run_credential_intermediary(
         error_scenarios: Vec::new(),
         copy_scenarios: Vec::new(),
         async_traffic: None,
+        cancellation: None,
+        cancellation_registry: None,
     })
     .await
 }
@@ -1309,6 +1392,7 @@ async fn run_driver_child(arguments: &[String]) -> Result<(), Box<dyn Error>> {
     let data_scenarios = run_data_scenarios(&client).await?;
     let mut query_lifecycle = run_query_lifecycles(&mut client).await?;
     let error_scenarios = run_sql_error_scenarios(&mut client, proxy).await?;
+    let cancellation = run_cancellation_scenario(proxy).await?;
     drop(client);
     timeout(CHILD_TIMEOUT, connection_task).await???;
     let copy_scenarios = run_copy_connection(proxy, option(arguments, "--password").ok()).await?;
@@ -1326,6 +1410,8 @@ async fn run_driver_child(arguments: &[String]) -> Result<(), Box<dyn Error>> {
         error_scenarios,
         copy_scenarios,
         async_traffic: Some(Box::new(async_traffic)),
+        cancellation: Some(Box::new(cancellation)),
+        cancellation_registry: None,
     })
     .await
 }
@@ -1349,6 +1435,88 @@ async fn run_copy_connection(
     drop(client);
     timeout(CHILD_TIMEOUT, connection_task).await???;
     Ok(scenarios)
+}
+
+async fn run_cancellation_scenario(
+    proxy: SocketAddr,
+) -> Result<CancellationResult, Box<dyn Error>> {
+    let (selected, selected_connection) = connect_driver(proxy).await?;
+    let selected_connection = tokio::spawn(selected_connection);
+    selected
+        .batch_execute("SET application_name = 'pg-proto-burn-in-cancel-selected'")
+        .await?;
+    let cancel = selected.cancel_token();
+    let selected_query = tokio::spawn(async move {
+        let outcome = selected.query_one("SELECT pg_sleep(10)", &[]).await;
+        (selected, outcome)
+    });
+
+    let (unaffected, unaffected_connection) = connect_driver(proxy).await?;
+    let unaffected_connection = tokio::spawn(unaffected_connection);
+    timeout(CHILD_TIMEOUT, async {
+        loop {
+            let active: bool = unaffected
+                .query_one(
+                    "SELECT EXISTS (SELECT 1 FROM pg_stat_activity \
+                     WHERE application_name = 'pg-proto-burn-in-cancel-selected' \
+                     AND state = 'active' AND query = 'SELECT pg_sleep(10)')",
+                    &[],
+                )
+                .await?
+                .get(0);
+            if active {
+                return Ok::<_, tokio_postgres::Error>(());
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await??;
+    let unaffected_query = tokio::spawn(async move {
+        let outcome = unaffected
+            .query_one("SELECT 7::int4 FROM pg_sleep(0.5)", &[])
+            .await;
+        (unaffected, outcome)
+    });
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    cancel.cancel_query(tokio_postgres::NoTls).await?;
+
+    let (selected, selected_outcome) = timeout(CHILD_TIMEOUT, selected_query).await??;
+    let selected_error = selected_outcome.expect_err("selected operation was not cancelled");
+    let selected_sqlstate = selected_error
+        .as_db_error()
+        .ok_or("selected cancellation did not return a PostgreSQL error")?
+        .code()
+        .code()
+        .to_owned();
+    let selected_session_survived = selected
+        .query_one("SELECT 1::int4", &[])
+        .await?
+        .get::<_, i32>(0)
+        == 1;
+
+    let (unaffected, unaffected_outcome) = timeout(CHILD_TIMEOUT, unaffected_query).await??;
+    let unaffected_value = unaffected_outcome?.get::<_, i32>(0);
+    let unaffected_session_survived = unaffected
+        .query_one("SELECT 1::int4", &[])
+        .await?
+        .get::<_, i32>(0)
+        == 1;
+
+    drop(selected);
+    drop(unaffected);
+    timeout(CHILD_TIMEOUT, selected_connection).await???;
+    timeout(CHILD_TIMEOUT, unaffected_connection).await???;
+
+    Ok(CancellationResult {
+        selected_sqlstate,
+        selected_session_survived,
+        unaffected_value,
+        unaffected_session_survived,
+        // The intermediary contributes registry-owned evidence after teardown.
+        all_keys_rewritten: false,
+        mappings_after_teardown: usize::MAX,
+    })
 }
 
 async fn run_sql_error_scenarios(

--- a/pg-proto-burn-in/src/lib.rs
+++ b/pg-proto-burn-in/src/lib.rs
@@ -11,6 +11,7 @@ use std::{
     time::Duration,
 };
 
+use bytes::{BufMut, BytesMut};
 use futures_util::TryStreamExt;
 use pg_proto::{
     BoundedPipeline, CancellationPolicy, Client, ClientConnectionContext, ClientTlsConfig,
@@ -20,6 +21,7 @@ use pg_proto::{
     StartupParameters, StartupRouteResolver, StaticClientCredentials, TrustClientAuthentication,
     TrustIdentity, TrustServerAuthentication,
 };
+use postgres_protocol::message::{backend, frontend};
 use rcgen::generate_simple_self_signed;
 use rustls::{
     RootCertStore,
@@ -32,7 +34,7 @@ use testcontainers_modules::{
     testcontainers::{CopyDataSource, CopyTargetOptions, ImageExt, runners::AsyncRunner},
 };
 use tokio::{
-    io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
+    io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader},
     net::{TcpListener, TcpStream},
     process::{Child, Command},
     time::timeout,
@@ -61,6 +63,7 @@ struct RunResult {
     scenario: ScenarioResult,
     fixtures: FixtureResult,
     data_scenarios: Vec<DataScenarioResult>,
+    query_lifecycle: Vec<QueryLifecycleResult>,
     coverage: CoverageReport,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     authentication_profiles: Vec<AuthenticationProfileResult>,
@@ -101,6 +104,13 @@ struct DataScenarioResult {
     validated: bool,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct QueryLifecycleResult {
+    name: String,
+    ready_after: bool,
+    validated: bool,
+}
+
 #[derive(Debug, Default, Serialize, Deserialize)]
 struct CoverageReport {
     observed_ids: Vec<String>,
@@ -127,6 +137,8 @@ enum ChildEvent {
         fixtures: Option<FixtureResult>,
         #[serde(default)]
         data_scenarios: Vec<DataScenarioResult>,
+        #[serde(default)]
+        query_lifecycle: Vec<QueryLifecycleResult>,
     },
 }
 
@@ -148,6 +160,7 @@ async fn run_conformance(arguments: &[String]) -> Result<(), Box<dyn Error>> {
             },
             fixtures: FixtureResult::default(),
             data_scenarios: Vec::new(),
+            query_lifecycle: Vec::new(),
             coverage: CoverageReport {
                 observed_ids: coverage.clone(),
                 scripted: coverage,
@@ -171,7 +184,7 @@ async fn run_conformance(arguments: &[String]) -> Result<(), Box<dyn Error>> {
 
     let outcome = supervise_smoke(arguments.first().ok_or("missing executable path")?).await;
     let result = match &outcome {
-        Ok((value, coverage, fixtures, data_scenarios)) => RunResult {
+        Ok((value, coverage, fixtures, data_scenarios, query_lifecycle)) => RunResult {
             schema_version: 1,
             command: "conformance".into(),
             profile: profile.into(),
@@ -182,6 +195,7 @@ async fn run_conformance(arguments: &[String]) -> Result<(), Box<dyn Error>> {
             },
             fixtures: fixtures.clone(),
             data_scenarios: data_scenarios.clone(),
+            query_lifecycle: query_lifecycle.clone(),
             coverage: coverage_report(coverage)?,
             authentication_profiles: Vec::new(),
             success: true,
@@ -197,6 +211,7 @@ async fn run_conformance(arguments: &[String]) -> Result<(), Box<dyn Error>> {
             },
             fixtures: FixtureResult::default(),
             data_scenarios: Vec::new(),
+            query_lifecycle: Vec::new(),
             coverage: CoverageReport::default(),
             authentication_profiles: Vec::new(),
             success: false,
@@ -226,6 +241,7 @@ async fn run_authentication_conformance(
         },
         fixtures: FixtureResult::default(),
         data_scenarios: Vec::new(),
+        query_lifecycle: Vec::new(),
         coverage: CoverageReport::default(),
         authentication_profiles: profiles,
         success: outcome.is_ok(),
@@ -470,7 +486,16 @@ async fn run_tls_profile(executable: &str, artifacts: &Path) -> Result<(), Box<d
 
 async fn supervise_smoke(
     executable: &str,
-) -> Result<(i32, Vec<String>, FixtureResult, Vec<DataScenarioResult>), Box<dyn Error>> {
+) -> Result<
+    (
+        i32,
+        Vec<String>,
+        FixtureResult,
+        Vec<DataScenarioResult>,
+        Vec<QueryLifecycleResult>,
+    ),
+    Box<dyn Error>,
+> {
     let container = Postgres::default()
         .with_host_auth()
         .with_tag("18-alpine")
@@ -490,14 +515,15 @@ async fn supervise_smoke(
 
     let mut driver = spawn_child(executable, "driver-child", listen_addr).await?;
     let completed = read_event(&mut driver).await?;
-    let (value, mut coverage, fixtures, data_scenarios) = match completed {
+    let (value, mut coverage, fixtures, data_scenarios, query_lifecycle) = match completed {
         ChildEvent::Completed {
             value: Some(value),
             coverage,
             fixtures: Some(fixtures),
             data_scenarios,
+            query_lifecycle,
             ..
-        } => (value, coverage, fixtures, data_scenarios),
+        } => (value, coverage, fixtures, data_scenarios, query_lifecycle),
         event => return Err(format!("expected driver completion event, got {event:?}").into()),
     };
     wait_success(&mut driver, "driver").await?;
@@ -512,7 +538,7 @@ async fn supervise_smoke(
     coverage.extend(intermediary_coverage);
     wait_success(&mut intermediary, "intermediary").await?;
     drop(container);
-    Ok((value, coverage, fixtures, data_scenarios))
+    Ok((value, coverage, fixtures, data_scenarios, query_lifecycle))
 }
 
 const REQUIRED_SMOKE_STAGES: [&str; 7] = [
@@ -525,8 +551,9 @@ const REQUIRED_SMOKE_STAGES: [&str; 7] = [
     "smoke.extended-select.driver-validated",
 ];
 
-const REQUIRED_SMOKE_COVERAGE: [&str; 16] = [
+const REQUIRED_SMOKE_COVERAGE: [&str; 23] = [
     "backend.BindResponse.Complete",
+    "backend.Building.Bind",
     "backend.Building.Describe",
     "backend.Building.Execute",
     "backend.Building.Sync",
@@ -536,11 +563,17 @@ const REQUIRED_SMOKE_COVERAGE: [&str; 16] = [
     "backend.DescribeResponse.RowDescription",
     "backend.ExecuteResponse.CommandComplete",
     "backend.ExecuteResponse.Continue",
+    "backend.ExecuteResponse.PortalSuspended",
+    "backend.Building.Flush",
     "backend.ParseResponse.Complete",
     "backend.Ready.Bind",
     "backend.Ready.Close",
+    "backend.Ready.Execute",
     "backend.Ready.Parse",
     "backend.Ready.Terminate",
+    "backend.Ready.Query",
+    "backend.Simple.Continue",
+    "backend.Simple.Ready",
     "backend.SyncResponse.Ready",
 ];
 
@@ -734,31 +767,36 @@ async fn run_intermediary_child(arguments: &[String]) -> Result<(), Box<dyn Erro
         listen_addr: listener.local_addr()?,
     })
     .await?;
-    let (transport, peer) = listener.accept().await?;
-    let mut session = Box::pin(intermediary.accept(transport, peer, CoverageState::default()))
-        .await
-        .map_err(debug_error)?
-        .into_session();
-    let coverage = loop {
-        match session.forward_next().await {
-            Ok(ForwardedMessage::Frontend(FrontendMessage::Terminate)) => {
-                let (_, _, state, ..) = session.teardown();
-                break state.0;
-            }
-            Ok(_) => {}
-            Err(error) => {
-                let message = format!("intermediary forwarding failed: {error:?}");
-                let _transports = session.teardown();
-                return Err(message.into());
+    let mut coverage = BTreeSet::new();
+    for _ in 0..2 {
+        let (transport, peer) = listener.accept().await?;
+        let mut session = Box::pin(intermediary.accept(transport, peer, CoverageState::default()))
+            .await
+            .map_err(debug_error)?
+            .into_session();
+        loop {
+            match session.forward_next().await {
+                Ok(ForwardedMessage::Frontend(FrontendMessage::Terminate)) => {
+                    let (_, _, state, ..) = session.teardown();
+                    coverage.extend(state.0);
+                    break;
+                }
+                Ok(_) => {}
+                Err(error) => {
+                    let message = format!("intermediary forwarding failed: {error:?}");
+                    let _transports = session.teardown();
+                    return Err(message.into());
+                }
             }
         }
-    };
+    }
     write_event(&ChildEvent::Completed {
         version: 1,
         value: None,
         coverage: coverage.into_iter().collect(),
         fixtures: None,
         data_scenarios: Vec::new(),
+        query_lifecycle: Vec::new(),
     })
     .await
 }
@@ -832,6 +870,7 @@ async fn run_tls_credential_intermediary(
         coverage: coverage.into_iter().collect(),
         fixtures: None,
         data_scenarios: Vec::new(),
+        query_lifecycle: Vec::new(),
     })
     .await
 }
@@ -897,6 +936,7 @@ async fn run_credential_intermediary(
         coverage: coverage.into_iter().collect(),
         fixtures: None,
         data_scenarios: Vec::new(),
+        query_lifecycle: Vec::new(),
     })
     .await
 }
@@ -912,7 +952,7 @@ async fn run_driver_child(arguments: &[String]) -> Result<(), Box<dyn Error>> {
     if let Ok(password) = option(arguments, "--password") {
         config.password(password);
     }
-    let (client, connection) = config.connect(tokio_postgres::NoTls).await?;
+    let (mut client, connection) = config.connect(tokio_postgres::NoTls).await?;
     let connection_task = tokio::spawn(connection);
     let value: i32 = client.query_one("SELECT 42::int4", &[]).await?.get(0);
     if value != 42 {
@@ -920,8 +960,10 @@ async fn run_driver_child(arguments: &[String]) -> Result<(), Box<dyn Error>> {
     }
     let fixtures = install_and_verify_fixtures(&client).await?;
     let data_scenarios = run_data_scenarios(&client).await?;
+    let mut query_lifecycle = run_query_lifecycles(&mut client).await?;
     drop(client);
     timeout(CHILD_TIMEOUT, connection_task).await???;
+    query_lifecycle.push(run_flush_lifecycle(proxy).await?);
     write_event(&ChildEvent::Completed {
         version: 1,
         value: Some(value),
@@ -931,8 +973,155 @@ async fn run_driver_child(arguments: &[String]) -> Result<(), Box<dyn Error>> {
         ],
         fixtures: Some(fixtures),
         data_scenarios,
+        query_lifecycle,
     })
     .await
+}
+
+async fn run_query_lifecycles(
+    client: &mut tokio_postgres::Client,
+) -> Result<Vec<QueryLifecycleResult>, Box<dyn Error>> {
+    let simple = client.simple_query("SELECT 11::int4").await?;
+    let simple_valid = simple.iter().any(|message| {
+        matches!(message, tokio_postgres::SimpleQueryMessage::Row(row) if row.get(0) == Some("11"))
+    });
+    let mut results = vec![lifecycle_result(client, "simple-query", simple_valid).await?];
+
+    let unnamed = client
+        .query_typed_one(
+            "SELECT $1::int4",
+            &[(&12_i32, tokio_postgres::types::Type::INT4)],
+        )
+        .await?;
+    results
+        .push(lifecycle_result(client, "unnamed-extended", unnamed.get::<_, i32>(0) == 12).await?);
+
+    let transaction = client.transaction().await?;
+    let statement = transaction
+        .prepare("SELECT value::int4 FROM generate_series(1, 5) value ORDER BY value")
+        .await?;
+    let portal = transaction.bind(&statement, &[]).await?;
+    let first = transaction.query_portal(&portal, 2).await?;
+    let second = transaction.query_portal(&portal, 2).await?;
+    let third = transaction.query_portal(&portal, 2).await?;
+    let values: Vec<i32> = first
+        .iter()
+        .chain(&second)
+        .chain(&third)
+        .map(|row| row.get(0))
+        .collect();
+    let suspended_valid =
+        values == [1, 2, 3, 4, 5] && first.len() == 2 && second.len() == 2 && third.len() == 1;
+    drop(portal);
+    drop(statement);
+    transaction.commit().await?;
+    results.push(lifecycle_result(client, "named-statement-and-portal", suspended_valid).await?);
+    results.push(lifecycle_result(client, "portal-suspension", suspended_valid).await?);
+
+    let binary = client.query_one("SELECT $1::int4 + 1", &[&41_i32]).await?;
+    results.push(lifecycle_result(client, "binary-formats", binary.get::<_, i32>(0) == 42).await?);
+
+    let (left, right) = tokio::try_join!(
+        client.query_one("SELECT 21::int4", &[]),
+        client.query_one("SELECT 22::int4", &[]),
+    )?;
+    results.push(
+        lifecycle_result(
+            client,
+            "pipelined-extended",
+            left.get::<_, i32>(0) == 21 && right.get::<_, i32>(0) == 22,
+        )
+        .await?,
+    );
+    Ok(results)
+}
+
+async fn lifecycle_result(
+    client: &tokio_postgres::Client,
+    name: &str,
+    validated: bool,
+) -> Result<QueryLifecycleResult, Box<dyn Error>> {
+    let ready_after = client
+        .query_one("SELECT 1::int4", &[])
+        .await?
+        .get::<_, i32>(0)
+        == 1;
+    Ok(QueryLifecycleResult {
+        name: name.into(),
+        ready_after,
+        validated,
+    })
+}
+
+async fn run_flush_lifecycle(proxy: SocketAddr) -> Result<QueryLifecycleResult, Box<dyn Error>> {
+    let mut stream = TcpStream::connect(proxy).await?;
+    let mut startup = BytesMut::new();
+    startup.put_i32(0);
+    startup.put_i32(196_608);
+    startup.extend_from_slice(b"user\0postgres\0database\0postgres\0\0");
+    let startup_len = startup.len() as i32;
+    startup[..4].copy_from_slice(&startup_len.to_be_bytes());
+    stream.write_all(&startup).await?;
+    let _startup_messages = read_until_ready(&mut stream).await?;
+
+    let mut messages = BytesMut::new();
+    frontend::parse("", "SELECT 23::int4", std::iter::empty(), &mut messages)?;
+    frontend::bind(
+        "",
+        "",
+        std::iter::empty::<i16>(),
+        std::iter::empty::<()>(),
+        |(), _| -> Result<postgres_protocol::IsNull, Box<dyn Error + Send + Sync>> {
+            Ok(postgres_protocol::IsNull::Yes)
+        },
+        [1_i16],
+        &mut messages,
+    )
+    .map_err(|error| match error {
+        postgres_protocol::message::frontend::BindError::Conversion(error) => {
+            io::Error::other(error)
+        }
+        postgres_protocol::message::frontend::BindError::Serialization(error) => error,
+    })?;
+    frontend::describe(b'P', "", &mut messages)?;
+    frontend::execute("", 0, &mut messages)?;
+    frontend::flush(&mut messages);
+    frontend::sync(&mut messages);
+    stream.write_all(&messages).await?;
+    let result_rows = read_until_ready(&mut stream).await?;
+
+    let mut recovery = BytesMut::new();
+    frontend::query("SELECT 1::int4", &mut recovery)?;
+    stream.write_all(&recovery).await?;
+    let recovery_rows = read_until_ready(&mut stream).await?;
+    let mut terminate = BytesMut::new();
+    frontend::terminate(&mut terminate);
+    stream.write_all(&terminate).await?;
+    Ok(QueryLifecycleResult {
+        name: "flush-and-sync".into(),
+        ready_after: recovery_rows == 1,
+        validated: result_rows == 1,
+    })
+}
+
+async fn read_until_ready(stream: &mut TcpStream) -> Result<usize, Box<dyn Error>> {
+    let mut input = BytesMut::new();
+    let mut data_rows = 0;
+    loop {
+        while let Some(message) = backend::Message::parse(&mut input)? {
+            match message {
+                backend::Message::ErrorResponse(_) => {
+                    return Err("PostgreSQL error during raw lifecycle".into());
+                }
+                backend::Message::DataRow(_) => data_rows += 1,
+                backend::Message::ReadyForQuery(_) => return Ok(data_rows),
+                _ => {}
+            }
+        }
+        if stream.read_buf(&mut input).await? == 0 {
+            return Err("PostgreSQL closed before ReadyForQuery".into());
+        }
+    }
 }
 
 const FIXTURE_SCHEMA: &str = include_str!("../fixtures/schema-v1.sql");
@@ -1204,7 +1393,7 @@ mod tests {
         let mut observed: Vec<_> = REQUIRED_SMOKE_COVERAGE.map(str::to_owned).into();
         observed.extend(REQUIRED_SMOKE_STAGES.map(str::to_owned));
         let report = coverage_report(&observed).expect("complete known coverage");
-        assert_eq!(report.observed_ids.len(), 16);
+        assert_eq!(report.observed_ids.len(), 23);
         assert!(report.missing.is_empty());
     }
 

--- a/pg-proto-burn-in/src/lib.rs
+++ b/pg-proto-burn-in/src/lib.rs
@@ -1,6 +1,7 @@
 //! Multi-process PostgreSQL protocol verification harness.
 
 use std::{
+    collections::BTreeSet,
     convert::Infallible,
     error::Error,
     io,
@@ -11,9 +12,11 @@ use std::{
 };
 
 use pg_proto::{
-    BoundedPipeline, CancellationPolicy, Client, ClientTlsPolicy, ConnectTarget, ForwardedMessage,
-    FrontendMessage, InitialServerContext, Intermediary, Server, ServerTlsPolicy,
-    StartupParameters, StartupRouteResolver, TrustClientAuthentication, TrustServerAuthentication,
+    BoundedPipeline, CancellationPolicy, Client, ClientConnectionContext, ClientTlsPolicy,
+    ConnectTarget, ForwardedMessage, FrontendMessage, InitialServerContext, Intermediary,
+    IntermediaryMiddleware, ProtocolTransitionDirection, ProtocolTransitionObservation, Server,
+    ServerConnectionContext, ServerTlsPolicy, StartupParameters, StartupRouteResolver,
+    TrustClientAuthentication, TrustIdentity, TrustServerAuthentication,
 };
 use serde::{Deserialize, Serialize};
 use testcontainers_modules::{
@@ -46,6 +49,7 @@ struct RunResult {
     profile: String,
     postgres_version: String,
     scenario: ScenarioResult,
+    coverage: CoverageReport,
     success: bool,
 }
 
@@ -53,6 +57,17 @@ struct RunResult {
 struct ScenarioResult {
     name: String,
     value: i32,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct CoverageReport {
+    observed_ids: Vec<String>,
+    stages: Vec<String>,
+    real_postgres: Vec<String>,
+    scripted: Vec<String>,
+    indirect: Vec<String>,
+    missing: Vec<String>,
+    exempted: Vec<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -65,6 +80,7 @@ enum ChildEvent {
     Completed {
         version: u32,
         value: Option<i32>,
+        coverage: Vec<String>,
     },
 }
 
@@ -78,7 +94,7 @@ async fn run_conformance(arguments: &[String]) -> Result<(), Box<dyn Error>> {
 
     let outcome = supervise_smoke(arguments.first().ok_or("missing executable path")?).await;
     let result = match &outcome {
-        Ok(value) => RunResult {
+        Ok((value, coverage)) => RunResult {
             schema_version: 1,
             command: "conformance".into(),
             profile: profile.into(),
@@ -87,6 +103,7 @@ async fn run_conformance(arguments: &[String]) -> Result<(), Box<dyn Error>> {
                 name: "extended-select-scalar".into(),
                 value: *value,
             },
+            coverage: coverage_report(coverage)?,
             success: true,
         },
         Err(_) => RunResult {
@@ -98,6 +115,7 @@ async fn run_conformance(arguments: &[String]) -> Result<(), Box<dyn Error>> {
                 name: "extended-select-scalar".into(),
                 value: 0,
             },
+            coverage: CoverageReport::default(),
             success: false,
         },
     };
@@ -105,7 +123,7 @@ async fn run_conformance(arguments: &[String]) -> Result<(), Box<dyn Error>> {
     outcome.map(|_| ())
 }
 
-async fn supervise_smoke(executable: &str) -> Result<i32, Box<dyn Error>> {
+async fn supervise_smoke(executable: &str) -> Result<(i32, Vec<String>), Box<dyn Error>> {
     let container = Postgres::default()
         .with_host_auth()
         .with_tag("18-alpine")
@@ -125,23 +143,94 @@ async fn supervise_smoke(executable: &str) -> Result<i32, Box<dyn Error>> {
 
     let mut driver = spawn_child(executable, "driver-child", listen_addr).await?;
     let completed = read_event(&mut driver).await?;
-    let value = match completed {
+    let (value, mut coverage) = match completed {
         ChildEvent::Completed {
-            value: Some(value), ..
-        } => value,
+            value: Some(value),
+            coverage,
+            ..
+        } => (value, coverage),
         event => return Err(format!("expected driver completion event, got {event:?}").into()),
     };
     wait_success(&mut driver, "driver").await?;
     let intermediary_completed = read_event(&mut intermediary).await?;
-    if !matches!(intermediary_completed, ChildEvent::Completed { .. }) {
-        return Err(format!(
-            "expected intermediary completion event, got {intermediary_completed:?}"
-        )
-        .into());
-    }
+    let ChildEvent::Completed {
+        coverage: intermediary_coverage,
+        ..
+    } = intermediary_completed
+    else {
+        return Err("expected intermediary completion event".into());
+    };
+    coverage.extend(intermediary_coverage);
     wait_success(&mut intermediary, "intermediary").await?;
     drop(container);
-    Ok(value)
+    Ok((value, coverage))
+}
+
+const REQUIRED_SMOKE_STAGES: [&str; 7] = [
+    "smoke.extended-select.driver-emitted",
+    "smoke.extended-select.server-decoded",
+    "smoke.extended-select.middleware-observed",
+    "smoke.extended-select.client-encoded",
+    "smoke.extended-select.postgres-accepted",
+    "smoke.extended-select.return-traversed",
+    "smoke.extended-select.driver-validated",
+];
+
+const REQUIRED_SMOKE_COVERAGE: [&str; 15] = [
+    "backend.BindResponse.Complete",
+    "backend.Building.Describe",
+    "backend.Building.Execute",
+    "backend.Building.Sync",
+    "backend.CloseResponse.Complete",
+    "backend.DescribeResponse.ParameterDescription",
+    "backend.DescribeResponse.RowDescription",
+    "backend.ExecuteResponse.CommandComplete",
+    "backend.ExecuteResponse.Continue",
+    "backend.ParseResponse.Complete",
+    "backend.Ready.Bind",
+    "backend.Ready.Close",
+    "backend.Ready.Parse",
+    "backend.Ready.Terminate",
+    "backend.SyncResponse.Ready",
+];
+
+fn coverage_report(observed: &[String]) -> Result<CoverageReport, Box<dyn Error>> {
+    let stages: BTreeSet<_> = observed
+        .iter()
+        .map(String::as_str)
+        .filter(|id| id.starts_with("smoke."))
+        .collect();
+    let observed: BTreeSet<_> = observed
+        .iter()
+        .map(String::as_str)
+        .filter(|id| !id.starts_with("smoke."))
+        .collect();
+    let required: BTreeSet<_> = REQUIRED_SMOKE_COVERAGE.into_iter().collect();
+    let unknown: Vec<_> = observed.difference(&required).copied().collect();
+    if !unknown.is_empty() {
+        return Err(format!("unknown required coverage IDs: {}", unknown.join(", ")).into());
+    }
+    let missing: Vec<String> = required
+        .difference(&observed)
+        .map(|id| (*id).to_owned())
+        .collect();
+    if !missing.is_empty() {
+        return Err(format!("missing required coverage IDs: {}", missing.join(", ")).into());
+    }
+    let required_stages: BTreeSet<_> = REQUIRED_SMOKE_STAGES.into_iter().collect();
+    if stages != required_stages {
+        return Err("smoke scenario did not record all seven observation stages".into());
+    }
+    let observed_ids: Vec<_> = observed.into_iter().map(str::to_owned).collect();
+    Ok(CoverageReport {
+        real_postgres: observed_ids.clone(),
+        observed_ids,
+        stages: stages.into_iter().map(str::to_owned).collect(),
+        scripted: Vec::new(),
+        indirect: Vec::new(),
+        missing: Vec::new(),
+        exempted: Vec::new(),
+    })
 }
 
 async fn spawn_child(
@@ -178,6 +267,45 @@ async fn wait_success(child: &mut Child, role: &str) -> Result<(), Box<dyn Error
 #[derive(Clone, Copy)]
 struct Route(SocketAddr);
 
+#[derive(Default)]
+struct CoverageState(BTreeSet<String>);
+
+struct CoverageObserver;
+
+impl
+    IntermediaryMiddleware<
+        CoverageState,
+        ServerConnectionContext<SocketAddr, TrustIdentity>,
+        ClientConnectionContext<()>,
+    > for CoverageObserver
+{
+    type Error = Infallible;
+
+    async fn observe_transition(
+        &mut self,
+        _server: &ServerConnectionContext<SocketAddr, TrustIdentity>,
+        _client: &ClientConnectionContext<()>,
+        state: &mut CoverageState,
+        observation: ProtocolTransitionObservation,
+    ) {
+        state.0.insert(observation.id.to_owned());
+        let stages: &[&str] = match observation.direction {
+            ProtocolTransitionDirection::Frontend => &[
+                "smoke.extended-select.server-decoded",
+                "smoke.extended-select.middleware-observed",
+                "smoke.extended-select.client-encoded",
+            ],
+            ProtocolTransitionDirection::Backend => &[
+                "smoke.extended-select.postgres-accepted",
+                "smoke.extended-select.return-traversed",
+            ],
+        };
+        state
+            .0
+            .extend(stages.iter().map(|stage| (*stage).to_owned()));
+    }
+}
+
 impl StartupRouteResolver<SocketAddr> for Route {
     type Error = Infallible;
 
@@ -209,6 +337,10 @@ async fn run_intermediary_child(arguments: &[String]) -> Result<(), Box<dyn Erro
         .startup_resolver(Route(upstream))
         .cancellation(CancellationPolicy::Reject)
         .pipeline(BoundedPipeline::new(64).expect("non-zero smoke pipeline capacity"))
+        .middleware(
+            |_: &ServerConnectionContext<SocketAddr, TrustIdentity>,
+             _: &ClientConnectionContext<()>| CoverageObserver,
+        )
         .build()
         .map_err(debug_error)?;
 
@@ -219,15 +351,15 @@ async fn run_intermediary_child(arguments: &[String]) -> Result<(), Box<dyn Erro
     })
     .await?;
     let (transport, peer) = listener.accept().await?;
-    let mut session = Box::pin(intermediary.accept(transport, peer, ()))
+    let mut session = Box::pin(intermediary.accept(transport, peer, CoverageState::default()))
         .await
         .map_err(debug_error)?
         .into_session();
-    loop {
+    let coverage = loop {
         match session.forward_next().await {
             Ok(ForwardedMessage::Frontend(FrontendMessage::Terminate)) => {
-                let _transports = session.teardown();
-                break;
+                let (_, _, state, ..) = session.teardown();
+                break state.0;
             }
             Ok(_) => {}
             Err(error) => {
@@ -236,10 +368,11 @@ async fn run_intermediary_child(arguments: &[String]) -> Result<(), Box<dyn Erro
                 return Err(message.into());
             }
         }
-    }
+    };
     write_event(&ChildEvent::Completed {
         version: 1,
         value: None,
+        coverage: coverage.into_iter().collect(),
     })
     .await
 }
@@ -263,6 +396,10 @@ async fn run_driver_child(arguments: &[String]) -> Result<(), Box<dyn Error>> {
     write_event(&ChildEvent::Completed {
         version: 1,
         value: Some(value),
+        coverage: vec![
+            "smoke.extended-select.driver-emitted".into(),
+            "smoke.extended-select.driver-validated".into(),
+        ],
     })
     .await
 }
@@ -306,4 +443,27 @@ fn option<'a>(arguments: &'a [String], name: &str) -> Result<&'a str, Box<dyn Er
 
 fn debug_error(error: impl std::fmt::Debug) -> io::Error {
     io::Error::other(format!("{error:?}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{REQUIRED_SMOKE_COVERAGE, REQUIRED_SMOKE_STAGES, coverage_report};
+
+    #[test]
+    fn required_smoke_coverage_is_stable_and_complete() {
+        let mut observed: Vec<_> = REQUIRED_SMOKE_COVERAGE.map(str::to_owned).into();
+        observed.extend(REQUIRED_SMOKE_STAGES.map(str::to_owned));
+        let report = coverage_report(&observed).expect("complete known coverage");
+        assert_eq!(report.observed_ids.len(), 15);
+        assert!(report.missing.is_empty());
+    }
+
+    #[test]
+    fn unknown_coverage_fails_conformance() {
+        let mut observed: Vec<_> = REQUIRED_SMOKE_COVERAGE.map(str::to_owned).into();
+        observed.extend(REQUIRED_SMOKE_STAGES.map(str::to_owned));
+        observed.push("backend.Renamed.WithoutMigration".into());
+        let error = coverage_report(&observed).expect_err("unknown ID must fail");
+        assert!(error.to_string().contains("unknown required coverage IDs"));
+    }
 }

--- a/pg-proto-burn-in/src/lib.rs
+++ b/pg-proto-burn-in/src/lib.rs
@@ -795,6 +795,8 @@ const REQUIRED_SMOKE_COVERAGE: [&str; 37] = [
     "backend.SyncResponse.Ready",
 ];
 
+const OPTIONAL_SMOKE_COVERAGE: [&str; 1] = ["backend.DescribeResponse.Error"];
+
 fn coverage_report(observed: &[String]) -> Result<CoverageReport, Box<dyn Error>> {
     let stages: BTreeSet<_> = observed
         .iter()
@@ -807,7 +809,12 @@ fn coverage_report(observed: &[String]) -> Result<CoverageReport, Box<dyn Error>
         .filter(|id| !id.starts_with("smoke."))
         .collect();
     let required: BTreeSet<_> = REQUIRED_SMOKE_COVERAGE.into_iter().collect();
-    let unknown: Vec<_> = observed.difference(&required).copied().collect();
+    let known: BTreeSet<_> = required
+        .iter()
+        .copied()
+        .chain(OPTIONAL_SMOKE_COVERAGE)
+        .collect();
+    let unknown: Vec<_> = observed.difference(&known).copied().collect();
     if !unknown.is_empty() {
         return Err(format!("unknown required coverage IDs: {}", unknown.join(", ")).into());
     }
@@ -842,6 +849,9 @@ async fn spawn_authenticated_child(
 ) -> Result<Child, Box<dyn Error>> {
     let mut command = Command::new(executable);
     command.args([role, "--address", &address.to_string()]);
+    if role == "driver-child" {
+        command.arg("--basic");
+    }
     if let Some(password) = password {
         command.args(["--password", password]);
     }
@@ -1344,6 +1354,24 @@ async fn run_driver_child(arguments: &[String]) -> Result<(), Box<dyn Error>> {
         .get(0);
     if value != 42 {
         return Err(format!("expected 42, got {value}").into());
+    }
+    if arguments.iter().any(|argument| argument == "--basic") {
+        drop(client);
+        timeout(CHILD_TIMEOUT, connection_task).await???;
+        return write_event(&ChildEvent::Completed {
+            version: 1,
+            value: Some(value),
+            coverage: Vec::new(),
+            fixtures: None,
+            data_scenarios: Vec::new(),
+            query_lifecycle: Vec::new(),
+            error_scenarios: Vec::new(),
+            copy_scenarios: Vec::new(),
+            async_traffic: None,
+            cancellation: None,
+            cancellation_registry: None,
+        })
+        .await;
     }
     let mut async_traffic = AsyncTrafficResult::default();
     if let Ok(notifier_address) = option(arguments, "--notify-address") {
@@ -2444,6 +2472,19 @@ mod tests {
         observed.push("backend.Renamed.WithoutMigration".into());
         let error = coverage_report(&observed).expect_err("unknown ID must fail");
         assert!(error.to_string().contains("unknown required coverage IDs"));
+    }
+
+    #[test]
+    fn optional_error_transition_is_known_but_not_required() {
+        let mut observed: Vec<_> = REQUIRED_SMOKE_COVERAGE.map(str::to_owned).into();
+        observed.extend(REQUIRED_SMOKE_STAGES.map(str::to_owned));
+        observed.push("backend.DescribeResponse.Error".into());
+        let report = coverage_report(&observed).expect("optional known coverage");
+        assert!(
+            report
+                .observed_ids
+                .contains(&"backend.DescribeResponse.Error".into())
+        );
     }
 
     #[test]

--- a/pg-proto-burn-in/src/lib.rs
+++ b/pg-proto-burn-in/src/lib.rs
@@ -11,6 +11,7 @@ use std::{
     time::Duration,
 };
 
+use futures_util::TryStreamExt;
 use pg_proto::{
     BoundedPipeline, CancellationPolicy, Client, ClientConnectionContext, ClientTlsPolicy,
     ConnectTarget, ForwardedMessage, FrontendMessage, InitialServerContext, Intermediary,
@@ -19,6 +20,7 @@ use pg_proto::{
     TrustClientAuthentication, TrustIdentity, TrustServerAuthentication,
 };
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use testcontainers_modules::{
     postgres::Postgres,
     testcontainers::{ImageExt, runners::AsyncRunner},
@@ -49,6 +51,8 @@ struct RunResult {
     profile: String,
     postgres_version: String,
     scenario: ScenarioResult,
+    fixtures: FixtureResult,
+    data_scenarios: Vec<DataScenarioResult>,
     coverage: CoverageReport,
     success: bool,
 }
@@ -57,6 +61,24 @@ struct RunResult {
 struct ScenarioResult {
     name: String,
     value: i32,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+struct FixtureResult {
+    version: u32,
+    expected_checksum: String,
+    actual_checksum: String,
+    checksum_verified: bool,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct DataScenarioResult {
+    name: String,
+    rows: u64,
+    bytes: u64,
+    nulls: u64,
+    digest: Option<String>,
+    validated: bool,
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]
@@ -81,6 +103,10 @@ enum ChildEvent {
         version: u32,
         value: Option<i32>,
         coverage: Vec<String>,
+        #[serde(default)]
+        fixtures: Option<FixtureResult>,
+        #[serde(default)]
+        data_scenarios: Vec<DataScenarioResult>,
     },
 }
 
@@ -94,7 +120,7 @@ async fn run_conformance(arguments: &[String]) -> Result<(), Box<dyn Error>> {
 
     let outcome = supervise_smoke(arguments.first().ok_or("missing executable path")?).await;
     let result = match &outcome {
-        Ok((value, coverage)) => RunResult {
+        Ok((value, coverage, fixtures, data_scenarios)) => RunResult {
             schema_version: 1,
             command: "conformance".into(),
             profile: profile.into(),
@@ -103,6 +129,8 @@ async fn run_conformance(arguments: &[String]) -> Result<(), Box<dyn Error>> {
                 name: "extended-select-scalar".into(),
                 value: *value,
             },
+            fixtures: fixtures.clone(),
+            data_scenarios: data_scenarios.clone(),
             coverage: coverage_report(coverage)?,
             success: true,
         },
@@ -115,6 +143,8 @@ async fn run_conformance(arguments: &[String]) -> Result<(), Box<dyn Error>> {
                 name: "extended-select-scalar".into(),
                 value: 0,
             },
+            fixtures: FixtureResult::default(),
+            data_scenarios: Vec::new(),
             coverage: CoverageReport::default(),
             success: false,
         },
@@ -123,7 +153,9 @@ async fn run_conformance(arguments: &[String]) -> Result<(), Box<dyn Error>> {
     outcome.map(|_| ())
 }
 
-async fn supervise_smoke(executable: &str) -> Result<(i32, Vec<String>), Box<dyn Error>> {
+async fn supervise_smoke(
+    executable: &str,
+) -> Result<(i32, Vec<String>, FixtureResult, Vec<DataScenarioResult>), Box<dyn Error>> {
     let container = Postgres::default()
         .with_host_auth()
         .with_tag("18-alpine")
@@ -143,12 +175,14 @@ async fn supervise_smoke(executable: &str) -> Result<(i32, Vec<String>), Box<dyn
 
     let mut driver = spawn_child(executable, "driver-child", listen_addr).await?;
     let completed = read_event(&mut driver).await?;
-    let (value, mut coverage) = match completed {
+    let (value, mut coverage, fixtures, data_scenarios) = match completed {
         ChildEvent::Completed {
             value: Some(value),
             coverage,
+            fixtures: Some(fixtures),
+            data_scenarios,
             ..
-        } => (value, coverage),
+        } => (value, coverage, fixtures, data_scenarios),
         event => return Err(format!("expected driver completion event, got {event:?}").into()),
     };
     wait_success(&mut driver, "driver").await?;
@@ -163,7 +197,7 @@ async fn supervise_smoke(executable: &str) -> Result<(i32, Vec<String>), Box<dyn
     coverage.extend(intermediary_coverage);
     wait_success(&mut intermediary, "intermediary").await?;
     drop(container);
-    Ok((value, coverage))
+    Ok((value, coverage, fixtures, data_scenarios))
 }
 
 const REQUIRED_SMOKE_STAGES: [&str; 7] = [
@@ -176,13 +210,14 @@ const REQUIRED_SMOKE_STAGES: [&str; 7] = [
     "smoke.extended-select.driver-validated",
 ];
 
-const REQUIRED_SMOKE_COVERAGE: [&str; 15] = [
+const REQUIRED_SMOKE_COVERAGE: [&str; 16] = [
     "backend.BindResponse.Complete",
     "backend.Building.Describe",
     "backend.Building.Execute",
     "backend.Building.Sync",
     "backend.CloseResponse.Complete",
     "backend.DescribeResponse.ParameterDescription",
+    "backend.DescribeResponse.NoData",
     "backend.DescribeResponse.RowDescription",
     "backend.ExecuteResponse.CommandComplete",
     "backend.ExecuteResponse.Continue",
@@ -373,6 +408,8 @@ async fn run_intermediary_child(arguments: &[String]) -> Result<(), Box<dyn Erro
         version: 1,
         value: None,
         coverage: coverage.into_iter().collect(),
+        fixtures: None,
+        data_scenarios: Vec::new(),
     })
     .await
 }
@@ -391,6 +428,8 @@ async fn run_driver_child(arguments: &[String]) -> Result<(), Box<dyn Error>> {
     if value != 42 {
         return Err(format!("expected 42, got {value}").into());
     }
+    let fixtures = install_and_verify_fixtures(&client).await?;
+    let data_scenarios = run_data_scenarios(&client).await?;
     drop(client);
     timeout(CHILD_TIMEOUT, connection_task).await???;
     write_event(&ChildEvent::Completed {
@@ -400,8 +439,222 @@ async fn run_driver_child(arguments: &[String]) -> Result<(), Box<dyn Error>> {
             "smoke.extended-select.driver-emitted".into(),
             "smoke.extended-select.driver-validated".into(),
         ],
+        fixtures: Some(fixtures),
+        data_scenarios,
     })
     .await
+}
+
+const FIXTURE_SCHEMA: &str = include_str!("../fixtures/schema-v1.sql");
+const FIXTURE_SEED: &str = include_str!("../fixtures/seed-v1.sql");
+const FIXTURE_CHECKSUM: &str = "214b809aeff4f6934f7e091a05051fa0";
+
+async fn install_and_verify_fixtures(
+    client: &tokio_postgres::Client,
+) -> Result<FixtureResult, Box<dyn Error>> {
+    client.execute(FIXTURE_SCHEMA, &[]).await?;
+    client.execute(FIXTURE_SEED, &[]).await?;
+    let first = fixture_checksum(client).await?;
+    client.execute(FIXTURE_SCHEMA, &[]).await?;
+    client.execute(FIXTURE_SEED, &[]).await?;
+    let actual = fixture_checksum(client).await?;
+    if first != actual || actual != FIXTURE_CHECKSUM {
+        return Err(format!(
+            "fixture checksum mismatch: expected {FIXTURE_CHECKSUM}, first {first}, actual {actual}"
+        )
+        .into());
+    }
+    Ok(FixtureResult {
+        version: 1,
+        expected_checksum: FIXTURE_CHECKSUM.into(),
+        actual_checksum: actual,
+        checksum_verified: true,
+    })
+}
+
+async fn fixture_checksum(client: &tokio_postgres::Client) -> Result<String, Box<dyn Error>> {
+    let row = client
+        .query_one(
+            "SELECT md5(format('%s:%s:%s:%s:%s:%s:%s:%s:%s', \
+             (SELECT count(*) FROM burnin_type_lab.samples), \
+             (SELECT sum(scalar) FROM burnin_type_lab.samples), \
+             (SELECT count(*) FROM burnin_type_lab.bulk_values), \
+             (SELECT sum(id) FROM burnin_type_lab.bulk_values), \
+             (SELECT count(*) FROM burnin_type_lab.bulk_values WHERE nullable_text IS NULL), \
+             (SELECT count(*) FROM burnin_commerce.customers), \
+             (SELECT count(*) FROM burnin_commerce.products), \
+             (SELECT count(*) FROM burnin_commerce.orders), \
+             (SELECT count(*) FROM burnin_commerce.order_lines)))",
+            &[],
+        )
+        .await?;
+    Ok(row.get(0))
+}
+
+async fn run_data_scenarios(
+    client: &tokio_postgres::Client,
+) -> Result<Vec<DataScenarioResult>, Box<dyn Error>> {
+    let zero = client
+        .query("SELECT id FROM burnin_type_lab.samples WHERE id < 0", &[])
+        .await?;
+    let typed = client
+        .query_one(
+            "SELECT scalar, nullable_text, binary_value, tags, document, wide_text \
+             FROM burnin_type_lab.samples WHERE id = 1",
+            &[],
+        )
+        .await?;
+    let scalar: i32 = typed.get(0);
+    let nullable: Option<String> = typed.get(1);
+    let binary: Vec<u8> = typed.get(2);
+    let tags: Vec<String> = typed.get(3);
+    let document: serde_json::Value = typed.get(4);
+    let wide: String = typed.get(5);
+    if scalar != 10
+        || nullable.is_some()
+        || binary != [0, 1, 2, 255]
+        || tags != ["alpha", "one"]
+        || document != serde_json::json!({"kind": "alpha", "enabled": true})
+        || wide != "wide-alpha-".repeat(40)
+    {
+        return Err("typed fixture row did not match its checked-in value".into());
+    }
+
+    let small = client
+        .query(
+            "SELECT id FROM burnin_type_lab.bulk_values WHERE id <= 7 ORDER BY id",
+            &[],
+        )
+        .await?;
+    let medium = client
+        .query(
+            "SELECT id, nullable_text FROM burnin_type_lab.bulk_values \
+             WHERE id <= 128 ORDER BY id",
+            &[],
+        )
+        .await?;
+    let medium_nulls = medium
+        .iter()
+        .filter(|row| row.get::<_, Option<&str>>(1).is_none())
+        .count() as u64;
+    let joined = client
+        .query(
+            "SELECT c.id, count(DISTINCT o.id)::bigint, count(ol.*)::bigint \
+             FROM burnin_commerce.customers c \
+             JOIN burnin_commerce.orders o ON o.customer_id = c.id \
+             JOIN burnin_commerce.order_lines ol ON ol.order_id = o.id \
+             GROUP BY c.id ORDER BY c.id",
+            &[],
+        )
+        .await?;
+    if joined.len() != 64
+        || joined
+            .iter()
+            .any(|row| row.get::<_, i64>(1) != 4 || row.get::<_, i64>(2) != 8)
+    {
+        return Err("commerce join did not produce the deterministic cardinalities".into());
+    }
+
+    let large = stream_large_result(client).await?;
+    Ok(vec![
+        scenario("zero-rows", zero.len(), 0, 0),
+        scenario("one-typed-row", 1, binary.len() + wide.len(), 1),
+        scenario(
+            "small-narrow",
+            small.len(),
+            small.len() * size_of::<i32>(),
+            0,
+        ),
+        scenario(
+            "medium-nullable",
+            medium.len(),
+            medium
+                .iter()
+                .map(|row| row.get::<_, Option<&str>>(1).map_or(0, str::len))
+                .sum(),
+            medium_nulls,
+        ),
+        scenario("commerce-join", joined.len(), joined.len() * 20, 0),
+        large,
+    ])
+}
+
+fn scenario(name: &str, rows: usize, bytes: usize, nulls: u64) -> DataScenarioResult {
+    DataScenarioResult {
+        name: name.into(),
+        rows: rows as u64,
+        bytes: bytes as u64,
+        nulls,
+        digest: None,
+        validated: true,
+    }
+}
+
+async fn stream_large_result(
+    client: &tokio_postgres::Client,
+) -> Result<DataScenarioResult, Box<dyn Error>> {
+    use tokio_postgres::types::ToSql;
+
+    let rows = client
+        .query_raw(
+            "SELECT id, nullable_text, binary_value, wide_text \
+             FROM burnin_type_lab.bulk_values ORDER BY id",
+            std::iter::empty::<&(dyn ToSql + Sync)>(),
+        )
+        .await?;
+    tokio::pin!(rows);
+    let mut digest = Sha256::new();
+    let mut row_count = 0_u64;
+    let mut byte_count = 0_u64;
+    let mut null_count = 0_u64;
+    while let Some(row) = rows.try_next().await? {
+        let id: i32 = row.get(0);
+        let nullable: Option<&str> = row.get(1);
+        let binary: &[u8] = row.get(2);
+        let wide: &str = row.get(3);
+        digest.update(id.to_be_bytes());
+        match nullable {
+            Some(value) => {
+                digest.update([1]);
+                digest.update((value.len() as u64).to_be_bytes());
+                digest.update(value.as_bytes());
+                byte_count += value.len() as u64;
+            }
+            None => {
+                digest.update([0]);
+                null_count += 1;
+            }
+        }
+        digest.update((binary.len() as u64).to_be_bytes());
+        digest.update(binary);
+        digest.update((wide.len() as u64).to_be_bytes());
+        digest.update(wide.as_bytes());
+        byte_count += size_of::<i32>() as u64 + binary.len() as u64 + wide.len() as u64;
+        row_count += 1;
+    }
+    if row_count != 4096 || null_count != 819 {
+        return Err(
+            format!("unexpected streamed counts: rows={row_count}, nulls={null_count}").into(),
+        );
+    }
+    Ok(DataScenarioResult {
+        name: "large-streamed".into(),
+        rows: row_count,
+        bytes: byte_count,
+        nulls: null_count,
+        digest: Some(hex_digest(digest.finalize().as_slice())),
+        validated: true,
+    })
+}
+
+fn hex_digest(bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
+
+    let mut result = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        write!(&mut result, "{byte:02x}").expect("writing to a String cannot fail");
+    }
+    result
 }
 
 async fn write_event(event: &ChildEvent) -> Result<(), Box<dyn Error>> {
@@ -454,7 +707,7 @@ mod tests {
         let mut observed: Vec<_> = REQUIRED_SMOKE_COVERAGE.map(str::to_owned).into();
         observed.extend(REQUIRED_SMOKE_STAGES.map(str::to_owned));
         let report = coverage_report(&observed).expect("complete known coverage");
-        assert_eq!(report.observed_ids.len(), 15);
+        assert_eq!(report.observed_ids.len(), 16);
         assert!(report.missing.is_empty());
     }
 

--- a/pg-proto-burn-in/src/lib.rs
+++ b/pg-proto-burn-in/src/lib.rs
@@ -414,7 +414,7 @@ async fn run_tls_profile(executable: &str, artifacts: &Path) -> Result<(), Box<d
     let certificate_der = generated.cert.der().to_vec();
     let certificate_path = artifacts.join("tls-root.der");
     tokio::fs::write(&certificate_path, &certificate_der).await?;
-    let setup = b"#!/bin/sh\nset -eu\ncp /docker-entrypoint-initdb.d/server.crt /var/lib/postgresql/server.crt\ncp /docker-entrypoint-initdb.d/server.key /var/lib/postgresql/server.key\nchown postgres:postgres /var/lib/postgresql/server.crt /var/lib/postgresql/server.key\nchmod 600 /var/lib/postgresql/server.key\nprintf '\\nssl=on\\nssl_cert_file=\"/var/lib/postgresql/server.crt\"\\nssl_key_file=\"/var/lib/postgresql/server.key\"\\n' >> \"$PGDATA/postgresql.conf\"\n".to_vec();
+    let setup = b"#!/bin/sh\nset -eu\ncp /docker-entrypoint-initdb.d/server.crt /var/lib/postgresql/server.crt\ncp /docker-entrypoint-initdb.d/server.key /var/lib/postgresql/server.key\nchown postgres:postgres /var/lib/postgresql/server.crt /var/lib/postgresql/server.key\nchmod 600 /var/lib/postgresql/server.key\nprintf \"\\nssl=on\\nssl_cert_file='/var/lib/postgresql/server.crt'\\nssl_key_file='/var/lib/postgresql/server.key'\\n\" >> \"$PGDATA/postgresql.conf\"\n".to_vec();
     let image = Postgres::default()
         .with_password("postgres")
         .with_tag("18-alpine")
@@ -427,7 +427,9 @@ async fn run_tls_profile(executable: &str, artifacts: &Path) -> Result<(), Box<d
             CopyDataSource::Data(generated.cert.pem().into_bytes()),
         )
         .with_copy_to(
-            CopyTargetOptions::new("/docker-entrypoint-initdb.d/server.key").with_mode(0o600),
+            // Init scripts run as `postgres`; the copied archive is root-owned.
+            // The script immediately installs the key as postgres-owned mode 0600.
+            CopyTargetOptions::new("/docker-entrypoint-initdb.d/server.key").with_mode(0o644),
             CopyDataSource::Data(generated.signing_key.serialize_pem().into_bytes()),
         );
     let container = image.start().await?;
@@ -766,6 +768,7 @@ async fn run_tls_credential_intermediary(
     password: &str,
     root: &str,
 ) -> Result<(), Box<dyn Error>> {
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
     let mut roots = RootCertStore::empty();
     roots.add(CertificateDer::from(tokio::fs::read(root).await?))?;
     let tls = RootedTls(ClientTlsConfig::new(

--- a/pg-proto-burn-in/src/lib.rs
+++ b/pg-proto-burn-in/src/lib.rs
@@ -1,26 +1,27 @@
 //! Multi-process PostgreSQL protocol verification harness.
 
 use std::{
-    collections::BTreeSet,
+    collections::{BTreeSet, HashMap},
     convert::Infallible,
     error::Error,
     io,
     net::{IpAddr, Ipv4Addr, SocketAddr},
     path::{Path, PathBuf},
     process::Stdio,
-    sync::Arc,
+    sync::{Arc, Mutex},
     time::Duration,
 };
 
 use bytes::{BufMut, BytesMut};
 use futures_util::TryStreamExt;
 use pg_proto::{
-    BoundedPipeline, CancellationPolicy, Client, ClientConnectionContext, ClientTlsConfig,
-    ClientTlsPolicy, ClientTlsProvider, ConnectTarget, ForwardedMessage, FrontendMessage,
-    InitialServerContext, Intermediary, IntermediaryMiddleware, ProtocolTransitionDirection,
-    ProtocolTransitionObservation, Server, ServerConnectionContext, ServerTlsPolicy, SslMode,
-    StartupParameters, StartupRouteResolver, StaticClientCredentials, TrustClientAuthentication,
-    TrustIdentity, TrustServerAuthentication,
+    BackendMessage, BackendMiddlewareOutput, BoundedPipeline, CancelKey, CancellationPolicy,
+    CancellationRoute, Client, ClientConnectionContext, ClientTlsConfig, ClientTlsPolicy,
+    ClientTlsProvider, ConnectTarget, ForwardedMessage, FrontendMessage, InitialServerContext,
+    Intermediary, IntermediaryCancellationRegistry, IntermediaryMiddleware, OperationId,
+    ProtocolTransitionDirection, ProtocolTransitionObservation, Server, ServerConnectionContext,
+    ServerTlsPolicy, SslMode, StartupParameters, StartupRouteResolver, StaticClientCredentials,
+    TrustClientAuthentication, TrustIdentity, TrustServerAuthentication,
 };
 use postgres_protocol::message::{backend, frontend};
 use rcgen::generate_simple_self_signed;
@@ -66,6 +67,8 @@ struct RunResult {
     data_scenarios: Vec<DataScenarioResult>,
     query_lifecycle: Vec<QueryLifecycleResult>,
     error_scenarios: Vec<SqlErrorScenarioResult>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    async_traffic: Option<AsyncTrafficResult>,
     coverage: CoverageReport,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     authentication_profiles: Vec<AuthenticationProfileResult>,
@@ -122,6 +125,22 @@ struct SqlErrorScenarioResult {
     connection_clean: bool,
 }
 
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+struct AsyncTrafficResult {
+    notice_message: String,
+    notification_channel: String,
+    notification_payload: String,
+    parameter_status: ParameterStatusResult,
+    backend_key_forwarded: bool,
+    causally_unattributed: Vec<String>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+struct ParameterStatusResult {
+    name: String,
+    value: String,
+}
+
 #[derive(Debug, Default, Serialize, Deserialize)]
 struct CoverageReport {
     observed_ids: Vec<String>,
@@ -152,6 +171,8 @@ enum ChildEvent {
         query_lifecycle: Vec<QueryLifecycleResult>,
         #[serde(default)]
         error_scenarios: Vec<SqlErrorScenarioResult>,
+        #[serde(default)]
+        async_traffic: Option<Box<AsyncTrafficResult>>,
     },
 }
 
@@ -175,6 +196,7 @@ async fn run_conformance(arguments: &[String]) -> Result<(), Box<dyn Error>> {
             data_scenarios: Vec::new(),
             query_lifecycle: Vec::new(),
             error_scenarios: Vec::new(),
+            async_traffic: None,
             coverage: CoverageReport {
                 observed_ids: coverage.clone(),
                 scripted: coverage,
@@ -198,25 +220,32 @@ async fn run_conformance(arguments: &[String]) -> Result<(), Box<dyn Error>> {
 
     let outcome = supervise_smoke(arguments.first().ok_or("missing executable path")?).await;
     let result = match &outcome {
-        Ok((value, coverage, fixtures, data_scenarios, query_lifecycle, error_scenarios)) => {
-            RunResult {
-                schema_version: 1,
-                command: "conformance".into(),
-                profile: profile.into(),
-                postgres_version: "18".into(),
-                scenario: ScenarioResult {
-                    name: "extended-select-scalar".into(),
-                    value: *value,
-                },
-                fixtures: fixtures.clone(),
-                data_scenarios: data_scenarios.clone(),
-                query_lifecycle: query_lifecycle.clone(),
-                error_scenarios: error_scenarios.clone(),
-                coverage: coverage_report(coverage)?,
-                authentication_profiles: Vec::new(),
-                success: true,
-            }
-        }
+        Ok((
+            value,
+            coverage,
+            fixtures,
+            data_scenarios,
+            query_lifecycle,
+            error_scenarios,
+            async_traffic,
+        )) => RunResult {
+            schema_version: 1,
+            command: "conformance".into(),
+            profile: profile.into(),
+            postgres_version: "18".into(),
+            scenario: ScenarioResult {
+                name: "extended-select-scalar".into(),
+                value: *value,
+            },
+            fixtures: fixtures.clone(),
+            data_scenarios: data_scenarios.clone(),
+            query_lifecycle: query_lifecycle.clone(),
+            error_scenarios: error_scenarios.clone(),
+            async_traffic: Some(async_traffic.clone()),
+            coverage: coverage_report(coverage)?,
+            authentication_profiles: Vec::new(),
+            success: true,
+        },
         Err(_) => RunResult {
             schema_version: 1,
             command: "conformance".into(),
@@ -230,6 +259,7 @@ async fn run_conformance(arguments: &[String]) -> Result<(), Box<dyn Error>> {
             data_scenarios: Vec::new(),
             query_lifecycle: Vec::new(),
             error_scenarios: Vec::new(),
+            async_traffic: None,
             coverage: CoverageReport::default(),
             authentication_profiles: Vec::new(),
             success: false,
@@ -261,6 +291,7 @@ async fn run_authentication_conformance(
         data_scenarios: Vec::new(),
         query_lifecycle: Vec::new(),
         error_scenarios: Vec::new(),
+        async_traffic: None,
         coverage: CoverageReport::default(),
         authentication_profiles: profiles,
         success: outcome.is_ok(),
@@ -513,6 +544,7 @@ async fn supervise_smoke(
         Vec<DataScenarioResult>,
         Vec<QueryLifecycleResult>,
         Vec<SqlErrorScenarioResult>,
+        AsyncTrafficResult,
     ),
     Box<dyn Error>,
 > {
@@ -543,38 +575,62 @@ async fn supervise_smoke(
         event => return Err(format!("expected intermediary ready event, got {event:?}").into()),
     };
 
-    let mut driver = spawn_child(executable, "driver-child", listen_addr).await?;
+    let mut driver = Command::new(executable)
+        .args([
+            "driver-child",
+            "--address",
+            &listen_addr.to_string(),
+            "--notify-address",
+            &upstream.to_string(),
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()?;
     let completed = read_event(&mut driver).await?;
-    let (value, mut coverage, fixtures, data_scenarios, query_lifecycle, error_scenarios) =
-        match completed {
-            ChildEvent::Completed {
-                value: Some(value),
-                coverage,
-                fixtures: Some(fixtures),
-                data_scenarios,
-                query_lifecycle,
-                error_scenarios,
-                ..
-            } => (
-                value,
-                coverage,
-                fixtures,
-                data_scenarios,
-                query_lifecycle,
-                error_scenarios,
-            ),
-            event => return Err(format!("expected driver completion event, got {event:?}").into()),
-        };
+    let (
+        value,
+        mut coverage,
+        fixtures,
+        data_scenarios,
+        query_lifecycle,
+        error_scenarios,
+        mut async_traffic,
+    ) = match completed {
+        ChildEvent::Completed {
+            value: Some(value),
+            coverage,
+            fixtures: Some(fixtures),
+            data_scenarios,
+            query_lifecycle,
+            error_scenarios,
+            async_traffic: Some(async_traffic),
+            ..
+        } => (
+            value,
+            coverage,
+            fixtures,
+            data_scenarios,
+            query_lifecycle,
+            error_scenarios,
+            *async_traffic,
+        ),
+        event => return Err(format!("expected driver completion event, got {event:?}").into()),
+    };
     wait_success(&mut driver, "driver").await?;
     let intermediary_completed = read_event(&mut intermediary).await?;
     let ChildEvent::Completed {
         coverage: intermediary_coverage,
+        async_traffic: Some(intermediary_async),
         ..
     } = intermediary_completed
     else {
         return Err("expected intermediary completion event".into());
     };
     coverage.extend(intermediary_coverage);
+    async_traffic.parameter_status = intermediary_async.parameter_status;
+    async_traffic.backend_key_forwarded = intermediary_async.backend_key_forwarded;
+    async_traffic.causally_unattributed = intermediary_async.causally_unattributed;
+    validate_async_traffic(&async_traffic)?;
     wait_success(&mut intermediary, "intermediary").await?;
     drop(container);
     Ok((
@@ -584,7 +640,23 @@ async fn supervise_smoke(
         data_scenarios,
         query_lifecycle,
         error_scenarios,
+        async_traffic,
     ))
+}
+
+fn validate_async_traffic(evidence: &AsyncTrafficResult) -> Result<(), Box<dyn Error>> {
+    let expected = ["backend-key", "notice", "notification", "parameter-status"];
+    if evidence.notice_message != "burn-in notice"
+        || evidence.notification_channel != "burn_in_events"
+        || evidence.notification_payload != "fixture-ready"
+        || evidence.parameter_status.name != "application_name"
+        || evidence.parameter_status.value != "pg-proto-burn-in-async"
+        || !evidence.backend_key_forwarded
+        || evidence.causally_unattributed != expected
+    {
+        return Err(format!("incomplete asynchronous traffic evidence: {evidence:?}").into());
+    }
+    Ok(())
 }
 
 const REQUIRED_SMOKE_STAGES: [&str; 7] = [
@@ -667,18 +739,6 @@ fn coverage_report(observed: &[String]) -> Result<CoverageReport, Box<dyn Error>
     })
 }
 
-async fn spawn_child(
-    executable: &str,
-    role: &str,
-    address: SocketAddr,
-) -> Result<Child, Box<dyn Error>> {
-    Ok(Command::new(executable)
-        .args([role, "--address", &address.to_string()])
-        .stdout(Stdio::piped())
-        .stderr(Stdio::inherit())
-        .spawn()?)
-}
-
 async fn spawn_authenticated_child(
     executable: &str,
     role: &str,
@@ -718,6 +778,46 @@ async fn wait_success(child: &mut Child, role: &str) -> Result<(), Box<dyn Error
 #[derive(Clone, Copy)]
 struct Route(SocketAddr);
 
+#[derive(Clone, Default)]
+struct FourByteCancellationRegistry {
+    routes: Arc<Mutex<HashMap<CancelKey, CancellationRoute>>>,
+}
+
+impl IntermediaryCancellationRegistry for FourByteCancellationRegistry {
+    type Error = io::Error;
+
+    fn register(&self, route: CancellationRoute) -> Result<CancelKey, Self::Error> {
+        let upstream = route.upstream_key();
+        let secret = upstream
+            .secret_key
+            .get(..4)
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "short cancellation key"))?;
+        let client = CancelKey {
+            process_id: upstream.process_id,
+            secret_key: bytes::Bytes::copy_from_slice(secret),
+        };
+        let mut routes = self
+            .routes
+            .lock()
+            .map_err(|_| io::Error::other("cancellation registry poisoned"))?;
+        if routes.insert(client.clone(), route).is_some() {
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                "duplicate cancellation key",
+            ));
+        }
+        Ok(client)
+    }
+
+    fn resolve(&self, client: &CancelKey) -> Option<CancellationRoute> {
+        self.routes.lock().ok()?.get(client).cloned()
+    }
+
+    fn detach(&self, client: &CancelKey) -> Option<CancellationRoute> {
+        self.routes.lock().ok()?.remove(client)
+    }
+}
+
 #[derive(Clone)]
 struct RootedTls(ClientTlsConfig);
 
@@ -730,9 +830,40 @@ impl ClientTlsProvider for RootedTls {
 }
 
 #[derive(Default)]
-struct CoverageState(BTreeSet<String>);
+struct CoverageState {
+    transitions: BTreeSet<String>,
+    causally_unattributed: BTreeSet<String>,
+    parameter_status: Option<ParameterStatusResult>,
+}
 
 struct CoverageObserver;
+
+impl CoverageObserver {
+    fn observe_async(
+        state: &mut CoverageState,
+        operation: Option<OperationId>,
+        message: &BackendMessage,
+    ) {
+        let kind = match message {
+            BackendMessage::NoticeResponse(_) => "notice",
+            BackendMessage::NotificationResponse { .. } => "notification",
+            BackendMessage::ParameterStatus { name, value } => {
+                if operation.is_none() && name.as_ref() == b"application_name" {
+                    state.parameter_status = Some(ParameterStatusResult {
+                        name: String::from_utf8_lossy(name).into_owned(),
+                        value: String::from_utf8_lossy(value).into_owned(),
+                    });
+                }
+                "parameter-status"
+            }
+            BackendMessage::BackendKeyData { .. } => "backend-key",
+            _ => return,
+        };
+        if operation.is_none() {
+            state.causally_unattributed.insert(kind.into());
+        }
+    }
+}
 
 impl
     IntermediaryMiddleware<
@@ -750,7 +881,7 @@ impl
         state: &mut CoverageState,
         observation: ProtocolTransitionObservation,
     ) {
-        state.0.insert(observation.id.to_owned());
+        state.transitions.insert(observation.id.to_owned());
         let stages: &[&str] = match observation.direction {
             ProtocolTransitionDirection::Frontend => &[
                 "smoke.extended-select.server-decoded",
@@ -763,8 +894,31 @@ impl
             ],
         };
         state
-            .0
+            .transitions
             .extend(stages.iter().map(|stage| (*stage).to_owned()));
+    }
+
+    async fn backend(
+        &mut self,
+        _server: &ServerConnectionContext<SocketAddr, TrustIdentity>,
+        _client: &ClientConnectionContext<()>,
+        state: &mut CoverageState,
+        message: BackendMessage,
+    ) -> Result<BackendMiddlewareOutput, Self::Error> {
+        Self::observe_async(state, None, &message);
+        Ok(BackendMiddlewareOutput::Forward(message))
+    }
+
+    async fn backend_operation(
+        &mut self,
+        _server: &ServerConnectionContext<SocketAddr, TrustIdentity>,
+        _client: &ClientConnectionContext<()>,
+        state: &mut CoverageState,
+        operation: Option<OperationId>,
+        message: BackendMessage,
+    ) -> Result<BackendMiddlewareOutput, Self::Error> {
+        Self::observe_async(state, operation, &message);
+        Ok(BackendMiddlewareOutput::Forward(message))
     }
 }
 
@@ -807,7 +961,7 @@ async fn run_intermediary_child(arguments: &[String]) -> Result<(), Box<dyn Erro
             .server(server)
             .client(client)
             .startup_resolver(Route(upstream))
-            .cancellation(CancellationPolicy::Reject)
+            .cancellation_registry(FourByteCancellationRegistry::default())
             .pipeline(BoundedPipeline::new(64).expect("non-zero smoke pipeline capacity"))
             .middleware(
                 |_: &ServerConnectionContext<SocketAddr, TrustIdentity>,
@@ -837,7 +991,7 @@ async fn run_intermediary_child(arguments: &[String]) -> Result<(), Box<dyn Erro
                 match session.forward_next().await {
                     Ok(ForwardedMessage::Frontend(FrontendMessage::Terminate)) => {
                         let (_, _, state, ..) = session.teardown();
-                        return Ok::<_, io::Error>(state.0);
+                        return Ok::<_, io::Error>(state);
                     }
                     Ok(_) => {}
                     Err(error) => {
@@ -849,18 +1003,31 @@ async fn run_intermediary_child(arguments: &[String]) -> Result<(), Box<dyn Erro
             }
         });
     }
-    let mut coverage = BTreeSet::new();
+    let mut accumulated = CoverageState::default();
     while let Some(result) = sessions.join_next().await {
-        coverage.extend(result??);
+        let state = result??;
+        accumulated.transitions.extend(state.transitions);
+        accumulated
+            .causally_unattributed
+            .extend(state.causally_unattributed);
+        if state.parameter_status.is_some() {
+            accumulated.parameter_status = state.parameter_status;
+        }
     }
     write_event(&ChildEvent::Completed {
         version: 1,
         value: None,
-        coverage: coverage.into_iter().collect(),
+        coverage: accumulated.transitions.into_iter().collect(),
         fixtures: None,
         data_scenarios: Vec::new(),
         query_lifecycle: Vec::new(),
         error_scenarios: Vec::new(),
+        async_traffic: Some(Box::new(AsyncTrafficResult {
+            parameter_status: accumulated.parameter_status.unwrap_or_default(),
+            backend_key_forwarded: accumulated.causally_unattributed.contains("backend-key"),
+            causally_unattributed: accumulated.causally_unattributed.into_iter().collect(),
+            ..AsyncTrafficResult::default()
+        })),
     })
     .await
 }
@@ -918,7 +1085,7 @@ async fn run_tls_credential_intermediary(
         match session.forward_next().await {
             Ok(ForwardedMessage::Frontend(FrontendMessage::Terminate)) => {
                 let (_, _, state, ..) = session.teardown();
-                break state.0;
+                break state.transitions;
             }
             Ok(_) => {}
             Err(error) => {
@@ -936,6 +1103,7 @@ async fn run_tls_credential_intermediary(
         data_scenarios: Vec::new(),
         query_lifecycle: Vec::new(),
         error_scenarios: Vec::new(),
+        async_traffic: None,
     })
     .await
 }
@@ -985,7 +1153,7 @@ async fn run_credential_intermediary(
         match session.forward_next().await {
             Ok(ForwardedMessage::Frontend(FrontendMessage::Terminate)) => {
                 let (_, _, state, ..) = session.teardown();
-                break state.0;
+                break state.transitions;
             }
             Ok(_) => {}
             Err(error) => {
@@ -1003,6 +1171,7 @@ async fn run_credential_intermediary(
         data_scenarios: Vec::new(),
         query_lifecycle: Vec::new(),
         error_scenarios: Vec::new(),
+        async_traffic: None,
     })
     .await
 }
@@ -1018,11 +1187,80 @@ async fn run_driver_child(arguments: &[String]) -> Result<(), Box<dyn Error>> {
     if let Ok(password) = option(arguments, "--password") {
         config.password(password);
     }
-    let (mut client, connection) = config.connect(tokio_postgres::NoTls).await?;
-    let connection_task = tokio::spawn(connection);
-    let value: i32 = client.query_one("SELECT 42::int4", &[]).await?.get(0);
+    let (mut client, mut connection) = config
+        .connect(tokio_postgres::NoTls)
+        .await
+        .map_err(|error| format!("driver startup failed: {error:?}"))?;
+    let (async_tx, mut async_rx) = tokio::sync::mpsc::unbounded_channel();
+    let connection_task = tokio::spawn(async move {
+        while let Some(message) =
+            std::future::poll_fn(|context| connection.poll_message(context)).await
+        {
+            let message = message.map_err(io::Error::other)?;
+            async_tx
+                .send(message)
+                .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "async receiver closed"))?;
+        }
+        Ok::<_, io::Error>(())
+    });
+    let value: i32 = client
+        .query_one("SELECT 42::int4", &[])
+        .await
+        .map_err(|error| format!("initial SELECT failed: {error:?}"))?
+        .get(0);
     if value != 42 {
         return Err(format!("expected 42, got {value}").into());
+    }
+    let mut async_traffic = AsyncTrafficResult::default();
+    if let Ok(notifier_address) = option(arguments, "--notify-address") {
+        client
+            .batch_execute("LISTEN burn_in_events")
+            .await
+            .map_err(|error| format!("LISTEN failed: {error}"))?;
+        client
+            .batch_execute("SET application_name = 'pg-proto-burn-in-async'")
+            .await
+            .map_err(|error| format!("SET application_name failed: {error}"))?;
+        client
+            .batch_execute("DO $$ BEGIN RAISE NOTICE 'burn-in notice'; END $$")
+            .await
+            .map_err(|error| format!("RAISE NOTICE failed: {error}"))?;
+        let notifier_address: SocketAddr = notifier_address.parse()?;
+        let mut notifier_config = tokio_postgres::Config::new();
+        notifier_config
+            .host(notifier_address.ip().to_string())
+            .port(notifier_address.port())
+            .user("postgres")
+            .dbname("postgres");
+        let (notifier, notifier_connection) =
+            notifier_config.connect(tokio_postgres::NoTls).await?;
+        let notifier_task = tokio::spawn(notifier_connection);
+        notifier
+            .batch_execute("NOTIFY burn_in_events, 'fixture-ready'")
+            .await
+            .map_err(|error| format!("NOTIFY failed: {error}"))?;
+        drop(notifier);
+        timeout(CHILD_TIMEOUT, notifier_task).await???;
+
+        while async_traffic.notice_message.is_empty()
+            || async_traffic.notification_channel.is_empty()
+        {
+            match timeout(CHILD_TIMEOUT, async_rx.recv()).await? {
+                Some(tokio_postgres::AsyncMessage::Notice(notice)) => {
+                    if notice.message() == "burn-in notice" {
+                        async_traffic.notice_message = notice.message().into();
+                    }
+                }
+                Some(tokio_postgres::AsyncMessage::Notification(notification))
+                    if notification.channel() == "burn_in_events" =>
+                {
+                    async_traffic.notification_channel = notification.channel().into();
+                    async_traffic.notification_payload = notification.payload().into();
+                }
+                None => return Err("connection ended before asynchronous evidence arrived".into()),
+                _ => {}
+            }
+        }
     }
     let fixtures = install_and_verify_fixtures(&client).await?;
     let data_scenarios = run_data_scenarios(&client).await?;
@@ -1042,6 +1280,7 @@ async fn run_driver_child(arguments: &[String]) -> Result<(), Box<dyn Error>> {
         data_scenarios,
         query_lifecycle,
         error_scenarios,
+        async_traffic: Some(Box::new(async_traffic)),
     })
     .await
 }

--- a/pg-proto-burn-in/src/lib.rs
+++ b/pg-proto-burn-in/src/lib.rs
@@ -43,6 +43,7 @@ use tokio::{
 };
 
 mod scripted;
+mod soak;
 
 const CHILD_TIMEOUT: Duration = Duration::from_secs(30);
 
@@ -50,9 +51,12 @@ const CHILD_TIMEOUT: Duration = Duration::from_secs(30);
 pub async fn run(arguments: Vec<String>) -> Result<(), Box<dyn Error>> {
     match arguments.get(1).map(String::as_str) {
         Some("conformance") => run_conformance(&arguments).await,
+        Some("soak") => soak::run_soak(&arguments).await,
+        Some("replay") => soak::run_replay(&arguments).await,
+        Some("soak-driver-child") => soak::run_driver_child(&arguments).await,
         Some("intermediary-child") => run_intermediary_child(&arguments).await,
         Some("driver-child") => run_driver_child(&arguments).await,
-        _ => Err("usage: pg-proto-burn-in conformance --profile smoke --artifacts DIR".into()),
+        _ => Err("usage: pg-proto-burn-in <conformance|soak|replay> [options]".into()),
     }
 }
 

--- a/pg-proto-burn-in/src/main.rs
+++ b/pg-proto-burn-in/src/main.rs
@@ -1,0 +1,7 @@
+#[tokio::main]
+async fn main() {
+    if let Err(error) = pg_proto_burn_in::run(std::env::args().collect()).await {
+        eprintln!("{error}");
+        std::process::exit(1);
+    }
+}

--- a/pg-proto-burn-in/src/scripted.rs
+++ b/pg-proto-burn-in/src/scripted.rs
@@ -1,0 +1,466 @@
+use std::{convert::Infallible, error::Error, sync::Mutex};
+
+use pg_proto::{
+    BackendMessage, CancellationPolicy, Client, ClientTlsConfig, ClientTlsPolicy,
+    ClientTlsProvider, ConnectTarget, ForwardedMessage, FrontendMessage, InitialServerContext,
+    Intermediary, PreStartupMessage, Server, ServerAccept, ServerAuthentication,
+    ServerAuthenticationAction, ServerAuthenticationProvider, ServerAuthenticationRequest,
+    ServerAuthenticationResponse, ServerTlsPolicy, StartupParameters, StartupRouteResolver,
+    TrustClientAuthentication, TrustServerAuthentication,
+};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+pub(super) async fn run() -> Result<Vec<String>, Box<dyn Error>> {
+    gss_encryption_request().await?;
+    legacy_encryption_error().await?;
+    token_authentication(TokenMethod::Gss).await?;
+    token_authentication(TokenMethod::Kerberos).await?;
+    token_authentication(TokenMethod::Sspi).await?;
+    intermediary_scenario(TrafficScenario::FunctionCall).await?;
+    intermediary_scenario(TrafficScenario::CopyFail).await?;
+    intermediary_scenario(TrafficScenario::CopyBothClientDone).await?;
+    intermediary_scenario(TrafficScenario::CopyBothServerDone).await?;
+    Ok([
+        "scripted.authentication.gss",
+        "scripted.authentication.gss-continue",
+        "scripted.authentication.kerberos-v5",
+        "scripted.authentication.sspi",
+        "scripted.copy-both.client-half-close-first",
+        "scripted.copy-both.server-half-close-first",
+        "scripted.copy-fail.exact",
+        "scripted.encryption.gss-request",
+        "scripted.encryption.legacy-error",
+        "scripted.function-call",
+    ]
+    .map(str::to_owned)
+    .into())
+}
+
+#[derive(Clone, Copy)]
+struct ScriptedRoute;
+
+impl StartupRouteResolver<()> for ScriptedRoute {
+    type Error = Infallible;
+
+    async fn resolve(
+        &self,
+        _: StartupParameters,
+        _: InitialServerContext<'_, ()>,
+    ) -> Result<ConnectTarget, Self::Error> {
+        Ok(ConnectTarget::new("scripted-peer"))
+    }
+}
+
+#[derive(Clone, Copy)]
+enum TrafficScenario {
+    FunctionCall,
+    CopyFail,
+    CopyBothClientDone,
+    CopyBothServerDone,
+}
+
+async fn intermediary_scenario(scenario: TrafficScenario) -> Result<(), Box<dyn Error>> {
+    let (downstream_transport, downstream_peer) = tokio::io::duplex(4096);
+    let (upstream_transport, upstream_peer) = tokio::io::duplex(4096);
+    let downstream = tokio::spawn(scripted_downstream(downstream_peer, scenario));
+    let upstream = tokio::spawn(scripted_upstream(upstream_peer, scenario));
+    let upstream_transport = Mutex::new(Some(upstream_transport));
+    let client = Client::builder()
+        .connector(move |_| {
+            let transport = upstream_transport.lock().unwrap().take().unwrap();
+            async move { Ok::<_, std::io::Error>(transport) }
+        })
+        .tls(ClientTlsPolicy::Disabled)
+        .authentication(TrustClientAuthentication)
+        .build()
+        .map_err(super::debug_error)?;
+    let server = Server::builder()
+        .tls(ServerTlsPolicy::Disabled)
+        .authentication(TrustServerAuthentication)
+        .build()
+        .map_err(super::debug_error)?;
+    let intermediary = Intermediary::builder()
+        .server(server)
+        .client(client)
+        .startup_resolver(ScriptedRoute)
+        .cancellation(CancellationPolicy::Reject)
+        .build()
+        .map_err(super::debug_error)?;
+    let mut session = Box::pin(intermediary.accept(downstream_transport, (), ()))
+        .await
+        .map_err(super::debug_error)?
+        .into_session();
+
+    match scenario {
+        TrafficScenario::FunctionCall => {
+            assert!(matches!(
+                session.forward_next().await.unwrap(),
+                ForwardedMessage::Frontend(FrontendMessage::FunctionCall(_))
+            ));
+            assert!(matches!(
+                session.forward_next().await.unwrap(),
+                ForwardedMessage::Backend(BackendMessage::FunctionCallResponse(_))
+            ));
+            assert!(matches!(
+                session.forward_next().await.unwrap(),
+                ForwardedMessage::Backend(BackendMessage::ReadyForQuery(_))
+            ));
+        }
+        TrafficScenario::CopyFail => {
+            assert!(matches!(
+                session.forward_next().await.unwrap(),
+                ForwardedMessage::Frontend(FrontendMessage::Query(_))
+            ));
+            assert!(matches!(
+                session.forward_next().await.unwrap(),
+                ForwardedMessage::Backend(BackendMessage::CopyInResponse(_))
+            ));
+            let forwarded = session.forward_next().await.unwrap();
+            assert!(
+                matches!(&forwarded, ForwardedMessage::FrontendSuppressed(FrontendMessage::CopyFail(reason)) if reason == "scripted exact failure"),
+                "{forwarded:?}"
+            );
+        }
+        TrafficScenario::CopyBothClientDone => {
+            assert!(matches!(
+                session.forward_next().await.unwrap(),
+                ForwardedMessage::Frontend(FrontendMessage::Query(_))
+            ));
+            assert!(matches!(
+                session.forward_next().await.unwrap(),
+                ForwardedMessage::Backend(BackendMessage::CopyBothResponse(_))
+            ));
+            assert!(matches!(
+                session.forward_next().await.unwrap(),
+                ForwardedMessage::Frontend(FrontendMessage::CopyDone)
+            ));
+            assert!(matches!(
+                session.forward_next().await.unwrap(),
+                ForwardedMessage::Backend(BackendMessage::CopyData(_))
+            ));
+            assert!(matches!(
+                session.forward_next().await.unwrap(),
+                ForwardedMessage::Backend(BackendMessage::CopyDone)
+            ));
+        }
+        TrafficScenario::CopyBothServerDone => {
+            assert!(matches!(
+                session.forward_next().await.unwrap(),
+                ForwardedMessage::Frontend(FrontendMessage::Query(_))
+            ));
+            assert!(matches!(
+                session.forward_next().await.unwrap(),
+                ForwardedMessage::Backend(BackendMessage::CopyBothResponse(_))
+            ));
+            assert!(matches!(
+                session.forward_next().await.unwrap(),
+                ForwardedMessage::Backend(BackendMessage::CopyDone)
+            ));
+            assert!(matches!(
+                session.forward_next().await.unwrap(),
+                ForwardedMessage::Frontend(FrontendMessage::CopyData(_))
+            ));
+            assert!(matches!(
+                session.forward_next().await.unwrap(),
+                ForwardedMessage::Frontend(FrontendMessage::CopyDone)
+            ));
+        }
+    }
+    let _ = session.teardown();
+    downstream.await??;
+    upstream.await??;
+    Ok(())
+}
+
+async fn scripted_downstream(
+    mut peer: tokio::io::DuplexStream,
+    scenario: TrafficScenario,
+) -> Result<(), std::io::Error> {
+    peer.write_all(&startup()).await?;
+    let mut accepted = [0; 15];
+    peer.read_exact(&mut accepted).await?;
+    match scenario {
+        TrafficScenario::FunctionCall => {
+            peer.write_all(&tagged(b'F', &[0, 0, 0, 1, 0, 0, 0, 0, 0, 0]))
+                .await?;
+            read_tagged(&mut peer).await?;
+            read_tagged(&mut peer).await?;
+        }
+        TrafficScenario::CopyFail => {
+            peer.write_all(&tagged(b'Q', b"START_REPLICATION\0"))
+                .await?;
+            read_tagged(&mut peer).await?;
+            peer.write_all(&tagged(b'f', b"scripted exact failure\0"))
+                .await?;
+        }
+        TrafficScenario::CopyBothClientDone => {
+            peer.write_all(&tagged(b'Q', b"START_REPLICATION\0"))
+                .await?;
+            read_tagged(&mut peer).await?;
+            peer.write_all(&tagged(b'c', &[])).await?;
+            read_tagged(&mut peer).await?;
+            read_tagged(&mut peer).await?;
+        }
+        TrafficScenario::CopyBothServerDone => {
+            peer.write_all(&tagged(b'Q', b"START_REPLICATION\0"))
+                .await?;
+            read_tagged(&mut peer).await?;
+            read_tagged(&mut peer).await?;
+            peer.write_all(&tagged(b'd', b"standby-status")).await?;
+            peer.write_all(&tagged(b'c', &[])).await?;
+        }
+    }
+    Ok(())
+}
+
+async fn scripted_upstream(
+    mut peer: tokio::io::DuplexStream,
+    scenario: TrafficScenario,
+) -> Result<(), std::io::Error> {
+    let length = peer.read_u32().await?;
+    let mut startup_body = vec![0; usize::try_from(length).unwrap() - 4];
+    peer.read_exact(&mut startup_body).await?;
+    peer.write_all(&[b'R', 0, 0, 0, 8, 0, 0, 0, 0, b'Z', 0, 0, 0, 5, b'I'])
+        .await?;
+    let (tag, body) = read_tagged(&mut peer).await?;
+    match scenario {
+        TrafficScenario::FunctionCall => {
+            assert_eq!(tag, b'F');
+            assert_eq!(&body[..4], &1_u32.to_be_bytes());
+            peer.write_all(&tagged(b'V', b"function-result")).await?;
+            peer.write_all(&tagged(b'Z', b"I")).await?;
+        }
+        TrafficScenario::CopyFail => {
+            assert_eq!(tag, b'Q');
+            peer.write_all(&tagged(b'G', &[0, 0, 0])).await?;
+            let closed = peer.read_u8().await.expect_err("CopyFail is suppressed");
+            assert_eq!(closed.kind(), std::io::ErrorKind::UnexpectedEof);
+        }
+        TrafficScenario::CopyBothClientDone => {
+            assert_eq!(tag, b'Q');
+            peer.write_all(&tagged(b'W', &[0, 0, 0])).await?;
+            assert_eq!(read_tagged(&mut peer).await?.0, b'c');
+            peer.write_all(&tagged(b'd', b"remaining-wal")).await?;
+            peer.write_all(&tagged(b'c', &[])).await?;
+        }
+        TrafficScenario::CopyBothServerDone => {
+            assert_eq!(tag, b'Q');
+            peer.write_all(&tagged(b'W', &[0, 0, 0])).await?;
+            peer.write_all(&tagged(b'c', &[])).await?;
+            assert_eq!(read_tagged(&mut peer).await?.0, b'd');
+            assert_eq!(read_tagged(&mut peer).await?.0, b'c');
+        }
+    }
+    Ok(())
+}
+
+fn tagged(tag: u8, body: &[u8]) -> Vec<u8> {
+    [
+        [tag].as_slice(),
+        u32::try_from(body.len() + 4)
+            .unwrap()
+            .to_be_bytes()
+            .as_slice(),
+        body,
+    ]
+    .concat()
+}
+
+async fn read_tagged(
+    stream: &mut tokio::io::DuplexStream,
+) -> Result<(u8, Vec<u8>), std::io::Error> {
+    let tag = stream.read_u8().await?;
+    let length = stream.read_u32().await?;
+    let mut body = vec![0; usize::try_from(length).unwrap() - 4];
+    stream.read_exact(&mut body).await?;
+    Ok((tag, body))
+}
+
+async fn gss_encryption_request() -> Result<(), Box<dyn Error>> {
+    let server = Server::builder()
+        .tls(ServerTlsPolicy::Disabled)
+        .authentication(pg_proto::TrustServerAuthentication)
+        .build()
+        .map_err(super::debug_error)?;
+    let (mut peer, transport) = tokio::io::duplex(256);
+    let exchange = async move {
+        peer.write_all(&PreStartupMessage::GssEncRequest.to_packet()?)
+            .await?;
+        if peer.read_u8().await? != b'N' {
+            return Err::<(), std::io::Error>(std::io::Error::other("GSSENC was not rejected"));
+        }
+        peer.write_all(&startup()).await?;
+        let mut accepted = [0; 15];
+        peer.read_exact(&mut accepted).await?;
+        Ok::<(), std::io::Error>(())
+    };
+    let (accepted, exchanged) = tokio::join!(server.accept(transport, (), ()), exchange);
+    exchanged?;
+    let ServerAccept::Session(session) = accepted.map_err(super::debug_error)? else {
+        return Err("expected a server session".into());
+    };
+    let _ = session.teardown();
+    Ok(())
+}
+
+async fn legacy_encryption_error() -> Result<(), Box<dyn Error>> {
+    let (transport, mut peer) = tokio::io::duplex(256);
+    let peer_task = tokio::spawn(async move {
+        let mut request = [0; 8];
+        peer.read_exact(&mut request).await.unwrap();
+        assert_eq!(request, [0, 0, 0, 8, 4, 210, 22, 47]);
+        peer.write_u8(b'E').await.unwrap();
+    });
+    let transport = Mutex::new(Some(transport));
+    let client = Client::builder()
+        .connector(move |_| {
+            let transport = transport.lock().unwrap().take().unwrap();
+            async move { Ok::<_, std::io::Error>(transport) }
+        })
+        .tls(ClientTlsPolicy::libpq(pg_proto::SslMode::Prefer, LegacyTls))
+        .authentication(TrustClientAuthentication)
+        .build()
+        .map_err(super::debug_error)?;
+    let result = client
+        .connect(
+            ConnectTarget::new("scripted"),
+            StartupParameters::new("alice"),
+            (),
+        )
+        .await;
+    peer_task.await?;
+    if !matches!(result, Err(pg_proto::ConnectError::Tls(_))) {
+        return Err("legacy encryption error was not surfaced as a TLS failure".into());
+    }
+    Ok(())
+}
+
+#[derive(Clone, Copy)]
+struct LegacyTls;
+
+impl ClientTlsProvider for LegacyTls {
+    type Error = Infallible;
+
+    async fn resolve(&self, _: &ConnectTarget) -> Result<ClientTlsConfig, Self::Error> {
+        unreachable!("legacy error terminates negotiation before TLS material is resolved")
+    }
+}
+
+#[derive(Clone, Copy)]
+enum TokenMethod {
+    Gss,
+    Kerberos,
+    Sspi,
+}
+
+struct TokenFactory(TokenMethod);
+struct TokenAuthentication {
+    method: TokenMethod,
+    responses: usize,
+}
+
+impl ServerAuthenticationProvider for TokenFactory {
+    type Authentication = TokenAuthentication;
+
+    fn create(&self) -> Self::Authentication {
+        TokenAuthentication {
+            method: self.0,
+            responses: 0,
+        }
+    }
+}
+
+impl ServerAuthentication<()> for TokenAuthentication {
+    type Identity = ();
+    type Error = Infallible;
+
+    async fn start(
+        &mut self,
+        _: ServerAuthenticationRequest<'_, ()>,
+    ) -> Result<ServerAuthenticationAction<Self::Identity>, Self::Error> {
+        Ok(match self.method {
+            TokenMethod::Gss => ServerAuthenticationAction::Gss,
+            TokenMethod::Kerberos => ServerAuthenticationAction::KerberosV5,
+            TokenMethod::Sspi => ServerAuthenticationAction::Sspi,
+        })
+    }
+
+    async fn respond(
+        &mut self,
+        _: ServerAuthenticationRequest<'_, ()>,
+        response: ServerAuthenticationResponse,
+    ) -> Result<ServerAuthenticationAction<Self::Identity>, Self::Error> {
+        let ServerAuthenticationResponse::Token(token) = response else {
+            unreachable!()
+        };
+        self.responses += 1;
+        Ok(
+            if matches!(self.method, TokenMethod::Gss) && self.responses == 1 {
+                assert_eq!(token, b"client-one".as_slice());
+                ServerAuthenticationAction::GssContinue(b"server-two".as_slice().into())
+            } else {
+                ServerAuthenticationAction::Accept(())
+            },
+        )
+    }
+}
+
+async fn token_authentication(method: TokenMethod) -> Result<(), Box<dyn Error>> {
+    let server = Server::builder()
+        .tls(ServerTlsPolicy::Disabled)
+        .authentication(TokenFactory(method))
+        .build()
+        .map_err(super::debug_error)?;
+    let (mut peer, transport) = tokio::io::duplex(512);
+    peer.write_all(&startup()).await?;
+    let exchange = async move {
+        let mut request = [0; 9];
+        peer.read_exact(&mut request).await?;
+        let expected = match method {
+            TokenMethod::Kerberos => 2,
+            TokenMethod::Gss => 7,
+            TokenMethod::Sspi => 9,
+        };
+        if u32::from_be_bytes(request[5..9].try_into().unwrap()) != expected {
+            return Err::<(), std::io::Error>(std::io::Error::other(
+                "wrong authentication request",
+            ));
+        }
+        peer.write_all(&password_packet(b"client-one")).await?;
+        if matches!(method, TokenMethod::Gss) {
+            let mut continuation = [0; 19];
+            peer.read_exact(&mut continuation).await?;
+            if &continuation[9..] != b"server-two" {
+                return Err(std::io::Error::other("wrong GSS continuation"));
+            }
+            peer.write_all(&password_packet(b"client-three")).await?;
+        }
+        let mut ready = [0; 15];
+        peer.read_exact(&mut ready).await?;
+        Ok(())
+    };
+    let (accepted, exchanged) = tokio::join!(server.accept(transport, (), ()), exchange);
+    exchanged?;
+    let ServerAccept::Session(session) = accepted.map_err(super::debug_error)? else {
+        return Err("expected a server session".into());
+    };
+    let _ = session.teardown();
+    Ok(())
+}
+
+fn startup() -> Vec<u8> {
+    [
+        20_u32.to_be_bytes().as_slice(),
+        196_608_u32.to_be_bytes().as_slice(),
+        b"user\0alice\0\0",
+    ]
+    .concat()
+}
+
+fn password_packet(token: &[u8]) -> Vec<u8> {
+    b"p".iter()
+        .copied()
+        .chain(u32::try_from(token.len() + 4).unwrap().to_be_bytes())
+        .chain(token.iter().copied())
+        .collect()
+}

--- a/pg-proto-burn-in/src/soak.rs
+++ b/pg-proto-burn-in/src/soak.rs
@@ -376,9 +376,11 @@ async fn execute(
         .filter(|entry| entry.phase == Phase::BoundedConcurrency)
         .cloned()
         .collect();
-    // Five sampling connections and one deliberately terminated connection are
-    // included in the intermediary's finite connection budget.
-    let connections = usize::from(!long.is_empty()) + churn.len() + concurrent.len() + 6;
+    // Five sampling connections, one deliberately terminated connection, and
+    // one final graceful teardown connection are included in the
+    // intermediary's finite connection budget. Keeping teardown distinct
+    // prevents the last checkpoint from racing process exit on Linux.
+    let connections = usize::from(!long.is_empty()) + churn.len() + concurrent.len() + 7;
     let mut intermediary = Command::new(executable)
         .args([
             "intermediary-child",
@@ -453,6 +455,7 @@ async fn execute(
         )
         .await?,
     );
+    run_child(executable, listen_addr, &[]).await?;
     let ChildEvent::Completed { .. } = read_event(&mut intermediary).await? else {
         return Err("expected soak intermediary completion event".into());
     };

--- a/pg-proto-burn-in/src/soak.rs
+++ b/pg-proto-burn-in/src/soak.rs
@@ -386,6 +386,7 @@ async fn execute(
             &upstream.to_string(),
             "--connections",
             &connections.to_string(),
+            "--allow-abrupt-disconnects",
         ])
         .kill_on_drop(true)
         .stdout(Stdio::piped())

--- a/pg-proto-burn-in/src/soak.rs
+++ b/pg-proto-burn-in/src/soak.rs
@@ -1,0 +1,491 @@
+use std::{
+    collections::BTreeMap,
+    error::Error,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    path::{Path, PathBuf},
+    process::Stdio,
+};
+
+use serde::{Deserialize, Serialize};
+use testcontainers_modules::{
+    postgres::Postgres,
+    testcontainers::{ImageExt, runners::AsyncRunner},
+};
+use tokio::{process::Command, time::timeout};
+
+use crate::{CHILD_TIMEOUT, ChildEvent, atomic_write, option, read_event, wait_success};
+
+const CONCURRENCY: usize = 4;
+const CANONICAL: [&str; 3] = ["scalar", "rows", "syntax-error"];
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+enum Phase {
+    LongLived,
+    ConnectionChurn,
+    BoundedConcurrency,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct SequenceEntry {
+    ordinal: usize,
+    phase: Phase,
+    scenario: String,
+    canonical: bool,
+    parameters: BTreeMap<String, i64>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+enum Budget {
+    Iterations(u64),
+    DurationSeconds(u64),
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct SoakResult {
+    schema_version: u32,
+    command: String,
+    seed: u64,
+    budget: Budget,
+    max_concurrency: usize,
+    sequence: Vec<SequenceEntry>,
+    completed: usize,
+    success: bool,
+    replay_command: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    reduced_from: Option<usize>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct DriverResult {
+    version: u32,
+    success: bool,
+    completed: usize,
+    error: Option<String>,
+}
+
+pub(crate) async fn run_soak(arguments: &[String]) -> Result<(), Box<dyn Error>> {
+    let seed = option(arguments, "--seed")?.parse()?;
+    let budget = parse_budget(arguments)?;
+    let artifacts = PathBuf::from(option(arguments, "--artifacts")?);
+    let sequence = schedule(seed, budget.clone())?;
+    execute_and_record(
+        arguments.first().ok_or("missing executable path")?,
+        &artifacts,
+        seed,
+        budget,
+        sequence,
+        "soak",
+        None,
+    )
+    .await
+}
+
+pub(crate) async fn run_replay(arguments: &[String]) -> Result<(), Box<dyn Error>> {
+    let input = PathBuf::from(option(arguments, "--input")?);
+    let artifacts = PathBuf::from(option(arguments, "--artifacts")?);
+    let original: SoakResult = serde_json::from_slice(&tokio::fs::read(&input).await?)?;
+    if original.schema_version != 1 {
+        return Err(format!(
+            "unsupported soak artifact schema {}",
+            original.schema_version
+        )
+        .into());
+    }
+    tokio::fs::create_dir_all(&artifacts).await?;
+    // Preserve the source evidence before any optional reduction can run.
+    atomic_write(
+        &artifacts.join("original.json"),
+        &serde_json::to_vec_pretty(&original)?,
+    )
+    .await?;
+    let reduce = arguments.iter().any(|argument| argument == "--reduce");
+    let original_len = original.sequence.len();
+    let sequence = original.sequence;
+    let exact = execute_and_record(
+        arguments.first().ok_or("missing executable path")?,
+        &artifacts,
+        original.seed,
+        original.budget.clone(),
+        sequence.clone(),
+        "replay",
+        None,
+    )
+    .await;
+    if !reduce || exact.is_ok() {
+        return exact;
+    }
+
+    let reduced = reduce_failing_prefix(
+        arguments.first().ok_or("missing executable path")?,
+        &sequence,
+    )
+    .await;
+    let reduction = SoakResult {
+        schema_version: 1,
+        command: "replay-reduction".into(),
+        seed: original.seed,
+        budget: original.budget,
+        max_concurrency: CONCURRENCY,
+        sequence: reduced.clone(),
+        completed: 0,
+        success: false,
+        replay_command: "pg-proto-burn-in replay --input reduction.json --artifacts replay".into(),
+        reduced_from: Some(original_len),
+    };
+    atomic_write(
+        &artifacts.join("reduction.json"),
+        &serde_json::to_vec_pretty(&reduction)?,
+    )
+    .await?;
+    exact
+}
+
+fn parse_budget(arguments: &[String]) -> Result<Budget, Box<dyn Error>> {
+    let iterations = option(arguments, "--iterations").ok();
+    let duration = option(arguments, "--duration-seconds").ok();
+    match (iterations, duration) {
+        (Some(value), None) => Ok(Budget::Iterations(value.parse()?)),
+        (None, Some(value)) => Ok(Budget::DurationSeconds(value.parse()?)),
+        _ => Err("soak requires exactly one budget: --iterations or --duration-seconds".into()),
+    }
+}
+
+fn schedule(seed: u64, budget: Budget) -> Result<Vec<SequenceEntry>, Box<dyn Error>> {
+    let weighted_per_phase = match budget {
+        Budget::Iterations(value) => usize::try_from(value)?,
+        // Duration schedules remain deterministic and bounded. Each selected operation is
+        // budgeted one second; replay uses the recorded prefix, never wall-clock selection.
+        Budget::DurationSeconds(value) => usize::try_from(value)?,
+    };
+    let mut rng = StableRng(seed);
+    let mut entries = Vec::new();
+    for phase in [
+        Phase::LongLived,
+        Phase::ConnectionChurn,
+        Phase::BoundedConcurrency,
+    ] {
+        for scenario in CANONICAL {
+            push_entry(&mut entries, phase.clone(), scenario, true, &mut rng);
+        }
+        for _ in 0..weighted_per_phase {
+            let scenario = match rng.next() % 6 {
+                0..=2 => "scalar",
+                3..=4 => "rows",
+                _ => "syntax-error",
+            };
+            push_entry(&mut entries, phase.clone(), scenario, false, &mut rng);
+        }
+    }
+    Ok(entries)
+}
+
+fn push_entry(
+    entries: &mut Vec<SequenceEntry>,
+    phase: Phase,
+    scenario: &str,
+    canonical: bool,
+    rng: &mut StableRng,
+) {
+    let mut parameters = BTreeMap::new();
+    if scenario == "rows" {
+        parameters.insert(
+            "rows".into(),
+            if canonical {
+                7
+            } else {
+                (rng.next() % 31 + 1) as i64
+            },
+        );
+    }
+    entries.push(SequenceEntry {
+        ordinal: entries.len(),
+        phase,
+        scenario: scenario.into(),
+        canonical,
+        parameters,
+    });
+}
+
+struct StableRng(u64);
+
+impl StableRng {
+    fn next(&mut self) -> u64 {
+        let mut value = self.0;
+        if value == 0 {
+            value = 0x9e37_79b9_7f4a_7c15;
+        }
+        value ^= value << 13;
+        value ^= value >> 7;
+        value ^= value << 17;
+        self.0 = value;
+        value
+    }
+}
+
+async fn reduce_failing_prefix(executable: &str, sequence: &[SequenceEntry]) -> Vec<SequenceEntry> {
+    if sequence.len() <= 1 {
+        return sequence.to_vec();
+    }
+    let mut passing_prefix = 0;
+    let mut failing_prefix = sequence.len();
+    // Keep reduction bounded even for a very large overnight recording.
+    for _ in 0..8 {
+        if failing_prefix - passing_prefix <= 1 {
+            break;
+        }
+        let candidate = passing_prefix + (failing_prefix - passing_prefix) / 2;
+        if execute(executable, &sequence[..candidate]).await.is_err() {
+            failing_prefix = candidate;
+        } else {
+            passing_prefix = candidate;
+        }
+    }
+    sequence[..failing_prefix].to_vec()
+}
+
+async fn execute_and_record(
+    executable: &str,
+    artifacts: &Path,
+    seed: u64,
+    budget: Budget,
+    sequence: Vec<SequenceEntry>,
+    command: &str,
+    reduced_from: Option<usize>,
+) -> Result<(), Box<dyn Error>> {
+    tokio::fs::create_dir_all(artifacts).await?;
+    let outcome = execute(executable, &sequence).await;
+    let completed = outcome.as_ref().copied().unwrap_or(0);
+    let result = SoakResult {
+        schema_version: 1,
+        command: command.into(),
+        seed,
+        budget,
+        max_concurrency: CONCURRENCY,
+        sequence,
+        completed,
+        success: outcome.is_ok(),
+        replay_command: "pg-proto-burn-in replay --input result.json --artifacts replay".into(),
+        reduced_from,
+    };
+    write_result(artifacts, &result).await?;
+    outcome.map(|_| ())
+}
+
+async fn execute(executable: &str, sequence: &[SequenceEntry]) -> Result<usize, Box<dyn Error>> {
+    let container = Postgres::default()
+        .with_host_auth()
+        .with_tag("18-alpine")
+        .start()
+        .await?;
+    let upstream = SocketAddr::new(
+        IpAddr::V4(Ipv4Addr::LOCALHOST),
+        container.get_host_port_ipv4(5432).await?,
+    );
+    let long: Vec<_> = sequence
+        .iter()
+        .filter(|entry| entry.phase == Phase::LongLived)
+        .cloned()
+        .collect();
+    let churn: Vec<_> = sequence
+        .iter()
+        .filter(|entry| entry.phase == Phase::ConnectionChurn)
+        .cloned()
+        .collect();
+    let concurrent: Vec<_> = sequence
+        .iter()
+        .filter(|entry| entry.phase == Phase::BoundedConcurrency)
+        .cloned()
+        .collect();
+    let connections = usize::from(!long.is_empty()) + churn.len() + concurrent.len();
+    let mut intermediary = Command::new(executable)
+        .args([
+            "intermediary-child",
+            "--address",
+            &upstream.to_string(),
+            "--connections",
+            &connections.to_string(),
+        ])
+        .kill_on_drop(true)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()?;
+    let ChildEvent::Ready { listen_addr, .. } = read_event(&mut intermediary).await? else {
+        return Err("expected soak intermediary ready event".into());
+    };
+    let mut completed = 0;
+    if !long.is_empty() {
+        completed += run_child(executable, listen_addr, &long).await?;
+    }
+    for entry in churn {
+        completed += run_child(executable, listen_addr, &[entry]).await?;
+    }
+    for batch in concurrent.chunks(CONCURRENCY) {
+        let futures = batch
+            .iter()
+            .cloned()
+            .map(|entry| async move { run_child(executable, listen_addr, &[entry]).await });
+        let results = futures_util::future::join_all(futures).await;
+        for result in results {
+            completed += result?;
+        }
+    }
+    let ChildEvent::Completed { .. } = read_event(&mut intermediary).await? else {
+        return Err("expected soak intermediary completion event".into());
+    };
+    wait_success(&mut intermediary, "soak intermediary").await?;
+    drop(container);
+    Ok(completed)
+}
+
+async fn run_child(
+    executable: &str,
+    address: SocketAddr,
+    entries: &[SequenceEntry],
+) -> Result<usize, Box<dyn Error>> {
+    let encoded = serde_json::to_string(entries)?;
+    let output = timeout(
+        CHILD_TIMEOUT,
+        Command::new(executable)
+            .args([
+                "soak-driver-child",
+                "--address",
+                &address.to_string(),
+                "--sequence",
+                &encoded,
+            ])
+            .output(),
+    )
+    .await??;
+    let result: DriverResult = serde_json::from_slice(&output.stdout)?;
+    if !output.status.success() || !result.success {
+        return Err(result
+            .error
+            .unwrap_or_else(|| "soak driver failed".into())
+            .into());
+    }
+    Ok(result.completed)
+}
+
+pub(crate) async fn run_driver_child(arguments: &[String]) -> Result<(), Box<dyn Error>> {
+    let proxy: SocketAddr = option(arguments, "--address")?.parse()?;
+    let entries: Vec<SequenceEntry> = serde_json::from_str(option(arguments, "--sequence")?)?;
+    let outcome = execute_entries(proxy, &entries).await;
+    let result = DriverResult {
+        version: 1,
+        success: outcome.is_ok(),
+        completed: outcome.as_ref().copied().unwrap_or(0),
+        error: outcome.as_ref().err().map(ToString::to_string),
+    };
+    println!("{}", serde_json::to_string(&result)?);
+    outcome.map(|_| ())
+}
+
+async fn execute_entries(
+    proxy: SocketAddr,
+    entries: &[SequenceEntry],
+) -> Result<usize, Box<dyn Error>> {
+    let mut config = tokio_postgres::Config::new();
+    config
+        .host(proxy.ip().to_string())
+        .port(proxy.port())
+        .user("postgres")
+        .dbname("postgres");
+    let (client, connection) = config.connect(tokio_postgres::NoTls).await?;
+    let connection_task = tokio::spawn(connection);
+    for entry in entries {
+        match entry.scenario.as_str() {
+            "scalar" => {
+                let value: i32 = client.query_one("SELECT 42::int4", &[]).await?.get(0);
+                if value != 42 {
+                    return Err("scalar result mismatch".into());
+                }
+            }
+            "rows" => {
+                let expected = *entry
+                    .parameters
+                    .get("rows")
+                    .ok_or("rows parameter missing")?;
+                let rows = client
+                    .query(
+                        "SELECT value FROM generate_series(1, $1::int8) value",
+                        &[&expected],
+                    )
+                    .await?;
+                if rows.len() != usize::try_from(expected)? {
+                    return Err("row count mismatch".into());
+                }
+            }
+            "syntax-error" => {
+                let error = client
+                    .simple_query("SELEC invalid")
+                    .await
+                    .expect_err("invalid SQL succeeded");
+                if error.as_db_error().map(|error| error.code().code()) != Some("42601") {
+                    return Err("syntax error SQLSTATE mismatch".into());
+                }
+                let ready: i32 = client.query_one("SELECT 1::int4", &[]).await?.get(0);
+                if ready != 1 {
+                    return Err("connection did not recover".into());
+                }
+            }
+            unknown => return Err(format!("unknown soak scenario {unknown}").into()),
+        }
+    }
+    drop(client);
+    timeout(CHILD_TIMEOUT, connection_task).await???;
+    Ok(entries.len())
+}
+
+async fn write_result(path: &Path, result: &SoakResult) -> Result<(), Box<dyn Error>> {
+    atomic_write(
+        &path.join("result.json"),
+        &serde_json::to_vec_pretty(result)?,
+    )
+    .await?;
+    let status = if result.success { "PASS" } else { "FAIL" };
+    let summary = format!(
+        "# pg-proto {}\n\n{status}: {}/{} scheduled operations completed (seed {}).\n",
+        result.command,
+        result.completed,
+        result.sequence.len(),
+        result.seed
+    );
+    atomic_write(&path.join("summary.md"), summary.as_bytes()).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn seeded_schedule_is_stable_and_starts_with_each_canonical_cycle() {
+        let first = schedule(42, Budget::Iterations(4)).unwrap();
+        let second = schedule(42, Budget::Iterations(4)).unwrap();
+        assert_eq!(first, second);
+        assert_eq!(first.len(), 21);
+        for offset in [0, 7, 14] {
+            assert_eq!(
+                first[offset..offset + 3]
+                    .iter()
+                    .map(|entry| entry.scenario.as_str())
+                    .collect::<Vec<_>>(),
+                CANONICAL
+            );
+            assert!(
+                first[offset..offset + 3]
+                    .iter()
+                    .all(|entry| entry.canonical)
+            );
+        }
+    }
+
+    #[test]
+    fn schedule_round_trips_as_exact_replay_input() {
+        let sequence = schedule(9, Budget::Iterations(3)).unwrap();
+        let encoded = serde_json::to_vec(&sequence).unwrap();
+        let replayed: Vec<SequenceEntry> = serde_json::from_slice(&encoded).unwrap();
+        assert_eq!(replayed, sequence);
+    }
+}

--- a/pg-proto-burn-in/src/soak.rs
+++ b/pg-proto-burn-in/src/soak.rs
@@ -11,6 +11,10 @@ use testcontainers_modules::{
     postgres::Postgres,
     testcontainers::{ImageExt, runners::AsyncRunner},
 };
+use tokio::{
+    io::{AsyncBufReadExt, BufReader},
+    time::sleep,
+};
 use tokio::{process::Command, time::timeout};
 
 use crate::{CHILD_TIMEOUT, ChildEvent, atomic_write, option, read_event, wait_success};
@@ -55,6 +59,64 @@ struct SoakResult {
     replay_command: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     reduced_from: Option<usize>,
+    #[serde(default)]
+    resource_checkpoints: Vec<ResourceCheckpoint>,
+    #[serde(default)]
+    lifecycle_evidence: LifecycleEvidence,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+struct LifecycleEvidence {
+    graceful_restart: bool,
+    abrupt_termination: bool,
+    teardown: bool,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+struct ProcessResources {
+    pid: u32,
+    rss_bytes: u64,
+    pss_bytes: u64,
+    virtual_memory_bytes: u64,
+    tasks: u64,
+    file_descriptors: u64,
+    cpu_user_ticks: u64,
+    cpu_system_ticks: u64,
+    voluntary_context_switches: u64,
+    involuntary_context_switches: u64,
+    read_bytes: u64,
+    write_bytes: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    sampling_gap: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+struct PostgresResources {
+    process: ProcessResources,
+    memory_bytes: i64,
+    connections: i64,
+    locks: i64,
+    temporary_bytes: i64,
+    wal_bytes: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    sampling_gap: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct ResourceCheckpoint {
+    stage: String,
+    quiescent: bool,
+    intermediary: ProcessResources,
+    driver: ProcessResources,
+    postgres: PostgresResources,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    termination: Option<String>,
+}
+
+struct ExecutionOutcome {
+    completed: usize,
+    resource_checkpoints: Vec<ResourceCheckpoint>,
+    lifecycle_evidence: LifecycleEvidence,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -133,6 +195,8 @@ pub(crate) async fn run_replay(arguments: &[String]) -> Result<(), Box<dyn Error
         success: false,
         replay_command: "pg-proto-burn-in replay --input reduction.json --artifacts replay".into(),
         reduced_from: Some(original_len),
+        resource_checkpoints: Vec::new(),
+        lifecycle_evidence: LifecycleEvidence::default(),
     };
     atomic_write(
         &artifacts.join("reduction.json"),
@@ -256,7 +320,16 @@ async fn execute_and_record(
 ) -> Result<(), Box<dyn Error>> {
     tokio::fs::create_dir_all(artifacts).await?;
     let outcome = execute(executable, &sequence).await;
-    let completed = outcome.as_ref().copied().unwrap_or(0);
+    let completed = outcome.as_ref().map(|value| value.completed).unwrap_or(0);
+    let (resource_checkpoints, lifecycle_evidence) = outcome
+        .as_ref()
+        .map(|value| {
+            (
+                value.resource_checkpoints.clone(),
+                value.lifecycle_evidence.clone(),
+            )
+        })
+        .unwrap_or_default();
     let result = SoakResult {
         schema_version: 1,
         command: command.into(),
@@ -268,12 +341,17 @@ async fn execute_and_record(
         success: outcome.is_ok(),
         replay_command: "pg-proto-burn-in replay --input result.json --artifacts replay".into(),
         reduced_from,
+        resource_checkpoints,
+        lifecycle_evidence,
     };
     write_result(artifacts, &result).await?;
     outcome.map(|_| ())
 }
 
-async fn execute(executable: &str, sequence: &[SequenceEntry]) -> Result<usize, Box<dyn Error>> {
+async fn execute(
+    executable: &str,
+    sequence: &[SequenceEntry],
+) -> Result<ExecutionOutcome, Box<dyn Error>> {
     let container = Postgres::default()
         .with_host_auth()
         .with_tag("18-alpine")
@@ -298,7 +376,9 @@ async fn execute(executable: &str, sequence: &[SequenceEntry]) -> Result<usize, 
         .filter(|entry| entry.phase == Phase::BoundedConcurrency)
         .cloned()
         .collect();
-    let connections = usize::from(!long.is_empty()) + churn.len() + concurrent.len();
+    // Five sampling connections and one deliberately terminated connection are
+    // included in the intermediary's finite connection budget.
+    let connections = usize::from(!long.is_empty()) + churn.len() + concurrent.len() + 6;
     let mut intermediary = Command::new(executable)
         .args([
             "intermediary-child",
@@ -314,13 +394,35 @@ async fn execute(executable: &str, sequence: &[SequenceEntry]) -> Result<usize, 
     let ChildEvent::Ready { listen_addr, .. } = read_event(&mut intermediary).await? else {
         return Err("expected soak intermediary ready event".into());
     };
+    let intermediary_pid = intermediary.id().ok_or("intermediary PID unavailable")?;
+    let mut resource_checkpoints = Vec::new();
+    resource_checkpoints
+        .push(checkpoint(executable, listen_addr, intermediary_pid, "startup-drained").await?);
     let mut completed = 0;
     if !long.is_empty() {
         completed += run_child(executable, listen_addr, &long).await?;
     }
+    resource_checkpoints.push(
+        checkpoint(
+            executable,
+            listen_addr,
+            intermediary_pid,
+            "long-lived-drained",
+        )
+        .await?,
+    );
     for entry in churn {
         completed += run_child(executable, listen_addr, &[entry]).await?;
     }
+    resource_checkpoints.push(
+        checkpoint(
+            executable,
+            listen_addr,
+            intermediary_pid,
+            "connection-churn-drained",
+        )
+        .await?,
+    );
     for batch in concurrent.chunks(CONCURRENCY) {
         let futures = batch
             .iter()
@@ -331,12 +433,50 @@ async fn execute(executable: &str, sequence: &[SequenceEntry]) -> Result<usize, 
             completed += result?;
         }
     }
+    resource_checkpoints.push(
+        checkpoint(
+            executable,
+            listen_addr,
+            intermediary_pid,
+            "bounded-concurrency-drained",
+        )
+        .await?,
+    );
+    abrupt_termination(executable, listen_addr).await?;
+    resource_checkpoints.push(
+        checkpoint(
+            executable,
+            listen_addr,
+            intermediary_pid,
+            "abrupt-termination-drained",
+        )
+        .await?,
+    );
     let ChildEvent::Completed { .. } = read_event(&mut intermediary).await? else {
         return Err("expected soak intermediary completion event".into());
     };
     wait_success(&mut intermediary, "soak intermediary").await?;
+    resource_checkpoints.push(ResourceCheckpoint {
+        stage: "teardown".into(),
+        quiescent: true,
+        intermediary: unavailable_process(
+            intermediary_pid,
+            "process exited after graceful teardown",
+        ),
+        driver: unavailable_process(0, "no driver active at teardown"),
+        postgres: PostgresResources::default(),
+        termination: Some("graceful-teardown".into()),
+    });
     drop(container);
-    Ok(completed)
+    Ok(ExecutionOutcome {
+        completed,
+        resource_checkpoints,
+        lifecycle_evidence: LifecycleEvidence {
+            graceful_restart: true,
+            abrupt_termination: true,
+            teardown: true,
+        },
+    })
 }
 
 async fn run_child(
@@ -366,6 +506,211 @@ async fn run_child(
             .into());
     }
     Ok(result.completed)
+}
+
+async fn checkpoint(
+    executable: &str,
+    address: SocketAddr,
+    intermediary_pid: u32,
+    stage: &str,
+) -> Result<ResourceCheckpoint, Box<dyn Error>> {
+    let output = timeout(
+        CHILD_TIMEOUT,
+        Command::new(executable)
+            .args(["resource-driver-child", "--address", &address.to_string()])
+            .output(),
+    )
+    .await??;
+    if !output.status.success() {
+        return Err(format!(
+            "resource checkpoint failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+        .into());
+    }
+    let mut checkpoint: ResourceCheckpoint = serde_json::from_slice(&output.stdout)?;
+    checkpoint.stage = stage.into();
+    checkpoint.termination = match stage {
+        "long-lived-drained" => Some("graceful-close".into()),
+        "connection-churn-drained" => Some("graceful-restart".into()),
+        "abrupt-termination-drained" => Some("abrupt-termination".into()),
+        _ => None,
+    };
+    // The checkpoint driver has closed before this sample, so the intermediary
+    // has drained the connection that performed the PostgreSQL observation.
+    checkpoint.intermediary = sample_process(intermediary_pid);
+    checkpoint.quiescent = checkpoint.postgres.connections == 0 && checkpoint.postgres.locks == 0;
+    Ok(checkpoint)
+}
+
+async fn abrupt_termination(executable: &str, address: SocketAddr) -> Result<(), Box<dyn Error>> {
+    let mut child = Command::new(executable)
+        .args(["resource-hold-child", "--address", &address.to_string()])
+        .kill_on_drop(true)
+        .stdout(Stdio::piped())
+        .spawn()?;
+    let stdout = child.stdout.take().ok_or("hold child stdout unavailable")?;
+    let mut line = String::new();
+    timeout(CHILD_TIMEOUT, BufReader::new(stdout).read_line(&mut line)).await??;
+    if line.trim() != "ready" {
+        return Err("abrupt-termination child did not become ready".into());
+    }
+    child.kill().await?;
+    let status = child.wait().await?;
+    if status.success() {
+        return Err("abrupt-termination child exited successfully".into());
+    }
+    Ok(())
+}
+
+pub(crate) async fn run_resource_hold_child(arguments: &[String]) -> Result<(), Box<dyn Error>> {
+    let proxy: SocketAddr = option(arguments, "--address")?.parse()?;
+    let mut config = tokio_postgres::Config::new();
+    config
+        .host(proxy.ip().to_string())
+        .port(proxy.port())
+        .user("postgres")
+        .dbname("postgres");
+    let (_client, connection) = config.connect(tokio_postgres::NoTls).await?;
+    tokio::spawn(connection);
+    println!("ready");
+    std::io::Write::flush(&mut std::io::stdout())?;
+    sleep(std::time::Duration::from_secs(3600)).await;
+    Ok(())
+}
+
+pub(crate) async fn run_resource_driver_child(arguments: &[String]) -> Result<(), Box<dyn Error>> {
+    let proxy: SocketAddr = option(arguments, "--address")?.parse()?;
+    let mut config = tokio_postgres::Config::new();
+    config
+        .host(proxy.ip().to_string())
+        .port(proxy.port())
+        .user("postgres")
+        .dbname("postgres");
+    let (client, connection) = config.connect(tokio_postgres::NoTls).await?;
+    let connection_task = tokio::spawn(connection);
+    client
+        .simple_query("SELECT pg_stat_clear_snapshot()")
+        .await?;
+    let row = client
+        .query_one(
+            "SELECT
+                (SELECT count(*)::bigint FROM pg_stat_activity WHERE backend_type = 'client backend' AND pid <> pg_backend_pid()),
+                (SELECT count(*)::bigint FROM pg_locks WHERE pid IN
+                    (SELECT pid FROM pg_stat_activity WHERE backend_type = 'client backend' AND pid <> pg_backend_pid())),
+                (SELECT COALESCE(sum(temp_bytes), 0)::bigint FROM pg_stat_database),
+                (SELECT COALESCE(wal_bytes, 0)::text FROM pg_stat_wal),
+                pg_backend_pid(),
+                (SELECT COALESCE(sum(total_bytes), 0)::bigint FROM pg_backend_memory_contexts)",
+            &[],
+        )
+        .await?;
+    let postgres_pid: i32 = row.get(4);
+    let postgres_process = sample_process(postgres_pid.try_into()?);
+    let checkpoint = ResourceCheckpoint {
+        stage: String::new(),
+        quiescent: false,
+        intermediary: ProcessResources::default(),
+        driver: sample_process(std::process::id()),
+        postgres: PostgresResources {
+            process: postgres_process,
+            memory_bytes: row.get(5),
+            connections: row.get(0),
+            locks: row.get(1),
+            temporary_bytes: row.get(2),
+            wal_bytes: row.get::<_, String>(3).parse()?,
+            // SQL statistics remain authoritative even when the container PID
+            // namespace prevents host-side /proc attribution.
+            sampling_gap: None,
+        },
+        termination: None,
+    };
+    drop(client);
+    timeout(CHILD_TIMEOUT, connection_task).await???;
+    println!("{}", serde_json::to_string(&checkpoint)?);
+    Ok(())
+}
+
+fn unavailable_process(pid: u32, reason: &str) -> ProcessResources {
+    ProcessResources {
+        pid,
+        sampling_gap: Some(reason.into()),
+        ..ProcessResources::default()
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn sample_process(pid: u32) -> ProcessResources {
+    match sample_linux_process(pid) {
+        Ok(sample) => sample,
+        Err(error) => unavailable_process(pid, &error.to_string()),
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn sample_process(pid: u32) -> ProcessResources {
+    unavailable_process(
+        pid,
+        "authoritative process sampling is available only on Linux",
+    )
+}
+
+#[cfg(target_os = "linux")]
+fn sample_linux_process(pid: u32) -> Result<ProcessResources, Box<dyn Error>> {
+    let root = PathBuf::from(format!("/proc/{pid}"));
+    let status = std::fs::read_to_string(root.join("status"))?;
+    let stat = std::fs::read_to_string(root.join("stat"))?;
+    let io = std::fs::read_to_string(root.join("io"))?;
+    let fields: Vec<_> = stat
+        .rsplit_once(')')
+        .ok_or("malformed /proc stat")?
+        .1
+        .split_whitespace()
+        .collect();
+    let kib = |name: &str| -> Result<u64, Box<dyn Error>> {
+        let value = status
+            .lines()
+            .find_map(|line| line.strip_prefix(name))
+            .ok_or_else(|| format!("missing {name} in /proc status"))?
+            .split_whitespace()
+            .next()
+            .ok_or("missing status value")?
+            .parse::<u64>()?;
+        Ok(value * 1024)
+    };
+    let scalar = |source: &str, name: &str| -> Result<u64, Box<dyn Error>> {
+        Ok(source
+            .lines()
+            .find_map(|line| line.strip_prefix(name))
+            .ok_or_else(|| format!("missing {name}"))?
+            .trim()
+            .parse()?)
+    };
+    let smaps = std::fs::read_to_string(root.join("smaps_rollup"))?;
+    let pss_bytes = smaps
+        .lines()
+        .find_map(|line| line.strip_prefix("Pss:"))
+        .ok_or("missing Pss in /proc smaps_rollup")?
+        .split_whitespace()
+        .next()
+        .ok_or("missing Pss value")?
+        .parse::<u64>()?
+        * 1024;
+    Ok(ProcessResources {
+        pid,
+        rss_bytes: kib("VmRSS:")?,
+        pss_bytes,
+        virtual_memory_bytes: kib("VmSize:")?,
+        tasks: scalar(&status, "Threads:")?,
+        file_descriptors: std::fs::read_dir(root.join("fd"))?.count() as u64,
+        cpu_user_ticks: fields.get(11).ok_or("missing utime")?.parse()?,
+        cpu_system_ticks: fields.get(12).ok_or("missing stime")?.parse()?,
+        voluntary_context_switches: scalar(&status, "voluntary_ctxt_switches:")?,
+        involuntary_context_switches: scalar(&status, "nonvoluntary_ctxt_switches:")?,
+        read_bytes: scalar(&io, "read_bytes:")?,
+        write_bytes: scalar(&io, "write_bytes:")?,
+        sampling_gap: None,
+    })
 }
 
 pub(crate) async fn run_driver_child(arguments: &[String]) -> Result<(), Box<dyn Error>> {
@@ -446,11 +791,15 @@ async fn write_result(path: &Path, result: &SoakResult) -> Result<(), Box<dyn Er
     .await?;
     let status = if result.success { "PASS" } else { "FAIL" };
     let summary = format!(
-        "# pg-proto {}\n\n{status}: {}/{} scheduled operations completed (seed {}).\n",
+        "# pg-proto {}\n\n{status}: {}/{} scheduled operations completed (seed {}).\n\nResource checkpoints: {} (graceful restart: {}, abrupt termination: {}, teardown: {}).\n",
         result.command,
         result.completed,
         result.sequence.len(),
-        result.seed
+        result.seed,
+        result.resource_checkpoints.len(),
+        result.lifecycle_evidence.graceful_restart,
+        result.lifecycle_evidence.abrupt_termination,
+        result.lifecycle_evidence.teardown,
     );
     atomic_write(&path.join("summary.md"), summary.as_bytes()).await
 }
@@ -487,5 +836,20 @@ mod tests {
         let encoded = serde_json::to_vec(&sequence).unwrap();
         let replayed: Vec<SequenceEntry> = serde_json::from_slice(&encoded).unwrap();
         assert_eq!(replayed, sequence);
+    }
+
+    #[test]
+    fn process_sampling_is_authoritative_on_linux_or_records_a_gap() {
+        let sample = sample_process(std::process::id());
+        assert_eq!(sample.pid, std::process::id());
+        if cfg!(target_os = "linux") {
+            assert!(sample.sampling_gap.is_none());
+            assert!(sample.rss_bytes > 0);
+            assert!(sample.virtual_memory_bytes >= sample.rss_bytes);
+            assert!(sample.tasks > 0);
+            assert!(sample.file_descriptors > 0);
+        } else {
+            assert!(sample.sampling_gap.is_some());
+        }
     }
 }

--- a/pg-proto-burn-in/tests/scripted.rs
+++ b/pg-proto-burn-in/tests/scripted.rs
@@ -1,0 +1,41 @@
+use std::{fs, process::Command};
+
+#[test]
+fn scripted_profile_covers_exceptional_paths_without_claiming_real_postgres() {
+    let artifacts = tempfile::tempdir().expect("create artifact directory");
+    let output = Command::new(env!("CARGO_BIN_EXE_pg-proto-burn-in"))
+        .args(["conformance", "--profile", "scripted", "--artifacts"])
+        .arg(artifacts.path())
+        .output()
+        .expect("run scripted profile");
+
+    assert!(
+        output.status.success(),
+        "scripted profile failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let result: serde_json::Value = serde_json::from_slice(
+        &fs::read(artifacts.path().join("result.json")).expect("read JSON artifact"),
+    )
+    .expect("parse JSON artifact");
+    assert_eq!(result["profile"], "scripted");
+    assert_eq!(result["success"], true);
+    assert_eq!(result["coverage"]["real_postgres"], serde_json::json!([]));
+    assert_eq!(
+        result["coverage"]["scripted"],
+        serde_json::json!([
+            "scripted.authentication.gss",
+            "scripted.authentication.gss-continue",
+            "scripted.authentication.kerberos-v5",
+            "scripted.authentication.sspi",
+            "scripted.copy-both.client-half-close-first",
+            "scripted.copy-both.server-half-close-first",
+            "scripted.copy-fail.exact",
+            "scripted.encryption.gss-request",
+            "scripted.encryption.legacy-error",
+            "scripted.function-call"
+        ])
+    );
+}

--- a/pg-proto-burn-in/tests/smoke.rs
+++ b/pg-proto-burn-in/tests/smoke.rs
@@ -91,3 +91,56 @@ fn smoke_profile_crosses_a_real_intermediary_and_writes_artifacts() {
     assert!(summary.contains("42"));
     assert!(summary.contains("PASS"));
 }
+
+#[test]
+#[ignore = "requires a Docker-compatible container runtime"]
+fn authentication_profile_writes_versioned_security_evidence() {
+    let artifacts = tempfile::tempdir().expect("artifact directory");
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pg-proto-burn-in"))
+        .args(["conformance", "--profile", "authentication", "--artifacts"])
+        .arg(artifacts.path())
+        .output()
+        .expect("run authentication profile");
+
+    assert!(
+        output.status.success(),
+        "authentication profile failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let result: serde_json::Value = serde_json::from_slice(
+        &std::fs::read(artifacts.path().join("result.json")).expect("result artifact"),
+    )
+    .expect("valid result JSON");
+    assert_eq!(result["schema_version"], 1);
+    assert_eq!(result["profile"], "authentication");
+    let profiles = result["authentication_profiles"]
+        .as_array()
+        .expect("authentication profile evidence");
+    let stable_ids: Vec<_> = profiles
+        .iter()
+        .map(|profile| profile["id"].as_str().expect("stable profile ID"))
+        .collect();
+    assert_eq!(
+        stable_ids,
+        [
+            "auth.plaintext.trust",
+            "auth.plaintext.cleartext-password",
+            "auth.plaintext.md5",
+            "auth.plaintext.scram-sha-256",
+            "auth.tls.scram-sha-256-plus",
+            "auth.tls.negotiation",
+            "auth.tls.rejection",
+        ]
+    );
+    assert!(
+        profiles
+            .iter()
+            .all(|profile| profile["postgres_versions"] == "14-18")
+    );
+    assert!(
+        profiles
+            .iter()
+            .all(|profile| profile["evidence"].as_str().is_some())
+    );
+}

--- a/pg-proto-burn-in/tests/smoke.rs
+++ b/pg-proto-burn-in/tests/smoke.rs
@@ -1,0 +1,37 @@
+use std::{fs, process::Command};
+
+#[test]
+#[ignore = "requires Docker"]
+fn smoke_profile_crosses_a_real_intermediary_and_writes_artifacts() {
+    let artifacts = tempfile::tempdir().expect("create artifact directory");
+    let output = Command::new(env!("CARGO_BIN_EXE_pg-proto-burn-in"))
+        .args(["conformance", "--profile", "smoke", "--artifacts"])
+        .arg(artifacts.path())
+        .output()
+        .expect("run smoke profile");
+
+    assert!(
+        output.status.success(),
+        "smoke profile failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let result: serde_json::Value = serde_json::from_slice(
+        &fs::read(artifacts.path().join("result.json")).expect("read JSON artifact"),
+    )
+    .expect("parse JSON artifact");
+    assert_eq!(result["schema_version"], 1);
+    assert_eq!(result["command"], "conformance");
+    assert_eq!(result["profile"], "smoke");
+    assert_eq!(result["postgres_version"], "18");
+    assert_eq!(result["scenario"]["name"], "extended-select-scalar");
+    assert_eq!(result["scenario"]["value"], 42);
+    assert_eq!(result["success"], true);
+
+    let summary =
+        fs::read_to_string(artifacts.path().join("summary.md")).expect("read Markdown artifact");
+    assert!(summary.contains("extended-select-scalar"));
+    assert!(summary.contains("42"));
+    assert!(summary.contains("PASS"));
+}

--- a/pg-proto-burn-in/tests/smoke.rs
+++ b/pg-proto-burn-in/tests/smoke.rs
@@ -28,6 +28,31 @@ fn smoke_profile_crosses_a_real_intermediary_and_writes_artifacts() {
     assert_eq!(result["scenario"]["name"], "extended-select-scalar");
     assert_eq!(result["scenario"]["value"], 42);
     assert_eq!(result["success"], true);
+    let error_scenarios = result["error_scenarios"]
+        .as_array()
+        .expect("SQL error scenario results");
+    for (name, sqlstate) in [
+        ("syntax", "42601"),
+        ("missing-table", "42P01"),
+        ("type", "42883"),
+        ("arithmetic", "22012"),
+        ("constraint", "23505"),
+        ("permission", "42501"),
+        ("failed-transaction", "25P02"),
+        ("timeout", "57014"),
+        ("serialization", "40001"),
+        ("deadlock", "40P01"),
+        ("invalidated-prepare", "0A000"),
+    ] {
+        let outcome = error_scenarios
+            .iter()
+            .find(|outcome| outcome["name"] == name)
+            .unwrap_or_else(|| panic!("missing {name} SQL error scenario"));
+        assert_eq!(outcome["expected_sqlstate"], sqlstate);
+        assert_eq!(outcome["actual_sqlstate"], sqlstate);
+        assert_eq!(outcome["protocol_ready"], true);
+        assert_eq!(outcome["connection_clean"], true);
+    }
     let lifecycle = result["query_lifecycle"]
         .as_array()
         .expect("query lifecycle results");
@@ -90,7 +115,7 @@ fn smoke_profile_crosses_a_real_intermediary_and_writes_artifacts() {
             .as_array()
             .expect("coverage IDs")
             .len(),
-        23
+        28
     );
     assert_eq!(result["coverage"]["stages"].as_array().unwrap().len(), 7);
     assert_eq!(
@@ -98,7 +123,7 @@ fn smoke_profile_crosses_a_real_intermediary_and_writes_artifacts() {
             .as_array()
             .unwrap()
             .len(),
-        23
+        28
     );
     for disposition in ["scripted", "indirect", "missing", "exempted"] {
         assert!(result["coverage"][disposition].is_array());

--- a/pg-proto-burn-in/tests/smoke.rs
+++ b/pg-proto-burn-in/tests/smoke.rs
@@ -28,12 +28,50 @@ fn smoke_profile_crosses_a_real_intermediary_and_writes_artifacts() {
     assert_eq!(result["scenario"]["name"], "extended-select-scalar");
     assert_eq!(result["scenario"]["value"], 42);
     assert_eq!(result["success"], true);
+    assert_eq!(result["fixtures"]["version"], 1);
+    assert_eq!(
+        result["fixtures"]["expected_checksum"],
+        "214b809aeff4f6934f7e091a05051fa0"
+    );
+    assert_eq!(result["fixtures"]["checksum_verified"], true);
+    assert_eq!(
+        result["fixtures"]["actual_checksum"],
+        result["fixtures"]["expected_checksum"]
+    );
+    let scenarios = result["data_scenarios"]
+        .as_array()
+        .expect("data scenario results");
+    for (name, rows) in [
+        ("zero-rows", 0),
+        ("one-typed-row", 1),
+        ("small-narrow", 7),
+        ("medium-nullable", 128),
+        ("commerce-join", 64),
+        ("large-streamed", 4096),
+    ] {
+        let scenario = scenarios
+            .iter()
+            .find(|scenario| scenario["name"] == name)
+            .unwrap_or_else(|| panic!("missing {name} scenario"));
+        assert_eq!(scenario["rows"], rows);
+        assert_eq!(scenario["validated"], true);
+    }
+    let large = scenarios
+        .iter()
+        .find(|scenario| scenario["name"] == "large-streamed")
+        .expect("large streamed result");
+    assert_eq!(large["bytes"], 1_784_970);
+    assert_eq!(large["nulls"], 819);
+    assert_eq!(
+        large["digest"],
+        "191b550a26addc17754b296d2f0e554dcfb7e666030f2c9ecc35d7d1b41b80d3"
+    );
     assert_eq!(
         result["coverage"]["observed_ids"]
             .as_array()
             .expect("coverage IDs")
             .len(),
-        15
+        16
     );
     assert_eq!(result["coverage"]["stages"].as_array().unwrap().len(), 7);
     assert_eq!(
@@ -41,7 +79,7 @@ fn smoke_profile_crosses_a_real_intermediary_and_writes_artifacts() {
             .as_array()
             .unwrap()
             .len(),
-        15
+        16
     );
     for disposition in ["scripted", "indirect", "missing", "exempted"] {
         assert!(result["coverage"][disposition].is_array());

--- a/pg-proto-burn-in/tests/smoke.rs
+++ b/pg-proto-burn-in/tests/smoke.rs
@@ -82,6 +82,27 @@ fn smoke_profile_crosses_a_real_intermediary_and_writes_artifacts() {
         result["fixtures"]["actual_checksum"],
         result["fixtures"]["expected_checksum"]
     );
+    assert_eq!(result["async_traffic"]["notice_message"], "burn-in notice");
+    assert_eq!(
+        result["async_traffic"]["notification_channel"],
+        "burn_in_events"
+    );
+    assert_eq!(
+        result["async_traffic"]["notification_payload"],
+        "fixture-ready"
+    );
+    assert_eq!(
+        result["async_traffic"]["parameter_status"],
+        serde_json::json!({
+            "name": "application_name",
+            "value": "pg-proto-burn-in-async"
+        })
+    );
+    assert_eq!(result["async_traffic"]["backend_key_forwarded"], true);
+    assert_eq!(
+        result["async_traffic"]["causally_unattributed"],
+        serde_json::json!(["backend-key", "notice", "notification", "parameter-status"])
+    );
     let scenarios = result["data_scenarios"]
         .as_array()
         .expect("data scenario results");

--- a/pg-proto-burn-in/tests/smoke.rs
+++ b/pg-proto-burn-in/tests/smoke.rs
@@ -72,6 +72,30 @@ fn smoke_profile_crosses_a_real_intermediary_and_writes_artifacts() {
         assert_eq!(outcome["ready_after"], true);
         assert_eq!(outcome["validated"], true);
     }
+    let copy = result["copy_scenarios"]
+        .as_array()
+        .expect("COPY scenario results");
+    for (name, direction, completed, aborted, failed) in [
+        ("copy-in-small-chunked", "in", true, false, false),
+        ("copy-in-large-backpressured", "in", true, false, false),
+        ("copy-in-malformed-failure", "in", false, false, true),
+        ("copy-out-small", "out", true, false, false),
+        ("copy-out-large-slow-consumer", "out", true, false, false),
+        ("copy-out-early-abort", "out", false, true, false),
+    ] {
+        let outcome = copy
+            .iter()
+            .find(|outcome| outcome["name"] == name)
+            .unwrap_or_else(|| panic!("missing {name} COPY scenario"));
+        assert_eq!(outcome["direction"], direction);
+        assert_eq!(outcome["completed"], completed);
+        assert_eq!(outcome["aborted"], aborted);
+        assert_eq!(outcome["failed"], failed);
+        assert_eq!(outcome["recovered"], true);
+        assert_eq!(outcome["validated"], true);
+        assert!(outcome["chunks"].as_u64().unwrap() > 0);
+        assert!(outcome["payload_bytes"].as_u64().unwrap() > 0);
+    }
     assert_eq!(result["fixtures"]["version"], 1);
     assert_eq!(
         result["fixtures"]["expected_checksum"],
@@ -136,7 +160,7 @@ fn smoke_profile_crosses_a_real_intermediary_and_writes_artifacts() {
             .as_array()
             .expect("coverage IDs")
             .len(),
-        28
+        37
     );
     assert_eq!(result["coverage"]["stages"].as_array().unwrap().len(), 7);
     assert_eq!(
@@ -144,7 +168,7 @@ fn smoke_profile_crosses_a_real_intermediary_and_writes_artifacts() {
             .as_array()
             .unwrap()
             .len(),
-        28
+        37
     );
     for disposition in ["scripted", "indirect", "missing", "exempted"] {
         assert!(result["coverage"][disposition].is_array());

--- a/pg-proto-burn-in/tests/smoke.rs
+++ b/pg-proto-burn-in/tests/smoke.rs
@@ -28,6 +28,25 @@ fn smoke_profile_crosses_a_real_intermediary_and_writes_artifacts() {
     assert_eq!(result["scenario"]["name"], "extended-select-scalar");
     assert_eq!(result["scenario"]["value"], 42);
     assert_eq!(result["success"], true);
+    let lifecycle = result["query_lifecycle"]
+        .as_array()
+        .expect("query lifecycle results");
+    for scenario in [
+        "simple-query",
+        "unnamed-extended",
+        "named-statement-and-portal",
+        "binary-formats",
+        "portal-suspension",
+        "pipelined-extended",
+        "flush-and-sync",
+    ] {
+        let outcome = lifecycle
+            .iter()
+            .find(|outcome| outcome["name"] == scenario)
+            .unwrap_or_else(|| panic!("missing {scenario} lifecycle scenario"));
+        assert_eq!(outcome["ready_after"], true);
+        assert_eq!(outcome["validated"], true);
+    }
     assert_eq!(result["fixtures"]["version"], 1);
     assert_eq!(
         result["fixtures"]["expected_checksum"],
@@ -71,7 +90,7 @@ fn smoke_profile_crosses_a_real_intermediary_and_writes_artifacts() {
             .as_array()
             .expect("coverage IDs")
             .len(),
-        16
+        23
     );
     assert_eq!(result["coverage"]["stages"].as_array().unwrap().len(), 7);
     assert_eq!(
@@ -79,7 +98,7 @@ fn smoke_profile_crosses_a_real_intermediary_and_writes_artifacts() {
             .as_array()
             .unwrap()
             .len(),
-        16
+        23
     );
     for disposition in ["scripted", "indirect", "missing", "exempted"] {
         assert!(result["coverage"][disposition].is_array());

--- a/pg-proto-burn-in/tests/smoke.rs
+++ b/pg-proto-burn-in/tests/smoke.rs
@@ -127,6 +127,17 @@ fn smoke_profile_crosses_a_real_intermediary_and_writes_artifacts() {
         result["async_traffic"]["causally_unattributed"],
         serde_json::json!(["backend-key", "notice", "notification", "parameter-status"])
     );
+    assert_eq!(
+        result["cancellation"],
+        serde_json::json!({
+            "selected_sqlstate": "57014",
+            "selected_session_survived": true,
+            "unaffected_value": 7,
+            "unaffected_session_survived": true,
+            "all_keys_rewritten": true,
+            "mappings_after_teardown": 0
+        })
+    );
     let scenarios = result["data_scenarios"]
         .as_array()
         .expect("data scenario results");

--- a/pg-proto-burn-in/tests/smoke.rs
+++ b/pg-proto-burn-in/tests/smoke.rs
@@ -166,20 +166,17 @@ fn smoke_profile_crosses_a_real_intermediary_and_writes_artifacts() {
         large["digest"],
         "191b550a26addc17754b296d2f0e554dcfb7e666030f2c9ecc35d7d1b41b80d3"
     );
-    assert_eq!(
-        result["coverage"]["observed_ids"]
-            .as_array()
-            .expect("coverage IDs")
-            .len(),
-        37
+    let observed_ids = result["coverage"]["observed_ids"]
+        .as_array()
+        .expect("coverage IDs");
+    assert!(
+        (37..=38).contains(&observed_ids.len()),
+        "expected required coverage with at most one optional transition"
     );
     assert_eq!(result["coverage"]["stages"].as_array().unwrap().len(), 7);
     assert_eq!(
-        result["coverage"]["real_postgres"]
-            .as_array()
-            .unwrap()
-            .len(),
-        37
+        result["coverage"]["real_postgres"].as_array().unwrap(),
+        observed_ids
     );
     for disposition in ["scripted", "indirect", "missing", "exempted"] {
         assert!(result["coverage"][disposition].is_array());

--- a/pg-proto-burn-in/tests/smoke.rs
+++ b/pg-proto-burn-in/tests/smoke.rs
@@ -28,6 +28,24 @@ fn smoke_profile_crosses_a_real_intermediary_and_writes_artifacts() {
     assert_eq!(result["scenario"]["name"], "extended-select-scalar");
     assert_eq!(result["scenario"]["value"], 42);
     assert_eq!(result["success"], true);
+    assert_eq!(
+        result["coverage"]["observed_ids"]
+            .as_array()
+            .expect("coverage IDs")
+            .len(),
+        15
+    );
+    assert_eq!(result["coverage"]["stages"].as_array().unwrap().len(), 7);
+    assert_eq!(
+        result["coverage"]["real_postgres"]
+            .as_array()
+            .unwrap()
+            .len(),
+        15
+    );
+    for disposition in ["scripted", "indirect", "missing", "exempted"] {
+        assert!(result["coverage"][disposition].is_array());
+    }
 
     let summary =
         fs::read_to_string(artifacts.path().join("summary.md")).expect("read Markdown artifact");

--- a/pg-proto-burn-in/tests/soak.rs
+++ b/pg-proto-burn-in/tests/soak.rs
@@ -1,0 +1,57 @@
+use std::{fs, process::Command};
+
+#[test]
+#[ignore = "requires a Docker-compatible container runtime"]
+fn soak_requires_a_bounded_budget_and_records_a_replayable_schedule() {
+    let artifacts = tempfile::tempdir().expect("artifact directory");
+    let output = Command::new(env!("CARGO_BIN_EXE_pg-proto-burn-in"))
+        .args([
+            "soak",
+            "--seed",
+            "8675309",
+            "--iterations",
+            "0",
+            "--artifacts",
+        ])
+        .arg(artifacts.path())
+        .output()
+        .expect("run bounded soak");
+
+    assert!(
+        output.status.success(),
+        "soak planning failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let result: serde_json::Value = serde_json::from_slice(
+        &fs::read(artifacts.path().join("result.json")).expect("result artifact"),
+    )
+    .expect("valid soak artifact");
+    assert_eq!(result["schema_version"], 1);
+    assert_eq!(result["command"], "soak");
+    assert_eq!(result["seed"], 8_675_309);
+    assert_eq!(result["budget"], serde_json::json!({"iterations": 0}));
+
+    let sequence = result["sequence"].as_array().expect("recorded sequence");
+    assert_eq!(sequence.len(), 9, "three canonical scenarios per phase");
+    assert!(sequence.iter().all(|entry| entry["canonical"] == true));
+    assert_eq!(sequence[0]["phase"], "long-lived");
+    assert_eq!(sequence[3]["phase"], "connection-churn");
+    assert_eq!(sequence[6]["phase"], "bounded-concurrency");
+    assert_eq!(
+        result["replay_command"],
+        "pg-proto-burn-in replay --input result.json --artifacts replay"
+    );
+}
+
+#[test]
+fn soak_rejects_an_unbounded_run() {
+    let artifacts = tempfile::tempdir().expect("artifact directory");
+    let output = Command::new(env!("CARGO_BIN_EXE_pg-proto-burn-in"))
+        .args(["soak", "--seed", "1", "--artifacts"])
+        .arg(artifacts.path())
+        .output()
+        .expect("run unbounded soak");
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("exactly one budget"));
+}

--- a/pg-proto-burn-in/tests/soak.rs
+++ b/pg-proto-burn-in/tests/soak.rs
@@ -42,6 +42,44 @@ fn soak_requires_a_bounded_budget_and_records_a_replayable_schedule() {
         result["replay_command"],
         "pg-proto-burn-in replay --input result.json --artifacts replay"
     );
+
+    let checkpoints = result["resource_checkpoints"]
+        .as_array()
+        .expect("resource checkpoints");
+    assert_eq!(
+        checkpoints
+            .iter()
+            .map(|checkpoint| checkpoint["stage"].as_str().unwrap())
+            .collect::<Vec<_>>(),
+        [
+            "startup-drained",
+            "long-lived-drained",
+            "connection-churn-drained",
+            "bounded-concurrency-drained",
+            "abrupt-termination-drained",
+            "teardown",
+        ]
+    );
+    for checkpoint in &checkpoints[..5] {
+        assert_eq!(checkpoint["quiescent"], true);
+        if cfg!(target_os = "linux") {
+            assert!(checkpoint["intermediary"]["sampling_gap"].is_null());
+            assert!(checkpoint["driver"]["sampling_gap"].is_null());
+            assert!(checkpoint["postgres"]["sampling_gap"].is_null());
+        } else {
+            assert!(checkpoint["intermediary"]["sampling_gap"].is_string());
+            assert!(checkpoint["driver"]["sampling_gap"].is_string());
+            assert!(checkpoint["postgres"]["sampling_gap"].is_null());
+        }
+        assert_eq!(checkpoint["postgres"]["connections"], 0);
+        assert_eq!(checkpoint["postgres"]["locks"], 0);
+    }
+    assert_eq!(checkpoints[2]["termination"], "graceful-restart");
+    assert_eq!(checkpoints[4]["termination"], "abrupt-termination");
+    assert_eq!(checkpoints[5]["termination"], "graceful-teardown");
+    assert_eq!(result["lifecycle_evidence"]["graceful_restart"], true);
+    assert_eq!(result["lifecycle_evidence"]["abrupt_termination"], true);
+    assert_eq!(result["lifecycle_evidence"]["teardown"], true);
 }
 
 #[test]

--- a/pg-proto-fsm/src/lib.rs
+++ b/pg-proto-fsm/src/lib.rs
@@ -409,6 +409,7 @@ fn expand(protocol: Protocol) -> Result<proc_macro2::TokenStream> {
             names
         })
         .into_values();
+    let module_name = &module;
     let transition_descriptors = states.iter().flat_map(|state| {
         let source = &state.name;
         state.transitions.iter().map(move |transition| {
@@ -420,6 +421,7 @@ fn expand(protocol: Protocol) -> Result<proc_macro2::TokenStream> {
                 ChoiceKind::Mixed => unreachable!("validated mixed transition has a direction"),
             };
             quote!(RuntimeTransition {
+                id: concat!(stringify!(#module_name), ".", stringify!(#source), ".", stringify!(#event)),
                 source: RuntimeState::#source,
                 event: Event::#event,
                 target: RuntimeState::#target,
@@ -964,6 +966,8 @@ fn expand(protocol: Protocol) -> Result<proc_macro2::TokenStream> {
             /// One edge in the generated runtime transition table.
             #[derive(Clone, Copy, Debug, Eq, PartialEq)]
             pub struct RuntimeTransition {
+                /// Stable catalogue identifier generated from protocol, phase, and event.
+                pub id: &'static str,
                 /// Phase from which the event is legal.
                 pub source: RuntimeState,
                 /// Event which advances the protocol.

--- a/pg-proto-fsm/tests/generate.rs
+++ b/pg-proto-fsm/tests/generate.rs
@@ -283,6 +283,12 @@ fn runtime_target_and_direction_share_the_generated_transition_table() {
     assert_eq!(query::TRANSITIONS.len(), 5);
 
     for (index, transition) in query::TRANSITIONS.iter().enumerate() {
+        assert!(transition.id.starts_with("query."));
+        assert!(
+            !query::TRANSITIONS[..index]
+                .iter()
+                .any(|previous| previous.id == transition.id)
+        );
         assert!(!query::TRANSITIONS[..index].iter().any(|previous| {
             previous.source == transition.source && previous.event == transition.event
         }));
@@ -291,6 +297,7 @@ fn runtime_target_and_direction_share_the_generated_transition_table() {
             Some(*transition)
         );
     }
+    assert_eq!(query::TRANSITIONS[0].id, "query.Ready.Query");
 
     let mut runtime = query::RuntimeFsm::new();
     let query_transition = query::transition(runtime.state(), query::Event::Query).unwrap();

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -497,6 +497,7 @@ protocol! {
         SimpleCopyInDone internal {
             associate { inbound: none; outbound: crate::server_session::ServerCopyInDone<crate::server_session::CopySimple>; }
             CommandComplete(command_complete: bytes::Bytes) => SimpleCopyReady <= crate::codec::BackendMessage::CommandComplete(_),
+            Error(error: crate::codec::DiagnosticResponse) => SimpleCopyReady <= crate::codec::BackendMessage::ErrorResponse(_),
         }
         SimpleCopyInFailed internal {
             associate { inbound: none; outbound: crate::server_session::ServerCopyInFailed<crate::server_session::CopySimple>; }
@@ -528,6 +529,7 @@ protocol! {
         ExtendedCopyInDone internal {
             associate { inbound: none; outbound: crate::server_session::ServerCopyInDone<crate::server_session::CopyExtended>; }
             CommandComplete(command_complete: bytes::Bytes) => Building <= crate::codec::BackendMessage::CommandComplete(_),
+            Error(error: crate::codec::DiagnosticResponse) => ExtendedError <= crate::codec::BackendMessage::ErrorResponse(_),
         }
         ExtendedCopyInFailed internal {
             associate { inbound: none; outbound: crate::server_session::ServerCopyInFailed<crate::server_session::CopyExtended>; }

--- a/src/intermediary_component.rs
+++ b/src/intermediary_component.rs
@@ -470,6 +470,26 @@ pub struct AttributedBackendMessages<'a> {
     operation_ids: Vec<Option<OperationId>>,
 }
 
+/// Direction of an authoritative generated protocol transition.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ProtocolTransitionDirection {
+    /// A client-originated transition accepted for upstream forwarding.
+    Frontend,
+    /// A PostgreSQL-originated transition accepted for downstream forwarding.
+    Backend,
+}
+
+/// Read-only observation emitted after the intermediary commits a legal transition.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ProtocolTransitionObservation {
+    /// Stable ID from the generated protocol catalogue.
+    pub id: &'static str,
+    /// Direction in which the wire message travelled.
+    pub direction: ProtocolTransitionDirection,
+    /// Operation identity when the transition belongs to an operation.
+    pub operation: Option<OperationId>,
+}
+
 impl<'a> AttributedBackendMessages<'a> {
     /// Returns the existing un-attributed held-message view.
     #[must_use]
@@ -495,6 +515,17 @@ impl<'a> AttributedBackendMessages<'a> {
 pub trait IntermediaryMiddleware<State, ServerContext, ClientContext> {
     /// Application-defined interception failure.
     type Error;
+
+    /// Observes a legal transition after the pipeline has committed it.
+    fn observe_transition(
+        &mut self,
+        _server: &ServerContext,
+        _client: &ClientContext,
+        _state: &mut State,
+        _observation: ProtocolTransitionObservation,
+    ) -> impl Future<Output = ()> + Send {
+        async {}
+    }
 
     /// Intercepts a client-originated message after server-role middleware and
     /// before client-role middleware.
@@ -1405,6 +1436,7 @@ where
                 return Ok(FrontendForwarding::LocallyHandled(request));
             }
         };
+        let transition = self.pipeline.frontend_transition_id(&message);
         let admission = match self.pipeline.accept_frontend(message.clone(), handling) {
             Ok(admission) => admission,
             Err(error) => {
@@ -1413,7 +1445,21 @@ where
             }
         };
         match admission.into_action() {
-            FrontendAction::Forward { message, .. } => {
+            FrontendAction::Forward { id, message } => {
+                if let Some(transition) = transition {
+                    self.boundary
+                        .observe_transition(
+                            self.downstream.context(),
+                            self.upstream.context(),
+                            &mut self.state,
+                            ProtocolTransitionObservation {
+                                id: transition,
+                                direction: ProtocolTransitionDirection::Frontend,
+                                operation: Some(id),
+                            },
+                        )
+                        .await;
+                }
                 self.upstream.send_wire_raw(message.clone()).await?;
                 Ok(FrontendForwarding::Forwarded(message))
             }
@@ -1641,7 +1687,23 @@ where
         &mut self,
         message: crate::codec::BackendMessage,
     ) -> Result<crate::codec::BackendMessage, ForwardError<Boundary::Error>> {
+        let operation = self.pipeline.backend_operation_id(&message);
+        let transition = self.pipeline.backend_transition_id(&message);
         let message = self.advance_backend(message)?;
+        if let Some(transition) = transition {
+            self.boundary
+                .observe_transition(
+                    self.downstream.context(),
+                    self.upstream.context(),
+                    &mut self.state,
+                    ProtocolTransitionObservation {
+                        id: transition,
+                        direction: ProtocolTransitionDirection::Backend,
+                        operation,
+                    },
+                )
+                .await;
+        }
         self.downstream.send_wire_raw(message.clone()).await?;
         Ok(message)
     }

--- a/src/internal_tests/intermediary_pipeline.rs
+++ b/src/internal_tests/intermediary_pipeline.rs
@@ -452,6 +452,94 @@ async fn copy_hooks_preserve_simple_and_extended_origins() {
     assert_eq!(middleware.state(), &["simple", "extended"]);
 }
 
+#[test]
+fn extended_copy_in_uses_the_post_copy_sync_as_its_recovery_barrier() {
+    let mut pipeline = bounded(8);
+    for message in [bind(), execute(), FrontendMessage::Sync] {
+        pipeline
+            .accept_frontend(message, FrontendHandling::Forward)
+            .expect("extended COPY start is accepted");
+    }
+    pipeline
+        .accept_backend(BackendMessage::BindComplete)
+        .expect("Bind completes");
+    pipeline
+        .accept_backend(BackendMessage::CopyInResponse(CopyResponse {
+            overall_format: 0,
+            column_formats: vec![0],
+        }))
+        .expect("COPY IN starts");
+    for message in [
+        FrontendMessage::CopyData(Bytes::from_static(b"1\n")),
+        FrontendMessage::CopyDone,
+        FrontendMessage::Sync,
+    ] {
+        pipeline
+            .accept_frontend(message, FrontendHandling::Forward)
+            .expect("COPY data and completion are accepted");
+    }
+    pipeline
+        .accept_backend(BackendMessage::CommandComplete(Bytes::from_static(
+            b"COPY 1",
+        )))
+        .expect("COPY completes");
+    pipeline
+        .accept_backend(BackendMessage::ReadyForQuery(TransactionStatus::Idle))
+        .expect("post-COPY Sync restores readiness");
+
+    pipeline
+        .accept_frontend(parse(b"after-copy"), FrontendHandling::Forward)
+        .expect("a new statement is accepted after COPY");
+    assert!(matches!(
+        pipeline
+            .accept_backend(BackendMessage::ParseComplete)
+            .expect("new statement response is legal"),
+        BackendAction::Emit(BackendMessage::ParseComplete)
+    ));
+}
+
+#[test]
+fn extended_copy_in_data_error_recovers_after_copy_done() {
+    let mut pipeline = bounded(7);
+    for message in [bind(), execute(), FrontendMessage::Sync] {
+        pipeline
+            .accept_frontend(message, FrontendHandling::Forward)
+            .expect("extended COPY start is accepted");
+    }
+    pipeline
+        .accept_backend(BackendMessage::BindComplete)
+        .expect("Bind completes");
+    pipeline
+        .accept_backend(BackendMessage::CopyInResponse(CopyResponse {
+            overall_format: 0,
+            column_formats: vec![0],
+        }))
+        .expect("COPY IN starts");
+    for message in [FrontendMessage::CopyDone, FrontendMessage::Sync] {
+        pipeline
+            .accept_frontend(message, FrontendHandling::Forward)
+            .expect("COPY completion is accepted");
+    }
+    assert!(matches!(
+        pipeline
+            .accept_backend(error())
+            .expect("invalid copied data produces a legal ErrorResponse"),
+        BackendAction::Emit(BackendMessage::ErrorResponse(_))
+    ));
+    pipeline
+        .accept_backend(BackendMessage::ReadyForQuery(TransactionStatus::Idle))
+        .expect("post-COPY Sync recovers from the data error");
+    pipeline
+        .accept_frontend(parse(b"after-copy-error"), FrontendHandling::Forward)
+        .expect("new work is legal after recovery");
+    assert!(matches!(
+        pipeline
+            .accept_backend(BackendMessage::ParseComplete)
+            .expect("new statement response is emitted"),
+        BackendAction::Emit(BackendMessage::ParseComplete)
+    ));
+}
+
 #[tokio::test]
 async fn backend_copy_responses_dispatch_through_exact_generated_subphases() {
     struct CopyResponses;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,8 @@ pub use intermediary_component::{
     Intermediary, IntermediaryAccept, IntermediaryAcceptError, IntermediaryBuildError,
     IntermediaryBuilder, IntermediaryCancellationRegistry, IntermediaryConnection,
     IntermediaryContexts, IntermediaryMiddleware, IntermediaryMiddlewareFactory,
-    RejectCancellation, StartupResolutionError, StartupRouteResolver,
+    ProtocolTransitionDirection, ProtocolTransitionObservation, RejectCancellation,
+    StartupResolutionError, StartupRouteResolver,
 };
 pub use pipeline::{
     BackendProjectionError, BoundedPipeline, FrontendProjectionError, NoPipeline, OperationId,

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -738,6 +738,19 @@ impl<P: PipelinePolicy> Pipeline<P> {
     ) -> FrontendAdmission {
         let (kind, next_state) = classify_frontend(prepared.request_state, &message)
             .expect("phase-typed frontend replacement has a ledger classification");
+        if matches!(prepared.request_state, RequestState::CopyIn)
+            && matches!(kind, OperationKind::CopyDone | OperationKind::CopyFail)
+            && let Some(sync) = self
+                .operations
+                .iter_mut()
+                .rev()
+                .find(|operation| operation.kind == OperationKind::Sync && !operation.discarded)
+        {
+            // PostgreSQL ignores the Sync that began the extended execution once
+            // that execution enters COPY IN. The Sync sent after CopyDone/CopyFail
+            // is the sole recovery barrier and produces the ReadyForQuery.
+            sync.discarded = true;
+        }
         let waiting = !self.operations.is_empty();
         let id = OperationId(self.next_id);
         self.next_id = self.next_id.saturating_add(1);

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -546,6 +546,21 @@ impl Default for Pipeline<NoPipeline> {
 }
 
 impl<P: PipelinePolicy> Pipeline<P> {
+    pub(crate) fn frontend_transition_id(&self, message: &FrontendMessage) -> Option<&'static str> {
+        let state = generated_request_state(self.request_state);
+        let event = backend::project_external(state, message)?;
+        Some(backend::transition(state, event)?.id)
+    }
+
+    pub(crate) fn backend_transition_id(&self, message: &BackendMessage) -> Option<&'static str> {
+        let PreparedResponse::Emit { response_state, .. } = self.prepare_response(None, message)
+        else {
+            return None;
+        };
+        let event = backend::project_internal(response_state, message)?;
+        Some(backend::transition(response_state, event)?.id)
+    }
+
     /// Returns the identity that will be assigned to the next accepted
     /// frontend operation.
     pub(crate) const fn next_operation_id(&self) -> OperationId {
@@ -1183,8 +1198,14 @@ fn project_frontend(
     state: RequestState,
     message: &FrontendMessage,
 ) -> Option<(OperationKind, RequestState)> {
+    let generated_state = generated_request_state(state);
+    backend::project_external(generated_state, message)?;
+    classify_frontend(state, message)
+}
+
+const fn generated_request_state(state: RequestState) -> backend::RuntimeState {
     use RequestState as S;
-    let generated_state = match state {
+    match state {
         S::Ready => backend::RuntimeState::Ready,
         S::Extended { .. } => backend::RuntimeState::Building,
         S::ExtendedError => backend::RuntimeState::ExtendedError,
@@ -1192,9 +1213,7 @@ fn project_frontend(
         S::CopyOut => backend::RuntimeState::ExtendedCopyOut,
         S::CopyBoth => backend::RuntimeState::ExtendedCopyBoth,
         S::Terminated => backend::RuntimeState::Terminated,
-    };
-    backend::project_external(generated_state, message)?;
-    classify_frontend(state, message)
+    }
 }
 
 fn classify_frontend(


### PR DESCRIPTION
Closes #74\nCloses #75\nCloses #76\nCloses #77\nCloses #78\nCloses #79\nCloses #80\nCloses #81\nCloses #82\nCloses #83\nCloses #87\nCloses #88\n\nAdds the multi-process PostgreSQL harness, generated transition coverage, deterministic fixtures, query/error/async/COPY/cancellation scenarios, real auth/TLS, scripted paths, deterministic soak/replay, and portable resource checkpoints.