### PR TITLE
docs: improve README and add architecture examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ connection is safe to reuse.
 
 ## What can be built with it?
 
-The [bounded intermediary pipeline example](examples/intermediary_pipeline.rs)
-shows ordered forwarding, local interception, and backpressure without proxy-owned
-message queues.
+The [backpressure for queued requests example](examples/queued_request_backpressure.rs)
+shows ordered forwarding and local interception without proxy-owned message
+queues.
 
 - A TLS-terminating PostgreSQL proxy which authenticates each side independently
   and inspects plaintext SQL and result rows.

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ routing, or other application-owned placement decisions.
   `RowDescription`, and `DataRow` values for SQL and result rewriting.
 - A demultiplexer for asynchronous notices, notifications, and parameter status
   updates without polluting the causal session type.
-- Positionally tagged notices and transaction/parameter evidence for pooling
-  decisions.
+- Protocol evidence for deciding whether a connection is safe to return to a
+  pool, including notices, transaction state, and changed session parameters.
 - Connection-branded prepared statements and portals with name rewriting.
 - Exact typestate erasure and checked re-entry at storage and pool boundaries.
 - A protocol grammar macro which emits typestates, their duals, a runtime FSM for

--- a/README.md
+++ b/README.md
@@ -81,18 +81,10 @@ cancellation storage, telemetry, and failure policy.
 
 ## Why use it?
 
-PostgreSQL infrastructure tends to fail at phase boundaries rather than while
-decoding an individual frame. A pooler may return a connection while it is still
-in a transaction, a proxy may forward `Query` while a COPY exchange is active,
-or an extended-query error path may forget to discard messages until `Sync`.
-Typestate makes these transitions explicit and turns many such bugs into type
-errors.
-
-The phase index is orthogonal to connection cleanliness. A connection can be
-protocol-ready but unsuitable for unconditional pool release because of an open
-transaction, changed GUC, prepared statement, portal, `LISTEN`, or advisory lock.
-Operational connections return explicit state evidence and preserve caller-owned
-state until teardown.
+pg-proto provides protocol-aware guardrails throughout its API, making many
+forms of misuse impossible to express. It also exposes accurate connection-state
+evidence, helping infrastructure such as connection pools determine whether a
+connection is safe to reuse.
 
 ## What can be built with it?
 

--- a/README.md
+++ b/README.md
@@ -92,16 +92,22 @@ The [backpressure for queued requests example](examples/queued_request_backpress
 shows ordered forwarding and local interception without proxy-owned message
 queues.
 
-- A TLS-terminating PostgreSQL proxy which authenticates each side independently
-  and inspects plaintext SQL and result rows.
-- A transaction or session pooler whose release policy consumes explicit
-  protocol and cleanliness evidence.
-- A SQL firewall, audit gateway, query rewriter, or column-encryption proxy.
-- A sharding/router layer which rewrites prepared-statement and portal names.
-- A logical or physical replication relay with typed COPY-BOTH half-closes.
-- A PostgreSQL-compatible server, mock backend, recorder, replay tool, or protocol
-  conformance harness.
-- A driver or administrative client which benefits from compile-time sequencing.
+- A [TLS-terminating SQL proxy](examples/sql_logging_proxy/main.rs) which
+  authenticates each side independently and inspects plaintext SQL and result
+  rows.
+- A [connection pool](examples/connection_pooler.rs) whose release policy
+  consumes explicit protocol and cleanliness evidence.
+- A [SQL query and result rewriter](examples/rewriting_intermediary.rs), which
+  provides the same interception points needed by firewalls, audit gateways,
+  and column-encryption proxies.
+- A [sharding router](examples/sharding_router.rs) which rewrites
+  prepared-statement and portal names into connection-specific namespaces.
+- A [replication relay](examples/replication_relay.rs) which observes typed
+  COPY-BOTH half-closes independently.
+- A [PostgreSQL-compatible mock server](examples/mock_postgres_server.rs) backed
+  by an in-memory result set.
+- An [administrative client](examples/administrative_client.rs) whose connection
+  type records when a query has changed session state.
 
 ## Security choices come first
 

--- a/README.md
+++ b/README.md
@@ -13,12 +13,11 @@ and protocol-aware test infrastructure.
 A builder API configures clients, servers, and intermediaries explicitly;
 internal typestates make invalid PostgreSQL protocol sequences unrepresentable.
 
-Most PostgreSQL protocol libraries decode messages but retain the session phase
-in a runtime enum. `pg-proto` is useful when protocol correctness is part of the
-architecture rather than merely an implementation detail: the legal next
-operations are visible in function signatures, illegal compositions are rejected
-at compile time, and proxy policy can still inspect, replace, or reject complete
-typed messages.
+`pg-proto` is useful when protocol correctness is part of the architecture
+rather than merely an implementation detail: the legal next operations are
+visible in function signatures, illegal compositions are rejected at compile
+time, and proxy policy can still inspect, replace, or reject complete typed
+messages.
 
 ## Modes of operation
 

--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ routing, or other application-owned placement decisions.
 
 ## What it provides
 
-- Direction-parameterised frontend and backend codecs. Ambiguous tags such as
-  `S` and `E` cannot be decoded in the wrong direction.
+- Message direction resolves ambiguous PostgreSQL wire tags: `S` means frontend
+  `Sync` but backend `ParameterStatus`, while `E` means frontend `Execute` but
+  backend `ErrorResponse`.
 - Typed pre-startup handling for `SSLRequest`, `GSSENCRequest`, `CancelRequest`,
   and `StartupMessage`, including transport-changing rustls upgrades.
 - A plain/client-TLS/server-TLS network stream, configurable TCP socket options,

--- a/README.md
+++ b/README.md
@@ -10,12 +10,8 @@
 frontend/backend wire protocol designed for proxies, poolers, gateways, drivers,
 and protocol-aware test infrastructure.
 
-Its distinguishing feature is a builder-only facade over PostgreSQL's typed
-connection state machine. `Client::builder()`, `Server::builder()`, and
-`Intermediary::builder()` require explicit transport-security, authentication,
-middleware, and routing policy before they establish operational connections.
-The internal protocol typestates prevent illegal sequencing without exposing
-the implementation graph as application API.
+A builder API configures clients, servers, and intermediaries explicitly;
+internal typestates make invalid PostgreSQL protocol sequences unrepresentable.
 
 Most PostgreSQL protocol libraries decode messages but retain the session phase
 in a runtime enum. `pg-proto` is useful when protocol correctness is part of the

--- a/examples/administrative_client.rs
+++ b/examples/administrative_client.rs
@@ -1,0 +1,49 @@
+//! Administrative client whose type records whether session state has changed.
+
+use pg_proto::{
+    BackendMessage, Client, ClientConnection, ClientTlsPolicy, ConnectTarget, ConnectionChanged,
+    StartupParameters, TrustClientAuthentication,
+};
+
+fn finish_changed<Transport, State, Evidence, Handler>(
+    connection: ClientConnection<Transport, State, ConnectionChanged, Evidence, Handler>,
+) {
+    let _parts = connection.into_parts();
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let upstream: std::net::SocketAddr = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "127.0.0.1:5432".into())
+        .parse()?;
+    let sql = std::env::args()
+        .nth(2)
+        .unwrap_or_else(|| "SELECT version()".into());
+    let client = Client::builder()
+        .connector(move |_| tokio::net::TcpStream::connect(upstream))
+        .tls(ClientTlsPolicy::Disabled)
+        .authentication(TrustClientAuthentication)
+        .build()?;
+    let connection = client
+        .connect(
+            ConnectTarget::new("administrative-upstream"),
+            StartupParameters::new("postgres").database("postgres"),
+            (),
+        )
+        .await?;
+    let (connection, messages) = connection.simple_query(sql.as_bytes()).await?;
+    for message in messages {
+        match message {
+            BackendMessage::DataRow(row) => println!("row: {:?}", row.columns),
+            BackendMessage::CommandComplete(tag) => {
+                println!("complete: {}", String::from_utf8_lossy(&tag));
+            }
+            _ => {}
+        }
+    }
+    // The query consumes the clean connection and returns ConnectionChanged,
+    // preventing code from accidentally treating it as unconditionally reusable.
+    finish_changed(connection);
+    Ok(())
+}

--- a/examples/connection_pooler.rs
+++ b/examples/connection_pooler.rs
@@ -1,0 +1,63 @@
+//! Connection-pool release policy driven by protocol and cleanliness evidence.
+
+use pg_proto::{
+    BackendMessage, Client, ClientConnection, ClientTlsPolicy, ConnectTarget, ConnectionChanged,
+    ConnectionClean, StartupParameters, TransactionStatus, TrustClientAuthentication,
+};
+
+fn release_clean<Transport, State, Evidence, Handler>(
+    connection: ClientConnection<Transport, State, ConnectionClean, Evidence, Handler>,
+) {
+    let _parts = connection.into_parts();
+    println!("unused connection is clean and may return to the pool");
+}
+
+fn discard_changed<Transport, State, Evidence, Handler>(
+    connection: ClientConnection<Transport, State, ConnectionChanged, Evidence, Handler>,
+    transaction_status: TransactionStatus,
+) {
+    let _parts = connection.into_parts();
+    println!(
+        "connection is protocol-ready ({transaction_status:?}) but session state changed; discard or reset it before reuse"
+    );
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let upstream: std::net::SocketAddr = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "127.0.0.1:5432".into())
+        .parse()?;
+    let release_without_use = std::env::args().any(|argument| argument == "--release-unused");
+    let client = Client::builder()
+        .connector(move |_| tokio::net::TcpStream::connect(upstream))
+        .tls(ClientTlsPolicy::Disabled)
+        .authentication(TrustClientAuthentication)
+        .build()?;
+    let connection = client
+        .connect(
+            ConnectTarget::new("pool-upstream"),
+            StartupParameters::new("postgres"),
+            (),
+        )
+        .await?;
+
+    if release_without_use {
+        release_clean(connection);
+        return Ok(());
+    }
+
+    // Arbitrary SQL conservatively changes the compile-time cleanliness marker,
+    // even when ReadyForQuery reports that no transaction remains open.
+    let (connection, messages) = connection.simple_query(b"SELECT current_user").await?;
+    let transaction_status = messages
+        .iter()
+        .rev()
+        .find_map(|message| match message {
+            BackendMessage::ReadyForQuery(status) => Some(*status),
+            _ => None,
+        })
+        .ok_or("upstream did not report transaction status")?;
+    discard_changed(connection, transaction_status);
+    Ok(())
+}

--- a/examples/mock_postgres_server.rs
+++ b/examples/mock_postgres_server.rs
@@ -1,0 +1,67 @@
+//! Minimal PostgreSQL-compatible server backed by an in-memory result set.
+
+use bytes::Bytes;
+use pg_proto::{
+    BackendMessage, DataRow, FieldDescription, FrontendMessage, RowDescription, Server,
+    ServerAccept, ServerConnection, ServerTlsPolicy, TransactionStatus, TrustServerAuthentication,
+};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let listen = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "127.0.0.1:55432".into());
+    let server = Server::builder()
+        .tls(ServerTlsPolicy::Disabled)
+        .authentication(TrustServerAuthentication)
+        .build()?;
+    let listener = tokio::net::TcpListener::bind(listen).await?;
+    let (transport, peer) = listener.accept().await?;
+    let ServerAccept::Session(connection) = server.accept(transport, peer, ()).await? else {
+        return Err("mock server does not accept cancellation requests".into());
+    };
+    serve(connection).await
+}
+
+async fn serve(
+    mut connection: ServerConnection<tokio::net::TcpStream, (), std::net::SocketAddr>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    loop {
+        match connection.receive_wire().await? {
+            FrontendMessage::Query(query) => {
+                println!("mock query: {}", String::from_utf8_lossy(&query));
+                connection
+                    .send_wire(BackendMessage::RowDescription(RowDescription {
+                        fields: vec![FieldDescription {
+                            name: Bytes::from_static(b"answer"),
+                            table_oid: 0,
+                            column: 0,
+                            type_oid: 23,
+                            type_size: 4,
+                            type_modifier: -1,
+                            format: 0,
+                        }],
+                    }))
+                    .await?;
+                connection
+                    .send_wire(BackendMessage::DataRow(DataRow {
+                        columns: vec![Some(Bytes::from_static(b"42"))],
+                    }))
+                    .await?;
+                connection
+                    .send_wire(BackendMessage::CommandComplete(Bytes::from_static(
+                        b"SELECT 1",
+                    )))
+                    .await?;
+                connection
+                    .send_wire(BackendMessage::ReadyForQuery(TransactionStatus::Idle))
+                    .await?;
+            }
+            FrontendMessage::Terminate => {
+                let _parts = connection.teardown();
+                return Ok(());
+            }
+            message => return Err(format!("unsupported mock request: {message:?}").into()),
+        }
+    }
+}

--- a/examples/protocol_logging_proxy/main.rs
+++ b/examples/protocol_logging_proxy/main.rs
@@ -218,7 +218,7 @@ async fn proxy_connection(
         .client(client)
         .startup_resolver(Route(upstream))
         .cancellation(CancellationPolicy::Reject)
-        .pipeline(BoundedPipeline::new(64).expect("non-zero proxy pipeline capacity"))
+        .pipeline(BoundedPipeline::new(64).expect("non-zero queued-request limit"))
         .middleware(
             |_: &ServerConnectionContext<SocketAddr, TrustIdentity>,
              _: &ClientConnectionContext<()>| ProtocolLogger,

--- a/examples/queued_request_backpressure.rs
+++ b/examples/queued_request_backpressure.rs
@@ -1,4 +1,4 @@
-//! Complete bounded-pipeline intermediary configuration.
+//! Complete example of backpressure for queued requests.
 
 use pg_proto::{
     BoundedPipeline, CancellationPolicy, Client, ClientTlsPolicy, ConnectTarget,
@@ -41,7 +41,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .client(client)
         .startup_resolver(Route)
         .cancellation(CancellationPolicy::Reject)
-        .pipeline(BoundedPipeline::new(1).expect("non-zero bound"))
+        // Allow one request to be in flight and return ownership of the next
+        // request to the caller until response progress frees capacity.
+        .pipeline(BoundedPipeline::new(1).expect("non-zero request limit"))
         .build()
         .unwrap();
     let listen = std::env::args()

--- a/examples/replication_relay.rs
+++ b/examples/replication_relay.rs
@@ -1,0 +1,78 @@
+//! Replication relay which observes both COPY-BOTH half-closes.
+
+use std::convert::Infallible;
+
+use pg_proto::{
+    BackendMessage, BoundedPipeline, CancellationPolicy, Client, ClientTlsPolicy, ConnectTarget,
+    ForwardedMessage, FrontendMessage, InitialServerContext, Intermediary, Server, ServerTlsPolicy,
+    StartupParameters, StartupRouteResolver, TrustClientAuthentication, TrustServerAuthentication,
+};
+
+struct Route;
+
+impl<Peer: Sync> StartupRouteResolver<Peer> for Route {
+    type Error = Infallible;
+
+    async fn resolve(
+        &self,
+        _startup: StartupParameters,
+        _context: InitialServerContext<'_, Peer>,
+    ) -> Result<ConnectTarget, Self::Error> {
+        Ok(ConnectTarget::new("replication-primary"))
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let listen = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "127.0.0.1:6432".into());
+    let upstream: std::net::SocketAddr = std::env::args()
+        .nth(2)
+        .unwrap_or_else(|| "127.0.0.1:5432".into())
+        .parse()?;
+    let server = Server::builder()
+        .tls(ServerTlsPolicy::Disabled)
+        .authentication(TrustServerAuthentication)
+        .build()?;
+    let client = Client::builder()
+        .connector(move |_| tokio::net::TcpStream::connect(upstream))
+        .tls(ClientTlsPolicy::Disabled)
+        .authentication(TrustClientAuthentication)
+        .build()?;
+    let intermediary = Intermediary::builder()
+        .server(server)
+        .client(client)
+        .startup_resolver(Route)
+        .cancellation(CancellationPolicy::Reject)
+        .pipeline(BoundedPipeline::new(4)?)
+        .build()?;
+    let listener = tokio::net::TcpListener::bind(listen).await?;
+    let (transport, peer) = listener.accept().await?;
+    let mut session = Box::pin(intermediary.accept(transport, peer, ()))
+        .await?
+        .into_session();
+    let mut standby_closed = false;
+    let mut primary_closed = false;
+    loop {
+        match session.forward_next().await? {
+            ForwardedMessage::Backend(BackendMessage::CopyBothResponse(_)) => {
+                println!("replication entered typed COPY-BOTH mode");
+            }
+            ForwardedMessage::Frontend(FrontendMessage::CopyDone) => {
+                standby_closed = true;
+                println!("standby closed its COPY-BOTH half");
+            }
+            ForwardedMessage::Backend(BackendMessage::CopyDone) => {
+                primary_closed = true;
+                println!("primary closed its COPY-BOTH half");
+            }
+            ForwardedMessage::Frontend(FrontendMessage::Terminate) => break,
+            _ => {}
+        }
+        if standby_closed && primary_closed {
+            println!("both typed COPY-BOTH halves are closed");
+        }
+    }
+    Ok(())
+}

--- a/examples/sharding_router.rs
+++ b/examples/sharding_router.rs
@@ -1,0 +1,152 @@
+//! Shard router which namespaces prepared statements and portals per route.
+
+use std::convert::Infallible;
+
+use bytes::Bytes;
+use pg_proto::{
+    CancellationPolicy, Client, ClientConnectionContext, ClientTlsPolicy, Close, ConnectTarget,
+    Describe, Execute, FrontendMessage, InitialServerContext, Intermediary, IntermediaryMiddleware,
+    Parse, Server, ServerConnectionContext, ServerTlsPolicy, StartupParameters,
+    StartupRouteResolver, TrustClientAuthentication, TrustIdentity, TrustServerAuthentication,
+};
+
+struct ShardRoute;
+
+impl<Peer: Sync> StartupRouteResolver<Peer> for ShardRoute {
+    type Error = Infallible;
+
+    async fn resolve(
+        &self,
+        startup: StartupParameters,
+        _context: InitialServerContext<'_, Peer>,
+    ) -> Result<ConnectTarget, Self::Error> {
+        let shard = startup
+            .database_name()
+            .map(|database| database.bytes().fold(0_u8, u8::wrapping_add) % 4)
+            .unwrap_or_default();
+        Ok(ConnectTarget::new(format!("shard-{shard}")))
+    }
+}
+
+#[derive(Default)]
+struct ShardState {
+    namespace: Bytes,
+}
+
+struct NamespaceResources;
+
+impl
+    IntermediaryMiddleware<
+        ShardState,
+        ServerConnectionContext<std::net::SocketAddr, TrustIdentity>,
+        ClientConnectionContext<()>,
+    > for NamespaceResources
+{
+    type Error = Infallible;
+
+    async fn frontend(
+        &mut self,
+        _server: &ServerConnectionContext<std::net::SocketAddr, TrustIdentity>,
+        _client: &ClientConnectionContext<()>,
+        state: &mut ShardState,
+        message: FrontendMessage,
+    ) -> Result<pg_proto::FrontendMiddlewareOutput, Self::Error> {
+        let rewritten = match message {
+            FrontendMessage::Parse(Parse {
+                statement,
+                query,
+                parameter_types,
+            }) => FrontendMessage::Parse(Parse {
+                statement: qualify(&state.namespace, &statement, b"statement"),
+                query,
+                parameter_types,
+            }),
+            FrontendMessage::Bind(mut bind) => {
+                bind.statement = qualify(&state.namespace, &bind.statement, b"statement");
+                bind.portal = qualify(&state.namespace, &bind.portal, b"portal");
+                FrontendMessage::Bind(bind)
+            }
+            FrontendMessage::Describe(Describe { target, name }) => {
+                let kind = match target {
+                    pg_proto::DescribeTarget::Statement => b"statement".as_slice(),
+                    pg_proto::DescribeTarget::Portal => b"portal".as_slice(),
+                };
+                FrontendMessage::Describe(Describe {
+                    target,
+                    name: qualify(&state.namespace, &name, kind),
+                })
+            }
+            FrontendMessage::Execute(Execute { portal, max_rows }) => {
+                FrontendMessage::Execute(Execute {
+                    portal: qualify(&state.namespace, &portal, b"portal"),
+                    max_rows,
+                })
+            }
+            FrontendMessage::Close(Close { target, name }) => {
+                let kind = match target {
+                    pg_proto::DescribeTarget::Statement => b"statement".as_slice(),
+                    pg_proto::DescribeTarget::Portal => b"portal".as_slice(),
+                };
+                FrontendMessage::Close(Close {
+                    target,
+                    name: qualify(&state.namespace, &name, kind),
+                })
+            }
+            other => other,
+        };
+        Ok(pg_proto::FrontendMiddlewareOutput::Forward(rewritten))
+    }
+}
+
+fn qualify(namespace: &[u8], client_name: &[u8], kind: &[u8]) -> Bytes {
+    let client_name = if client_name.is_empty() {
+        b"unnamed".as_slice()
+    } else {
+        client_name
+    };
+    Bytes::from([namespace, b"::", kind, b"::", client_name].concat())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let listen = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "127.0.0.1:6432".into());
+    let upstream: std::net::SocketAddr = std::env::args()
+        .nth(2)
+        .unwrap_or_else(|| "127.0.0.1:5432".into())
+        .parse()?;
+    let server = Server::builder()
+        .tls(ServerTlsPolicy::Disabled)
+        .authentication(TrustServerAuthentication)
+        .build()?;
+    let client = Client::builder()
+        .connector(move |_| tokio::net::TcpStream::connect(upstream))
+        .tls(ClientTlsPolicy::Disabled)
+        .authentication(TrustClientAuthentication)
+        .build()?;
+    let intermediary = Intermediary::builder()
+        .server(server)
+        .client(client)
+        .startup_resolver(ShardRoute)
+        .cancellation(CancellationPolicy::Reject)
+        .middleware(
+            |_: &ServerConnectionContext<std::net::SocketAddr, TrustIdentity>,
+             target: &ClientConnectionContext<()>| {
+                println!("routing through {}", target.target().name());
+                NamespaceResources
+            },
+        )
+        .build()?;
+    let listener = tokio::net::TcpListener::bind(listen).await?;
+    let (transport, peer) = listener.accept().await?;
+    let namespace = Bytes::from(format!("client-{peer}"));
+    let mut session = Box::pin(intermediary.accept(transport, peer, ShardState { namespace }))
+        .await?
+        .into_session();
+    while !matches!(
+        session.forward_next().await?,
+        pg_proto::ForwardedMessage::Frontend(FrontendMessage::Terminate)
+    ) {}
+    Ok(())
+}

--- a/examples/sql_logging_proxy/main.rs
+++ b/examples/sql_logging_proxy/main.rs
@@ -293,7 +293,7 @@ async fn proxy_connection(
         .client(client)
         .startup_resolver(Route(upstream))
         .cancellation(CancellationPolicy::Reject)
-        .pipeline(BoundedPipeline::new(64).expect("non-zero proxy pipeline capacity"))
+        .pipeline(BoundedPipeline::new(64).expect("non-zero queued-request limit"))
         .middleware(
             |_: &ServerConnectionContext<SocketAddr, TrustIdentity>,
              _: &ClientConnectionContext<()>| SqlLogger,

--- a/pg-proto-burn-in/src/lib.rs
+++ b/pg-proto-burn-in/src/lib.rs
@@ -1675,7 +1675,7 @@ async fn run_intermediary_child(arguments: &[String]) -> Result<(), Box<dyn Erro
             .client(client)
             .startup_resolver(Route(upstream))
             .cancellation_registry(cancellation_registry.clone())
-            .pipeline(BoundedPipeline::new(64).expect("non-zero smoke pipeline capacity"))
+            .pipeline(BoundedPipeline::new(64).expect("non-zero smoke queued-request limit"))
             .middleware(
                 move |_: &ServerConnectionContext<SocketAddr, TrustIdentity>,
                       _: &ClientConnectionContext<()>| CoverageObserver {
@@ -1883,7 +1883,7 @@ async fn run_tls_credential_intermediary(
         .client(client)
         .startup_resolver(Route(upstream))
         .cancellation(CancellationPolicy::Reject)
-        .pipeline(BoundedPipeline::new(64).expect("non-zero TLS pipeline capacity"))
+        .pipeline(BoundedPipeline::new(64).expect("non-zero TLS queued-request limit"))
         .middleware(
             |_: &ServerConnectionContext<SocketAddr, TrustIdentity>,
              _: &ClientConnectionContext<()>| CoverageObserver::default(),
@@ -1955,7 +1955,7 @@ async fn run_credential_intermediary(
         .client(client)
         .startup_resolver(Route(upstream))
         .cancellation(CancellationPolicy::Reject)
-        .pipeline(BoundedPipeline::new(64).expect("non-zero authentication pipeline capacity"))
+        .pipeline(BoundedPipeline::new(64).expect("non-zero authentication queued-request limit"))
         .middleware(
             |_: &ServerConnectionContext<SocketAddr, TrustIdentity>,
              _: &ClientConnectionContext<()>| CoverageObserver::default(),

--- a/src/intermediary.rs
+++ b/src/intermediary.rs
@@ -65,7 +65,7 @@ impl<Downstream, Upstream, Policy: PipelinePolicy> SessionPair<Downstream, Upstr
         &self.pipeline
     }
 
-    /// Returns mutable access to bounded pipeline orchestration.
+    /// Returns mutable access to queued-request backpressure orchestration.
     pub(crate) const fn pipeline_mut(&mut self) -> &mut Pipeline<Policy> {
         &mut self.pipeline
     }

--- a/src/intermediary_component.rs
+++ b/src/intermediary_component.rs
@@ -808,7 +808,8 @@ impl<S, C, R, A, P, B, K> IntermediaryBuilder<S, C, R, A, P, B, K> {
         }
     }
 
-    /// Selects lock-step or bounded request pipelining.
+    /// Configures backpressure for queued requests by selecting lock-step or a
+    /// fixed number of in-flight operations.
     #[must_use]
     pub fn pipeline<Next: PipelinePolicy>(
         self,

--- a/src/internal_tests.rs
+++ b/src/internal_tests.rs
@@ -4,7 +4,7 @@
 /// Shared neutral intermediary construction for internal integration tests.
 mod intermediary_harness;
 #[path = "internal_tests/intermediary_pipeline.rs"]
-/// Integration tests for intermediary pipeline state and ordering.
+/// Integration tests for queued-request backpressure and ordering.
 mod intermediary_pipeline;
 #[path = "internal_tests/postgres_container.rs"]
 /// Compatibility tests against Testcontainers-managed PostgreSQL instances.

--- a/src/internal_tests/intermediary_pipeline.rs
+++ b/src/internal_tests/intermediary_pipeline.rs
@@ -1,4 +1,4 @@
-//! Deterministic coverage for bounded intermediary pipeline orchestration.
+//! Deterministic coverage for backpressure applied to queued requests.
 
 use std::convert::Infallible;
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1,4 +1,4 @@
-//! Bounded, payload-free orchestration for proxy request pipelines.
+//! Payload-free backpressure orchestration for queued proxy requests.
 //!
 //! The ledger in this module records protocol obligations, not wire messages.
 //! Applications retain ownership of decoded messages until

--- a/tests/builder_examples.rs
+++ b/tests/builder_examples.rs
@@ -36,7 +36,7 @@ fn named_intermediary_examples_drive_the_operational_facade() {
     for name in [
         "proxy_skeleton.rs",
         "rewriting_intermediary.rs",
-        "intermediary_pipeline.rs",
+        "queued_request_backpressure.rs",
     ] {
         let source = fs::read_to_string(root.join(name)).unwrap();
         assert!(
@@ -51,9 +51,9 @@ fn named_intermediary_examples_drive_the_operational_facade() {
     let rewriting = fs::read_to_string(root.join("rewriting_intermediary.rs")).unwrap();
     assert!(rewriting.contains("visible = true"));
     assert!(rewriting.contains("visible_amount"));
-    let pipeline = fs::read_to_string(root.join("intermediary_pipeline.rs")).unwrap();
-    assert!(pipeline.contains("BoundedPipeline::new(1)"));
-    assert!(pipeline.contains("session.forward_frontend().await?"));
+    let backpressure = fs::read_to_string(root.join("queued_request_backpressure.rs")).unwrap();
+    assert!(backpressure.contains("BoundedPipeline::new(1)"));
+    assert!(backpressure.contains("session.forward_frontend().await?"));
 }
 
 #[test]

--- a/tests/builder_examples.rs
+++ b/tests/builder_examples.rs
@@ -82,6 +82,68 @@ fn logging_proxies_build_roles_directly() {
     assert!(!root.join("proxy_support").exists());
 }
 
+#[test]
+fn readme_links_to_substantive_examples_for_each_advertised_use_case() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let readme = fs::read_to_string(root.join("README.md")).unwrap();
+    let examples = [
+        (
+            "examples/sql_logging_proxy/main.rs",
+            &[
+                "ServerTlsPolicy::Required",
+                "FrontendMessage::Query",
+                "BackendMessage::DataRow",
+            ][..],
+        ),
+        (
+            "examples/connection_pooler.rs",
+            &["ConnectionClean", "ConnectionChanged", "TransactionStatus"][..],
+        ),
+        (
+            "examples/rewriting_intermediary.rs",
+            &["FrontendMessage::Query", "BackendMessage::RowDescription"][..],
+        ),
+        (
+            "examples/sharding_router.rs",
+            &[
+                "FrontendMessage::Parse",
+                "FrontendMessage::Bind",
+                "FrontendMessage::Execute",
+            ][..],
+        ),
+        (
+            "examples/replication_relay.rs",
+            &[
+                "CopyBothResponse",
+                "FrontendMessage::CopyDone",
+                "BackendMessage::CopyDone",
+            ][..],
+        ),
+        (
+            "examples/mock_postgres_server.rs",
+            &[
+                "Server::builder()",
+                "BackendMessage::DataRow",
+                "FrontendMessage::Query",
+            ][..],
+        ),
+        (
+            "examples/administrative_client.rs",
+            &["Client::builder()", ".simple_query(", "ConnectionChanged"][..],
+        ),
+    ];
+    for (relative, required) in examples {
+        assert!(readme.contains(relative), "README must link to {relative}");
+        let source = fs::read_to_string(root.join(relative)).unwrap();
+        for marker in required {
+            assert!(
+                source.contains(marker),
+                "{relative} must demonstrate `{marker}`"
+            );
+        }
+    }
+}
+
 fn rust_sources(root: &Path) -> Vec<std::path::PathBuf> {
     let mut sources = Vec::new();
     for entry in fs::read_dir(root).unwrap() {


### PR DESCRIPTION
## Summary

- simplify the README introduction and explain protocol guardrails in plain language
- clarify direction-dependent wire tags, pooling evidence, and queued-request backpressure
- add and link runnable examples for TLS proxying, connection pooling, SQL rewriting, sharding, replication, a mock PostgreSQL server, and an administrative client
- audit that every advertised use case links to a substantive public-facade example

## Validation

- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --test builder_examples --test documentation_audit`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `git diff --check`