### PR TITLE
docs: document public and private modules

### DIFF
--- a/fuzz/fuzz_targets/backend_codec.rs
+++ b/fuzz/fuzz_targets/backend_codec.rs
@@ -1,3 +1,5 @@
+//! Fuzzes decoding of arbitrary backend protocol frames.
+
 #![no_main]
 
 use std::sync::{Arc, Mutex};

--- a/fuzz/fuzz_targets/frontend_codec.rs
+++ b/fuzz/fuzz_targets/frontend_codec.rs
@@ -1,3 +1,5 @@
+//! Fuzzes decoding of arbitrary frontend protocol frames.
+
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;

--- a/fuzz/fuzz_targets/pre_startup.rs
+++ b/fuzz/fuzz_targets/pre_startup.rs
@@ -1,3 +1,5 @@
+//! Fuzzes decoding of arbitrary pre-startup protocol frames.
+
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;

--- a/fuzz/fuzz_targets/runtime_fsm.rs
+++ b/fuzz/fuzz_targets/runtime_fsm.rs
@@ -1,3 +1,5 @@
+//! Fuzzes generated runtime FSM transition sequences.
+
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;

--- a/fuzz/fuzz_targets/scram.rs
+++ b/fuzz/fuzz_targets/scram.rs
@@ -1,3 +1,5 @@
+//! Fuzzes SCRAM client/server exchanges and malformed inputs.
+
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;

--- a/pg-proto-burn-in/build.rs
+++ b/pg-proto-burn-in/build.rs
@@ -1,3 +1,5 @@
+//! Captures Cargo build-profile metadata for performance artifacts.
+
 fn main() {
     println!("cargo:rerun-if-env-changed=PG_PROTO_REQUESTED_PROFILE");
     let base_profile = std::env::var("PROFILE").expect("Cargo supplies PROFILE to build scripts");

--- a/pg-proto-burn-in/src/bin/pg-proto-burn-in-performance.rs
+++ b/pg-proto-burn-in/src/bin/pg-proto-burn-in-performance.rs
@@ -1,3 +1,5 @@
+//! Optimized process entry point for performance-sensitive burn-in commands.
+
 #[tokio::main]
 async fn main() {
     if let Err(error) = pg_proto_burn_in::run(std::env::args().collect()).await {

--- a/pg-proto-burn-in/src/catalogue.rs
+++ b/pg-proto-burn-in/src/catalogue.rs
@@ -1,3 +1,5 @@
+//! Authoritative protocol catalogue assembly and evidence auditing.
+
 use std::{
     collections::{BTreeMap, BTreeSet},
     error::Error,
@@ -569,6 +571,7 @@ fn insert_disposition(
 }
 
 #[cfg(test)]
+/// Tests for catalogue closure and migration validation.
 mod tests {
     use super::*;
 

--- a/pg-proto-burn-in/src/cli.rs
+++ b/pg-proto-burn-in/src/cli.rs
@@ -1,3 +1,5 @@
+//! Command-line parsing, help text, and argument validation.
+
 use std::{error::Error, path::PathBuf};
 
 use clap::{Args, Parser, Subcommand};

--- a/pg-proto-burn-in/src/faults.rs
+++ b/pg-proto-burn-in/src/faults.rs
@@ -1,3 +1,5 @@
+//! Isolated PostgreSQL fault-injection profiles and recovery evidence.
+
 use std::{
     error::Error,
     future::Future,
@@ -413,6 +415,7 @@ async fn write_artifacts(path: &Path, result: &FaultRunResult) -> Result<(), Box
 }
 
 #[cfg(test)]
+/// Tests for bounded fault readiness probes.
 mod tests {
     use std::{cell::Cell, time::Duration};
 

--- a/pg-proto-burn-in/src/lib.rs
+++ b/pg-proto-burn-in/src/lib.rs
@@ -46,15 +46,25 @@ use tokio::{
     time::timeout,
 };
 
+/// Authoritative protocol catalogue assembly and evidence auditing.
 mod catalogue;
+/// Command-line parsing and validation.
 mod cli;
+/// Isolated PostgreSQL fault-injection profiles.
 mod faults;
+/// Controlled performance capture, evaluation, and artifact generation.
 mod performance;
+/// Delegation of performance commands to an optimized executable.
 mod performance_delegate;
+/// Markdown report generation for conventional run directories.
 mod report;
+/// Exhaustive orchestration of supported action/profile combinations.
 mod run_all;
+/// Scripted peers for exceptional and otherwise unreachable protocol paths.
 mod scripted;
+/// Deterministic soak scheduling, execution, replay, and resource sampling.
 mod soak;
+/// Historical throughput trend extraction and chart rendering.
 mod trends;
 
 const CHILD_TIMEOUT: Duration = Duration::from_secs(30);
@@ -3333,6 +3343,7 @@ fn debug_error(error: impl std::fmt::Debug) -> io::Error {
 }
 
 #[cfg(test)]
+/// Tests for conformance policy and top-level artifact contracts.
 mod tests {
     use super::{
         REQUIRED_SMOKE_COVERAGE, REQUIRED_SMOKE_STAGES, authentication_profile_results,

--- a/pg-proto-burn-in/src/main.rs
+++ b/pg-proto-burn-in/src/main.rs
@@ -1,3 +1,5 @@
+//! Command-line entry point for the PostgreSQL burn-in harness.
+
 #[tokio::main]
 async fn main() {
     if let Err(error) = pg_proto_burn_in::run(std::env::args().collect()).await {

--- a/pg-proto-burn-in/src/performance.rs
+++ b/pg-proto-burn-in/src/performance.rs
@@ -1,3 +1,5 @@
+//! Controlled performance capture, evaluation, and artifact generation.
+
 use std::{
     cmp::Ordering,
     error::Error,

--- a/pg-proto-burn-in/src/performance_delegate.rs
+++ b/pg-proto-burn-in/src/performance_delegate.rs
@@ -1,3 +1,5 @@
+//! Delegation of performance commands to a profile-optimized executable.
+
 use std::{error::Error, path::PathBuf};
 
 use tokio::process::Command;

--- a/pg-proto-burn-in/src/report.rs
+++ b/pg-proto-burn-in/src/report.rs
@@ -1,3 +1,5 @@
+//! Markdown report generation for a conventional burn-in result tree.
+
 use std::{error::Error, path::Path};
 
 use crate::{atomic_write, option};

--- a/pg-proto-burn-in/src/run_all.rs
+++ b/pg-proto-burn-in/src/run_all.rs
@@ -1,3 +1,5 @@
+//! Exhaustive orchestration of supported burn-in action/profile combinations.
+
 use std::{error::Error, path::PathBuf, time::SystemTime};
 
 use tokio::process::Command;
@@ -134,6 +136,7 @@ fn utc_date(now: SystemTime) -> Result<String, Box<dyn Error>> {
 }
 
 #[cfg(test)]
+/// Tests for exhaustive run orchestration and naming.
 mod tests {
     use super::*;
 

--- a/pg-proto-burn-in/src/scripted.rs
+++ b/pg-proto-burn-in/src/scripted.rs
@@ -1,3 +1,5 @@
+//! Scripted peers for exceptional and otherwise unreachable protocol paths.
+
 use std::{convert::Infallible, error::Error, sync::Mutex, time::Duration};
 
 use pg_proto::{

--- a/pg-proto-burn-in/src/soak.rs
+++ b/pg-proto-burn-in/src/soak.rs
@@ -1,3 +1,5 @@
+//! Deterministic soak scheduling, execution, replay, and resource sampling.
+
 use std::{
     collections::BTreeMap,
     error::Error,
@@ -1443,6 +1445,7 @@ async fn write_result(path: &Path, result: &SoakResult) -> Result<(), Box<dyn Er
 }
 
 #[cfg(test)]
+/// Tests for deterministic soak schedules and resource sampling.
 mod tests {
     use super::*;
 

--- a/pg-proto-burn-in/src/trends.rs
+++ b/pg-proto-burn-in/src/trends.rs
@@ -1,3 +1,5 @@
+//! Historical throughput trend extraction and SVG report generation.
+
 use std::{error::Error, path::Path};
 
 use serde::Deserialize;
@@ -234,6 +236,7 @@ fn render_markdown(points: &[Point]) -> String {
 }
 
 #[cfg(test)]
+/// Tests for report discovery, trend classification, and SVG rendering.
 mod tests {
     use super::*;
 

--- a/pg-proto-burn-in/tests/catalogue.rs
+++ b/pg-proto-burn-in/tests/catalogue.rs
@@ -1,3 +1,5 @@
+//! Process-level tests for authoritative catalogue closure.
+
 use std::{fs, process::Command};
 
 #[test]

--- a/pg-proto-burn-in/tests/cli.rs
+++ b/pg-proto-burn-in/tests/cli.rs
@@ -1,3 +1,5 @@
+//! Process-level tests for the burn-in command-line interface.
+
 use std::{fs, process::Command};
 
 #[cfg(unix)]

--- a/pg-proto-burn-in/tests/faults.rs
+++ b/pg-proto-burn-in/tests/faults.rs
@@ -1,3 +1,5 @@
+//! End-to-end tests for isolated PostgreSQL fault profiles.
+
 use std::{fs, process::Command};
 
 #[test]

--- a/pg-proto-burn-in/tests/performance.rs
+++ b/pg-proto-burn-in/tests/performance.rs
@@ -1,3 +1,5 @@
+//! Process-level tests for performance capture and evaluation.
+
 use std::{fs, process::Command};
 
 #[test]

--- a/pg-proto-burn-in/tests/replication.rs
+++ b/pg-proto-burn-in/tests/replication.rs
@@ -1,3 +1,5 @@
+//! End-to-end physical replication conformance coverage.
+
 use std::{fs, process::Command};
 
 #[test]

--- a/pg-proto-burn-in/tests/scripted.rs
+++ b/pg-proto-burn-in/tests/scripted.rs
@@ -1,3 +1,5 @@
+//! End-to-end tests for scripted exceptional protocol paths.
+
 use std::{fs, process::Command};
 
 #[test]

--- a/pg-proto-burn-in/tests/smoke.rs
+++ b/pg-proto-burn-in/tests/smoke.rs
@@ -1,3 +1,5 @@
+//! End-to-end tests for real PostgreSQL conformance profiles.
+
 use std::{fs, process::Command};
 
 #[test]

--- a/pg-proto-burn-in/tests/soak.rs
+++ b/pg-proto-burn-in/tests/soak.rs
@@ -1,3 +1,5 @@
+//! Process-level tests for bounded soak execution and replay.
+
 use std::{fs, process::Command};
 
 #[test]

--- a/pg-proto-burn-in/tests/trends.rs
+++ b/pg-proto-burn-in/tests/trends.rs
@@ -1,3 +1,5 @@
+//! Process-level tests for historical performance trend reports.
+
 use std::{fs, path::Path, process::Command};
 
 fn write_report(root: &Path, name: &str, throughput: f64) {

--- a/pg-proto-fsm/src/lib.rs
+++ b/pg-proto-fsm/src/lib.rs
@@ -15,6 +15,7 @@ use syn::{
     visit_mut::{self, VisitMut},
 };
 
+/// Custom keywords accepted by the protocol grammar DSL.
 mod keyword {
     syn::custom_keyword!(initial);
     syn::custom_keyword!(messages);

--- a/pg-proto-fsm/tests/generate.rs
+++ b/pg-proto-fsm/tests/generate.rs
@@ -13,6 +13,7 @@ trait PhaseAssociation<Direction, Role, Wire>:
     type Message;
 }
 
+/// Sealed traits used by the test protocol associations.
 mod private {
     pub trait PhaseAssociationSeal<Direction, Role, Wire> {}
 }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -559,6 +559,7 @@ fn sasl_initial<S>(
 }
 
 #[cfg(test)]
+/// Tests for client-side authentication state transitions.
 mod tests {
     use super::*;
 

--- a/src/backend_hold.rs
+++ b/src/backend_hold.rs
@@ -1,3 +1,5 @@
+//! Ordered storage for one backend message held by pipeline backpressure.
+
 use crate::codec::BackendMessage;
 
 #[derive(Debug, Default)]
@@ -60,6 +62,7 @@ fn retained_bytes(message: &BackendMessage) -> usize {
 }
 
 #[cfg(test)]
+/// Tests for ordered backend-message holding.
 mod tests {
     use bytes::Bytes;
 

--- a/src/cancel.rs
+++ b/src/cancel.rs
@@ -152,6 +152,7 @@ fn validate_key(key: &CancelKey) -> Result<(), usize> {
 }
 
 #[cfg(test)]
+/// Tests for cancellation key translation and policy hooks.
 mod tests {
     use super::*;
 

--- a/src/cleanliness.rs
+++ b/src/cleanliness.rs
@@ -86,6 +86,7 @@ impl CleanlinessPolicy for IgnoreCleanliness {
 }
 
 #[cfg(test)]
+/// Tests for protocol-derived connection cleanliness.
 mod tests {
     use super::*;
 

--- a/src/client_component.rs
+++ b/src/client_component.rs
@@ -613,6 +613,7 @@ impl ClientAuthenticationSession for StaticClientCredentialSession {
 }
 
 #[cfg(test)]
+/// Tests for the static client credential implementation.
 mod static_credential_tests {
     use super::*;
 

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1349,6 +1349,7 @@ fn unknown_tag(direction: &str, tag: u8) -> io::Error {
 }
 
 #[cfg(test)]
+/// Tests for structured frontend and backend wire codecs.
 mod tests {
     use super::*;
 

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -28,6 +28,7 @@ pub(crate) fn verify_cleartext(response: &[u8], expected: &[u8]) -> bool {
 }
 
 #[cfg(test)]
+/// Tests for PostgreSQL credential verification helpers.
 mod tests {
     use super::*;
 

--- a/src/demux.rs
+++ b/src/demux.rs
@@ -286,6 +286,7 @@ impl Demux {
 }
 
 #[cfg(test)]
+/// Tests for asynchronous backend message ordering and attribution.
 mod tests {
     use super::*;
 

--- a/src/erased.rs
+++ b/src/erased.rs
@@ -117,6 +117,7 @@ impl<S> Drop for ErasedConn<S> {
 }
 
 #[cfg(test)]
+/// Tests for state erasure and checked re-entry.
 mod tests {
     use crate::{Dirty, Pristine, auth::Ready, session::Building};
 

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -1,8 +1,9 @@
 //! Generated `PostgreSQL` grammars and differential-test runtime FSMs.
 //!
 //! Each generated role module embeds its railroad diagram directly in its
-//! rustdoc landing page. Open a module such as [`frontend`] or [`backend`] to
-//! review the grammar alongside its generated transition API.
+//! rustdoc landing page. Open a module such as [`crate::grammar::frontend`] or
+//! [`crate::grammar::backend`] to review the grammar alongside its generated
+//! transition API.
 
 use pg_proto_fsm::protocol;
 
@@ -717,6 +718,7 @@ protocol! {
 }
 
 #[cfg(test)]
+/// Tests for generated grammar projection and runtime behavior.
 mod tests {
     use std::collections::BTreeMap;
 

--- a/src/integrations.rs
+++ b/src/integrations.rs
@@ -66,6 +66,7 @@ pub(crate) trait TokenAuthEngine {
 }
 
 #[cfg(test)]
+/// Tests for integration-neutral recursive exchange adapters.
 mod tests {
     use super::*;
 

--- a/src/intermediary.rs
+++ b/src/intermediary.rs
@@ -202,6 +202,7 @@ impl<Downstream, Upstream, Policy: PipelinePolicy> SessionPair<Downstream, Upstr
 }
 
 #[cfg(test)]
+/// Tests for independently advancing intermediary sides.
 mod tests {
     use bytes::Bytes;
 

--- a/src/intermediary_component.rs
+++ b/src/intermediary_component.rs
@@ -171,6 +171,7 @@ impl IntermediaryCancellationRegistry for InMemoryCancellationRegistry {
 }
 
 #[cfg(test)]
+/// Tests for the in-memory cancellation registry implementation.
 mod in_memory_cancellation_registry_tests {
     use super::*;
     use bytes::Bytes;

--- a/src/internal_tests.rs
+++ b/src/internal_tests.rs
@@ -1,16 +1,23 @@
 //! Legacy protocol coverage retained behind the builder-only public boundary.
 
 #[path = "internal_tests/intermediary_harness.rs"]
+/// Shared neutral intermediary construction for internal integration tests.
 mod intermediary_harness;
 #[path = "internal_tests/intermediary_pipeline.rs"]
+/// Integration tests for intermediary pipeline state and ordering.
 mod intermediary_pipeline;
 #[path = "internal_tests/postgres_container.rs"]
+/// Compatibility tests against Testcontainers-managed PostgreSQL instances.
 mod postgres_container;
 #[path = "internal_tests/recorded_fixtures.rs"]
+/// Tests for sanitized recorded wire fixtures.
 mod recorded_fixtures;
 #[path = "internal_tests/runtime_middleware.rs"]
+/// Integration tests for runtime middleware lifecycle and isolation.
 mod runtime_middleware;
 #[path = "internal_tests/security.rs"]
+/// Security regression tests for secret handling.
 mod security;
 #[path = "internal_tests/server_role.rs"]
+/// Integration tests for typed and facade server roles.
 mod server_role;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,55 +7,83 @@
 #![deny(private_bounds, private_interfaces, unreachable_pub)]
 
 #[allow(dead_code)]
+/// Typed client-side authentication protocol states and transitions.
 mod auth;
+/// Ordered storage for backend messages held by pipeline backpressure.
 mod backend_hold;
 #[allow(dead_code)]
+/// PostgreSQL cancellation keys, routing, and policy hooks.
 mod cancel;
 #[allow(dead_code)]
+/// Connection-cleanliness evidence and state markers.
 mod cleanliness;
+/// Public client facade, builder, and operational connection types.
 mod client_component;
 #[allow(dead_code)]
+/// Structured PostgreSQL wire messages and codecs.
 mod codec;
 #[allow(dead_code)]
+/// Credential verification helpers for PostgreSQL authentication methods.
 mod credentials;
 #[allow(dead_code)]
+/// Ordering and attribution of asynchronous backend traffic.
 mod demux;
 #[allow(dead_code)]
+/// Runtime state erasure and checked typestate re-entry.
 mod erased;
 #[allow(dead_code)]
+/// Generated protocol grammars and runtime transition catalogues.
 pub mod grammar;
 #[allow(dead_code)]
+/// Integration-neutral adapters for recursive protocol exchanges.
 mod integrations;
 #[allow(dead_code)]
+/// Independent client/server state composition used by intermediaries.
 mod intermediary;
+/// Public intermediary facade, builder, middleware, and forwarding loop.
 mod intermediary_component;
 #[allow(dead_code)]
+/// Typed and wire-level middleware abstractions.
 mod middleware;
 #[allow(dead_code)]
+/// Network connection and retry utilities.
 mod net;
 #[allow(dead_code)]
+/// Stateful intermediary admission, correlation, and response pipeline.
 mod pipeline;
 #[allow(dead_code)]
+/// Typed PostgreSQL pre-startup negotiation.
 mod pre_startup;
 #[allow(dead_code)]
+/// Physical replication message encoding and decoding.
 mod replication;
 #[allow(dead_code)]
+/// Branded prepared-statement and portal resource tracking.
 mod resources;
+/// Runtime middleware adapters used by the public facades.
 mod runtime_middleware;
 #[allow(dead_code)]
+/// SCRAM authentication client and server engines.
 mod scram;
 #[allow(dead_code)]
+/// Typed server-side authentication protocol.
 mod server_auth;
+/// Public server facade, builder, and accepted connection types.
 mod server_component;
 #[allow(dead_code)]
+/// Typed server-side operational protocol sessions.
 mod server_session;
 #[allow(dead_code)]
+/// Typed client-side operational protocol sessions.
 mod session;
 #[allow(dead_code)]
+/// Startup packet parsing and parameter representation.
 mod startup;
 #[allow(dead_code)]
+/// TLS policies, providers, upgrades, and channel binding.
 mod tls;
 #[allow(dead_code)]
+/// Buffered transports with protocol projection and middleware interception.
 mod transport;
 
 pub use client_component::{
@@ -113,6 +141,7 @@ pub use startup::{ProtocolVersion, StartupMessage};
 extern crate self as pg_proto;
 
 #[cfg(test)]
+/// Internal integration coverage that exercises non-public protocol seams.
 mod internal_tests;
 
 use std::marker::PhantomData;

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -251,6 +251,7 @@ pub(crate) trait PhaseAssociation<Direction, Role, Wire>:
 
 /// Seals [`PhaseAssociation`] while remaining nameable by generated grammar implementations.
 #[doc(hidden)]
+/// Seals generated phase associations to this crate.
 pub(crate) mod phase_association_seal {
     /// Implemented alongside each generated phase association.
     pub(crate) trait Sealed<Direction, Role, Wire> {}
@@ -667,6 +668,7 @@ impl<Transport, Phase, Cleanliness> crate::Conn<Transport, Phase, Cleanliness> {
 }
 
 #[cfg(test)]
+/// Tests for typed and wire-level middleware composition.
 mod tests {
     use std::convert::Infallible;
 

--- a/src/net.rs
+++ b/src/net.rs
@@ -309,6 +309,7 @@ pub(crate) fn configure_tcp(
 }
 
 #[cfg(test)]
+/// Tests for network streams and bounded connection retries.
 mod tests {
     use super::*;
     use tokio::net::TcpListener;

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1,11 +1,13 @@
 //! Bounded, payload-free orchestration for proxy request pipelines.
 //!
 //! The ledger in this module records protocol obligations, not wire messages.
-//! Applications retain ownership of decoded messages until [`FrontendAction`] or
-//! [`BackendAction`] tells them to forward, emit, retry, or discard the value.
-//! [`Pipeline::accept_frontend`] and [`Pipeline::accept_backend`] are the canonical
-//! ledger interface. Their typed counterparts additionally dispatch accepted
-//! messages through phase-specific middleware before committing them.
+//! Applications retain ownership of decoded messages until
+//! [`crate::pipeline::FrontendAction`] or [`crate::pipeline::BackendAction`] tells
+//! them to forward, emit, retry, or discard the value.
+//! [`crate::pipeline::Pipeline::accept_frontend`] and
+//! [`crate::pipeline::Pipeline::accept_backend`] are the canonical ledger
+//! interface. Their typed counterparts additionally dispatch accepted messages
+//! through phase-specific middleware before committing them.
 //! Callers receiving [`crate::demux::SessionItem`] values should first consume
 //! any pooling or attribution evidence they need, then convert the item with
 //! [`crate::demux::SessionItem::into_backend_message`] before backend acceptance.
@@ -74,6 +76,7 @@ impl std::fmt::Display for PipelineConfigError {
 
 impl std::error::Error for PipelineConfigError {}
 
+/// Sealed implementation details for pipeline state transitions.
 mod private {
     pub trait Sealed {}
 }

--- a/src/pre_startup.rs
+++ b/src/pre_startup.rs
@@ -563,6 +563,7 @@ fn invalid(message: &'static str) -> std::io::Error {
 }
 
 #[cfg(test)]
+/// Tests for typed pre-startup negotiation and upgrades.
 mod tests {
     use super::*;
 

--- a/src/replication.rs
+++ b/src/replication.rs
@@ -260,6 +260,7 @@ fn invalid(message: &'static str) -> io::Error {
 }
 
 #[cfg(test)]
+/// Tests for physical replication message codecs.
 mod tests {
     use super::*;
 

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -910,6 +910,7 @@ impl Portal<'_> {
 }
 
 #[cfg(test)]
+/// Tests for branded statement and portal resource tracking.
 mod tests {
     use super::*;
 

--- a/src/scram.rs
+++ b/src/scram.rs
@@ -307,6 +307,7 @@ fn invalid(message: &'static str) -> io::Error {
 }
 
 #[cfg(test)]
+/// Tests for SCRAM authentication engines.
 mod tests {
     use postgres_protocol::authentication::sasl::{ChannelBinding, ScramSha256};
 

--- a/src/server_auth.rs
+++ b/src/server_auth.rs
@@ -504,6 +504,7 @@ fn sasl_initial(mut body: Bytes) -> Result<SaslInitialResponse, Bytes> {
 }
 
 #[cfg(test)]
+/// Tests for server-side authentication state machines.
 mod tests {
     use super::*;
     use crate::{

--- a/src/server_component.rs
+++ b/src/server_component.rs
@@ -488,6 +488,7 @@ impl ServerIdentityProvider for NoServerIdentityProvider {
     }
 }
 
+/// Sealed traits used to constrain server facade implementations.
 mod sealed {
     pub trait Sealed {}
 }

--- a/src/server_session.rs
+++ b/src/server_session.rs
@@ -1341,6 +1341,7 @@ fn ready<S, Phase, C>(
 }
 
 #[cfg(test)]
+/// Tests for typed server operational sessions.
 mod tests {
     use super::*;
     use crate::{

--- a/src/session.rs
+++ b/src/session.rs
@@ -934,6 +934,7 @@ fn ready_state<S, P, C>(
 }
 
 #[cfg(test)]
+/// Tests for typed client operational sessions.
 mod tests {
     use super::*;
 

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -124,6 +124,7 @@ fn invalid(message: &'static str) -> io::Error {
 }
 
 #[cfg(test)]
+/// Tests for startup packet and parameter handling.
 mod tests {
     use super::*;
 

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -273,6 +273,7 @@ pub(crate) fn channel_binding(certificate: &CertificateDer<'_>) -> io::Result<Ve
 }
 
 #[cfg(test)]
+/// Tests for TLS negotiation, policies, and channel binding.
 mod tests {
     use super::*;
     use crate::{

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -904,6 +904,7 @@ impl<S: AsyncRead + Unpin, Cleanliness> Conn<Buffered<S, Frontend>, PreStartup, 
 }
 
 #[cfg(test)]
+/// Tests for buffering, projection, limits, and transport middleware.
 mod tests {
     use std::{
         convert::Infallible,

--- a/tests/logging_proxy_example.rs
+++ b/tests/logging_proxy_example.rs
@@ -8,6 +8,7 @@ use tokio::net::TcpListener;
 
 #[path = "../examples/sql_logging_proxy/main.rs"]
 #[allow(dead_code)]
+/// The example implementation included as a testable module.
 pub(crate) mod sql_logging_proxy;
 
 use sql_logging_proxy::Observation;


### PR DESCRIPTION
## Summary

- add module-level Rustdoc across the library, FSM generator, burn-in harness, tests, and fuzz targets
- document private and sealed implementation modules as well as public modules
- repair intra-doc links exposed by private-item documentation builds

Compile-fail fixtures remain unchanged because shifting their source lines would invalidate intentional diagnostic snapshots. Generated grammar modules continue to receive their Rustdoc from the FSM macro.

## Validation

- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items`
- `cargo clippy --workspace --all-targets -- -D warnings`
- workspace tests, with Trybuild suites separately verified under an isolated HOME to match CI path normalization